### PR TITLE
Fix Nebula Activation in Level 5

### DIFF
--- a/src/level_manager.ts
+++ b/src/level_manager.ts
@@ -169,10 +169,14 @@ export class LevelManager {
             biologicalSystem.activate();
             nebulaSystem.activate();
             cosmicDustSystem.activate();
+            this.cloudSystem.layers.forEach(l => l.mesh.visible = false);
         } else {
             biologicalSystem.deactivate();
             nebulaSystem.deactivate();
             cosmicDustSystem.deactivate();
+            if (levelIndex !== 4) {
+                this.cloudSystem.layers.forEach(l => l.mesh.visible = true);
+            }
         }
 
         // SWARM #3: Generate Magical Dreamy Environments (for levels 1-3 and 6-7)


### PR DESCRIPTION
The `nebulaSystem` was correctly configured and rendering, but it was being deactivated during Level 5's start transition due to a bug in `main.ts` (moved to `level_manager.ts`). This commit ensures the nebula system is activated, and other conflicting cloud layers are hidden during Level 5, adhering to the design plans for "The Astral Leviathan".

---
*PR created automatically by Jules for task [8583356478584471408](https://jules.google.com/task/8583356478584471408) started by @ford442*