### PR TITLE
Architect: Atmospheric Re-Entry Progressive Intensity Fix

### DIFF
--- a/src/level_manager.ts
+++ b/src/level_manager.ts
@@ -169,6 +169,7 @@ export class LevelManager {
             planetaryHorizonSystem.levelDistance = cfg.distance;
             planetaryHorizonSystem.activate();
             // Activate Re-Entry Heat in Level 3 "Orbital Descent"
+            reEntrySystem.levelDistance = cfg.distance;
             reEntrySystem.activate();
         } else {
             planetaryHorizonSystem.deactivate();

--- a/src/reentry.ts
+++ b/src/reentry.ts
@@ -99,6 +99,7 @@ export class ReEntrySystem {
 
     // Data
     streakCount: number = 50;
+    levelDistance: number = 2200;
     streakPositions: Float32Array;
     streakSpeeds: Float32Array;
 
@@ -180,7 +181,8 @@ export class ReEntrySystem {
         const matGlow = this.heatGlowMesh.material as THREE.MeshBasicMaterial;
 
         // Fade Logic
-        const targetOpacity = this.active ? 1.0 : 0.0;
+        const progress = Math.max(0, Math.min(1, cameraX / this.levelDistance));
+        const targetOpacity = this.active ? Math.min(1.0, progress * 1.5) : 0.0;
 
         // We use a custom property on the material to track "intensity" for fading
         // because opacity behaves differently for Physical vs Basic
@@ -243,7 +245,7 @@ export class ReEntrySystem {
                 x = spawnX + Math.random() * 20;
                 y = cameraY + (Math.random() - 0.5) * 30;
                 z = (Math.random() - 0.5) * 30;
-                this.streakSpeeds[i] = 50 + Math.random() * 50;
+                this.streakSpeeds[i] = (50 + Math.random() * 50) * (0.5 + progress * 0.5);
 
                 this.streakPositions[i * 3 + 1] = y;
                 this.streakPositions[i * 3 + 2] = z;


### PR DESCRIPTION
## 🌌 Architect: Atmospheric Re-Entry Progressive Intensity Fix

### Concept
> "The screen is overlaid with a transparent orange-red gradient that intensifies as you go deeper"

### Implementation
- `reentry.ts` was mostly complete but relied on a binary active/inactive opacity. Added a progress interpolator using `levelDistance` and `cameraX` to ramp up the effect.
- Modifies `ReEntrySystem` to calculate a progress ratio.
- Level 3 (Orbital Descent) is affected.

### Visuals
- Plasma streak speeds now scale based on distance, moving significantly faster towards the end of the level.
- Heat glow overlay gradually shifts from 0 opacity to 1.0 opacity dynamically across the 2200 units of the level, instead of jumping to 1.0 immediately upon entering the level.

### Integration
- `src/level_manager.ts`: Hooked in `cfg.distance` assignment to `reEntrySystem.levelDistance` right before activation.

### Testing
- [x] `npm run build` passes
- [x] Mobile/touch controls still work


---
*PR created automatically by Jules for task [7255743365299882064](https://jules.google.com/task/7255743365299882064) started by @ford442*