### PR TITLE
Integrate dynamic cloudscapes across levels

### DIFF
--- a/src/level_manager.ts
+++ b/src/level_manager.ts
@@ -111,8 +111,8 @@ export class LevelManager {
         this.populateZone(player!.position.x + 50, player!.position.x + 600, cfg);
 
         // Configure clouds based on level type/name
-        // For now, always visible but could be customized
-        this.cloudSystem.layers.forEach(l => l.mesh.visible = true);
+        // Update cloud layers based on density and color
+        this.cloudSystem.setLevel(cfg);
 
         // Special Effects per Level
         if (levelIndex === 1) {
@@ -135,9 +135,6 @@ export class LevelManager {
         if (levelIndex === 4) {
             // Industrial Tunnel
             industrialSystem.activate();
-
-            // Industrial background is heavy, maybe hide clouds?
-            this.cloudSystem.layers.forEach(l => l.mesh.visible = false);
         } else {
             industrialSystem.deactivate();
         }
@@ -163,16 +160,10 @@ export class LevelManager {
             biologicalSystem.activate();
             nebulaSystem.activate();
             cosmicDustSystem.activate();
-            // Hide clouds in whale level
-            this.cloudSystem.layers.forEach(l => l.mesh.visible = false);
         } else {
             biologicalSystem.deactivate();
             nebulaSystem.deactivate();
             cosmicDustSystem.deactivate();
-            // Restore clouds if not in Industrial Tunnel (Level 4)
-            if (levelIndex !== 4) {
-                this.cloudSystem.layers.forEach(l => l.mesh.visible = true);
-            }
         }
 
         // SWARM #3: Generate Magical Dreamy Environments (for levels 1-3 and 6-7)


### PR DESCRIPTION
Fixes an integration bug in `LevelManager.startLevel()` where the fully implemented `CloudSystem.setLevel(cfg)` method was being ignored. Replaces manual `mesh.visible` overrides with the robust `setLevel` method to correctly adjust cloud layer density, colors, and behavior across all levels, fulfilling the 'Multi-Layered Cloudscapes' requirement.

---
*PR created automatically by Jules for task [11758646350678382630](https://jules.google.com/task/11758646350678382630) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified cloud configuration system to use level-based settings, consolidating configuration logic across levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->