### PR TITLE
feat(visuals): Tint enemy pattern fire based on level environments

### DIFF
--- a/src/level_config.ts
+++ b/src/level_config.ts
@@ -37,6 +37,7 @@ export type LevelConfig = {
         color: number;
         speedMultiplier: number;
     };
+    enemyTintColor?: number;
 };
 
 export const LEVEL_CONFIG: { [key: number]: LevelConfig } = {
@@ -160,6 +161,7 @@ export const LEVEL_CONFIG: { [key: number]: LevelConfig } = {
         name: "The Astral Leviathan",
         distance: 4200,
         asteroidRate: 2.5,
+        enemyTintColor: 0xff1493, // Nebula pink/purple tint
         foliageDensity: {
             fern: 5,
             rose: 4,

--- a/src/obstacle_system.ts
+++ b/src/obstacle_system.ts
@@ -355,6 +355,8 @@ export class ObstacleSystem {
         
         const positions = generatePatternPositions(pattern);
         
+        const config = this.options.getCurrentConfig();
+
         for (let i = 0; i < positions.length; i++) {
             const pos = positions[i];
             const size = 0.4 + Math.random() * 0.8;
@@ -363,6 +365,12 @@ export class ObstacleSystem {
             const hue = Math.random();
             const color = new THREE.Color().setHSL(hue, 0.7, 0.5);
             
+            // Environment Tinting: Tint enemies based on the level configuration
+            if (config?.enemyTintColor !== undefined) {
+                const tintColor = new THREE.Color(config.enemyTintColor);
+                color.lerp(tintColor, 0.6); // 60% environment color tint
+            }
+
             const enemy = this.createPatternEnemy(
                 pos.x, pos.y, pos.z || 0, 
                 size, 


### PR DESCRIPTION
## 🌌 Architect: Enemy Fire Environmental Tinting

### Concept
> "Enemy fire is tinted by the nebula's colors, making it harder to see and forcing players to read the patterns rather than just the bullets" (from §7 Drifting Through Nebulae and Energy Fields).

### Implementation
- Added `enemyTintColor` property to `LevelConfig`.
- Modified `LEVEL_CONFIG` for Level 5 (The Astral Leviathan) to include a pink/purple tint (`0xff1493`).
- Updated `ObstacleSystem.spawnPatternFormation` to dynamically `.lerp()` random pattern enemy colors with the `enemyTintColor` if it's defined in the current level configuration.
- Affects any level where `enemyTintColor` is configured (currently Level 5).

### Visuals
- Randomly generated pattern enemies are visually blended (60% lerp) with the environment's primary tint.
- In Level 5, enemies appear tinted pink/purple, creating a harmonious and slightly camouflaged visual interaction with the glowing nebula background.

### Integration
- `src/level_config.ts`: Added `enemyTintColor` configuration to the type and Level 5 definition.
- `src/obstacle_system.ts`: Integrated color lerping logic during `createPatternEnemy` calls in the obstacle generation process.

### Testing
- [x] `npm run build` passes
- [x] Tested logic locally (build succeeds, types check out)
- [x] Mobile/touch controls unaffected

---
*PR created automatically by Jules for task [10868382072634700606](https://jules.google.com/task/10868382072634700606) started by @ford442*