### PR TITLE
feat: Add dynamic atmospheric palette shift to Planetary Horizon

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -525,7 +525,7 @@ const waterfallSystem = new WaterfallSystem(scene, camera);
 const asteroidFieldSystem = new AsteroidFieldSystem(scene, weaponLightManager);
 
 // PLANETARY HORIZON SYSTEM (Massive scrolling planet)
-const planetaryHorizonSystem = new PlanetaryHorizonSystem(scene);
+const planetaryHorizonSystem = new PlanetaryHorizonSystem(scene, camera);
 
 // INDUSTRIAL BACKGROUND SYSTEM (Megastructures)
 const industrialSystem = new IndustrialBackgroundSystem(scene, weaponLightManager);

--- a/src/planetary_horizon.ts
+++ b/src/planetary_horizon.ts
@@ -282,6 +282,39 @@ function createDeepSpaceStars(count: number = 1000) {
     return stars;
 }
 
+
+export class AtmosphereOverlay {
+    mesh: THREE.Mesh;
+    uIntensity: any;
+
+    constructor(camera: THREE.Camera) {
+        const geo = new THREE.PlaneGeometry(2, 2);
+
+        this.uIntensity = uniform(0.0);
+
+        const mat = new MeshBasicNodeMaterial({
+            transparent: true,
+            depthWrite: false,
+            blending: THREE.AdditiveBlending,
+            side: THREE.DoubleSide
+        });
+
+        const atmColor = color(0x114488); // Atmospheric blue
+        mat.colorNode = vec4(atmColor, this.uIntensity);
+
+        this.mesh = new THREE.Mesh(geo, mat);
+        this.mesh.position.set(0, 0, -1.05); // Just in front of camera
+        this.mesh.visible = false;
+
+        camera.add(this.mesh);
+    }
+
+    setIntensity(intensity: number) {
+        this.uIntensity.value = intensity;
+        this.mesh.visible = intensity > 0.01;
+    }
+}
+
 export class PlanetaryHorizonSystem {
     scene: THREE.Scene;
     active: boolean = false;
@@ -301,7 +334,10 @@ export class PlanetaryHorizonSystem {
     // BgStars move at 95% camera speed (creating "Deep Space" depth where they drift slowly)
     starPositions: Float32Array;
 
-    constructor(scene: THREE.Scene) {
+
+    atmosphereOverlay: AtmosphereOverlay;
+
+    constructor(scene: THREE.Scene, camera: THREE.Camera) {
         this.scene = scene;
         this.container = new THREE.Group();
         this.scene.add(this.container);
@@ -337,19 +373,23 @@ export class PlanetaryHorizonSystem {
         this.starPositions = (this.bgStars.geometry.attributes.position as THREE.BufferAttribute).array as Float32Array;
         this.container.add(this.bgStars);
 
+        // 5. Atmosphere Overlay for gradual palette shift
+        this.atmosphereOverlay = new AtmosphereOverlay(camera);
+
         this.deactivate();
     }
-
     activate() {
         if (this.active) return;
         this.active = true;
         this.container.visible = true;
+        if (this.atmosphereOverlay) this.atmosphereOverlay.mesh.visible = true;
     }
 
     deactivate() {
         if (!this.active) return;
         this.active = false;
         this.container.visible = false;
+        if (this.atmosphereOverlay) this.atmosphereOverlay.mesh.visible = false;
     }
 
     update(cameraX: number, delta: number = 0.016) {
@@ -414,6 +454,7 @@ export class PlanetaryHorizonSystem {
         this.planet.rotation.z += 0.005 * delta;
         this.clouds.rotation.z += 0.008 * delta; // Differential rotation
 
+
         // 4. Approach Scaling
         // Scale the planet as we move along X to simulate approaching it.
         // We use a dynamic distance value based on the level configuration if available, otherwise fallback.
@@ -429,5 +470,17 @@ export class PlanetaryHorizonSystem {
         this.planet.position.y = baseY + (approachScale - 1.0) * 50;
         this.clouds.position.y = this.planet.position.y;
         this.atmosphere.position.y = this.planet.position.y;
+
+        // 5. Atmospheric Palette Shift
+        // Gradually increase intensity of the blue overlay as we approach the planet
+        // e.g. start fading in at distance 1000m to 0m, reaching max 0.6 intensity
+        const fadeStartDistance = 1000.0;
+        let atmIntensity = 0.0;
+        if (distanceToPlanet < fadeStartDistance) {
+            atmIntensity = (1.0 - (distanceToPlanet / fadeStartDistance)) * 0.5;
+        }
+        if (this.atmosphereOverlay) {
+            this.atmosphereOverlay.setIntensity(atmIntensity);
+        }
     }
 }


### PR DESCRIPTION
## 🌌 Architect: Atmospheric Palette Shift

### Concept
> "As the stage progresses, the color palette shifts from deep space black to the planet's atmospheric blue, signaling your entry into its airspace." (Technique 3: Approaching Planetary Horizons)

### Implementation
- Added an `AtmosphereOverlay` class to `planetary_horizon.ts`.
- Uses a full-screen quad (`THREE.PlaneGeometry(2, 2)`) attached to the camera.
- Utilizes `MeshBasicNodeMaterial` with `THREE.AdditiveBlending` and `depthWrite = false`.
- The intensity dynamically scales based on the distance to the planet (`distanceToPlanet`), gradually shifting the color of the screen to an atmospheric blue (`0x114488`) as the player approaches the horizon.

### Visuals
- 1 full-screen overlay quad using AdditiveBlending.
- Smooth fading using `distanceToPlanet` relative to a defined `fadeStartDistance` (1000m).
- Creates a soft, enveloping blue hue that grows stronger, signaling orbital re-entry sequence.

### Integration
- `planetary_horizon.ts`: Embedded `AtmosphereOverlay` into `PlanetaryHorizonSystem` constructor, updating its intensity during the `update()` loop based on `cameraX`.
- `main.ts`: Updated `PlanetaryHorizonSystem` instantiation to pass the global `camera` reference for the overlay.

### Testing
- [x] `npm run build` passes
- [x] Verified code integration and imports
- [x] Uses TSL shaders and maintains WebGPU compatibility

---
*PR created automatically by Jules for task [9797916820013315578](https://jules.google.com/task/9797916820013315578) started by @ford442*