### PR TITLE
Feature: Asteroid fragmentation and main loop integration

### DIFF
--- a/src/asteroid_field.ts
+++ b/src/asteroid_field.ts
@@ -80,11 +80,15 @@ export class AsteroidLayer {
     width: number;
     depth: number;
     baseZ: number;
+    sizeMin: number;
+    sizeMax: number;
 
     // Instance Data
     positions: Float32Array;
     rotations: Float32Array;
     rotationSpeeds: Float32Array;
+    scales: Float32Array;
+    velocities: Float32Array;
 
     constructor(
         scene: THREE.Scene,
@@ -104,6 +108,8 @@ export class AsteroidLayer {
         this.width = config.width;
         this.baseZ = config.z;
         this.depth = config.zRange;
+        this.sizeMin = config.sizeMin;
+        this.sizeMax = config.sizeMax;
 
         // Geometry: Icosahedron for jagged rock look
         const geometry = new THREE.IcosahedronGeometry(1, 0);
@@ -122,6 +128,8 @@ export class AsteroidLayer {
         this.positions = new Float32Array(this.maxCount * 3);
         this.rotations = new Float32Array(this.maxCount * 3); // Euler angles
         this.rotationSpeeds = new Float32Array(this.maxCount * 3); // Speed per axis
+        this.scales = new Float32Array(this.maxCount * 3);
+        this.velocities = new Float32Array(this.maxCount * 3);
 
         for (let i = 0; i < this.maxCount; i++) {
             // Random Position
@@ -147,11 +155,18 @@ export class AsteroidLayer {
             this.rotationSpeeds[i * 3 + 1] = (Math.random() - 0.5) * 1.0;
             this.rotationSpeeds[i * 3 + 2] = (Math.random() - 0.5) * 1.0;
 
+            const scale = config.sizeMin + Math.random() * (config.sizeMax - config.sizeMin);
+            this.scales[i * 3] = scale;
+            this.scales[i * 3 + 1] = scale;
+            this.scales[i * 3 + 2] = scale;
+
+            this.velocities[i * 3] = 0;
+            this.velocities[i * 3 + 1] = 0;
+            this.velocities[i * 3 + 2] = 0;
+
             // Setup instance
             this.dummy.position.set(x, y, z);
             this.dummy.rotation.set(rx, ry, rz);
-
-            const scale = config.sizeMin + Math.random() * (config.sizeMax - config.sizeMin);
             this.dummy.scale.setScalar(scale);
 
             this.dummy.updateMatrix();
@@ -184,18 +199,148 @@ export class AsteroidLayer {
             const s = new THREE.Vector3();
             this.dummy.matrix.decompose(p, q, s);
 
+            this.velocities[idx] = 0;
+            this.velocities[idx + 1] = 0;
+            this.velocities[idx + 2] = 0;
+
             this.dummy.position.set(x, y, z);
             this.dummy.rotation.set(
                 this.rotations[idx],
                 this.rotations[idx+1],
                 this.rotations[idx+2]
             );
-            this.dummy.scale.copy(s);
+            this.dummy.scale.set(this.scales[idx], this.scales[idx+1], this.scales[idx+2]);
             this.dummy.updateMatrix();
 
             this.mesh.setMatrixAt(i, this.dummy.matrix);
         }
         this.mesh.instanceMatrix.needsUpdate = true;
+    }
+
+
+    breakAsteroid(hitIdx: number, hitPos: THREE.Vector3, cameraPos: THREE.Vector3, shotDirection: THREE.Vector3 = new THREE.Vector3(1, 0, 0)) {
+        // Hide original asteroid by making scale 0
+        const idx = hitIdx * 3;
+        const originalScale = this.scales[idx];
+        this.scales[idx] = 0;
+        this.scales[idx+1] = 0;
+        this.scales[idx+2] = 0;
+
+        // Find 2-4 asteroids off-screen to use as fragments
+        const margin = 20;
+        const limitBack = cameraPos.x - (this.width / 2) - margin;
+        const limitFront = cameraPos.x + (this.width / 2) + margin;
+
+        const numFragments = Math.floor(Math.random() * 3) + 2; // 2 to 4
+        let fragmentsFound = 0;
+
+        for (let i = 0; i < this.mesh.count; i++) {
+            if (fragmentsFound >= numFragments) break;
+            if (i === hitIdx) continue;
+
+            const i3 = i * 3;
+            const x = this.positions[i3];
+
+            // If it's off-screen or invisible (scale 0)
+            if (x < limitBack || x > limitFront || this.scales[i3] === 0) {
+                fragmentsFound++;
+
+                // Repurpose as fragment
+                this.positions[i3] = hitPos.x + (Math.random() - 0.5) * originalScale;
+                this.positions[i3+1] = hitPos.y + (Math.random() - 0.5) * originalScale;
+                this.positions[i3+2] = hitPos.z + (Math.random() - 0.5) * originalScale;
+
+                const fragmentScale = originalScale * (0.3 + Math.random() * 0.3);
+                this.scales[i3] = fragmentScale;
+                this.scales[i3+1] = fragmentScale;
+                this.scales[i3+2] = fragmentScale;
+
+                // Set burst velocity outward
+                const outVel = new THREE.Vector3(
+                    (Math.random() - 0.5) * 2.0,
+                    (Math.random() - 0.5) * 2.0,
+                    (Math.random() - 0.5) * 2.0
+                ).normalize().multiplyScalar(5.0 + Math.random() * 10.0);
+
+                // Add some inherited shot velocity
+                outVel.add(shotDirection.clone().multiplyScalar(3.0));
+
+                this.velocities[i3] = outVel.x;
+                this.velocities[i3+1] = outVel.y;
+                this.velocities[i3+2] = outVel.z;
+
+                // Set random rotation speeds for fragments
+                this.rotationSpeeds[i3] = (Math.random() - 0.5) * 5.0;
+                this.rotationSpeeds[i3+1] = (Math.random() - 0.5) * 5.0;
+                this.rotationSpeeds[i3+2] = (Math.random() - 0.5) * 5.0;
+
+                // Update matrix immediately
+                this.dummy.position.set(this.positions[i3], this.positions[i3+1], this.positions[i3+2]);
+                this.dummy.rotation.set(this.rotations[i3], this.rotations[i3+1], this.rotations[i3+2]);
+                this.dummy.scale.setScalar(fragmentScale);
+                this.dummy.updateMatrix();
+                this.mesh.setMatrixAt(i, this.dummy.matrix);
+            }
+        }
+
+        // Update the original asteroid matrix
+        this.dummy.scale.setScalar(0);
+        this.dummy.updateMatrix();
+        this.mesh.setMatrixAt(hitIdx, this.dummy.matrix);
+        this.mesh.instanceMatrix.needsUpdate = true;
+    }
+
+    hitAsteroid(worldPosition: THREE.Vector3, particleSystem: any, cameraPos: THREE.Vector3, shotDirection: THREE.Vector3 = new THREE.Vector3(1, 0, 0)): boolean {
+        let hitFound = false;
+
+        // Ray from camera to projectile
+        const rayDir = new THREE.Vector3().subVectors(worldPosition, cameraPos).normalize();
+
+        for (let i = 0; i < this.mesh.count; i++) {
+            const idx = i * 3;
+            const ax = this.positions[idx];
+            const ay = this.positions[idx+1];
+            const az = this.positions[idx+2];
+
+            const scale = this.scales[idx];
+            if (scale === 0) continue; // Skip already destroyed/invisible
+
+            // 1. Find where the ray intersects the Z-plane of the asteroid
+            // ray: P = cameraPos + t * rayDir
+            // We want P.z = az
+            // cameraPos.z + t * rayDir.z = az
+            // t = (az - cameraPos.z) / rayDir.z
+
+            if (Math.abs(rayDir.z) < 0.001) continue; // Prevent division by zero
+            const t = (az - cameraPos.z) / rayDir.z;
+
+            if (t < 0) continue; // Behind camera
+
+            // Point of intersection on the asteroid's Z-plane
+            const projectedX = cameraPos.x + t * rayDir.x;
+            const projectedY = cameraPos.y + t * rayDir.y;
+
+            // 2. Check 2D distance on that plane
+            const distSq = (projectedX - ax) * (projectedX - ax) + (projectedY - ay) * (projectedY - ay);
+
+            const hitRadius = scale * 1.5; // Approximate radius of Icosahedron * scale
+            if (distSq < hitRadius * hitRadius) {
+                // Hit!
+                const hitPos = new THREE.Vector3(ax, ay, az);
+                this.breakAsteroid(i, hitPos, cameraPos, shotDirection);
+
+                // Emit particles
+                if (particleSystem) {
+                    particleSystem.emit(hitPos, 0x888888, 5, 2.0, scale);
+                }
+
+                hitFound = true;
+                // Usually just hit one per check
+                return true;
+            }
+        }
+
+        return hitFound;
     }
 
     update(delta: number, cameraX: number) {
@@ -208,38 +353,71 @@ export class AsteroidLayer {
             const idx = i * 3;
 
             // 1. Rotation Animation
-            this.rotations[idx] += this.rotationSpeeds[idx] * delta;
-            this.rotations[idx+1] += this.rotationSpeeds[idx+1] * delta;
-            this.rotations[idx+2] += this.rotationSpeeds[idx+2] * delta;
-
-            // 2. Parallax / Infinite Scroll Logic
-            let x = this.positions[idx];
-
-            if (x < limitBack) {
-                x += this.width + margin * 2;
-                this.positions[idx] = x;
-                needsUpdate = true;
-            } else if (x > limitFront) {
-                x -= (this.width + margin * 2);
-                this.positions[idx] = x;
+            if (this.rotationSpeeds[idx] !== 0 || this.rotationSpeeds[idx+1] !== 0 || this.rotationSpeeds[idx+2] !== 0) {
+                this.rotations[idx] += this.rotationSpeeds[idx] * delta;
+                this.rotations[idx+1] += this.rotationSpeeds[idx+1] * delta;
+                this.rotations[idx+2] += this.rotationSpeeds[idx+2] * delta;
                 needsUpdate = true;
             }
 
-            // Update Instance
-            // Scale handling: Reconstruct transform
-            this.mesh.getMatrixAt(i, this.dummy.matrix);
-            const p = new THREE.Vector3();
-            const q = new THREE.Quaternion();
-            const s = new THREE.Vector3();
-            this.dummy.matrix.decompose(p, q, s); // Get current scale
+            // 2. Parallax / Infinite Scroll Logic
+            let x = this.positions[idx];
+            let y = this.positions[idx+1];
+            let z = this.positions[idx+2];
 
-            this.dummy.position.set(x, this.positions[idx+1], this.positions[idx+2]);
+            if (this.velocities[idx] !== 0 || this.velocities[idx+1] !== 0 || this.velocities[idx+2] !== 0) {
+                x += this.velocities[idx] * delta;
+                y += this.velocities[idx+1] * delta;
+                z += this.velocities[idx+2] * delta;
+                needsUpdate = true;
+            }
+
+            if (x < limitBack || x > limitFront) {
+                if (x < limitBack) {
+                    x += this.width + margin * 2;
+                } else {
+                    x -= (this.width + margin * 2);
+                }
+
+                this.positions[idx] = x;
+
+                // Reset Y and Z to original random distribution
+                y = (Math.random() - 0.5) * 40; // Vertical spread
+                z = this.baseZ + (Math.random() - 0.5) * this.depth;
+                this.positions[idx+1] = y;
+                this.positions[idx+2] = z;
+
+                // Reset scale to original
+                const scale = this.sizeMin + Math.random() * (this.sizeMax - this.sizeMin);
+                this.scales[idx] = scale;
+                this.scales[idx+1] = scale;
+                this.scales[idx+2] = scale;
+
+                // Reset velocities
+                this.velocities[idx] = 0;
+                this.velocities[idx+1] = 0;
+                this.velocities[idx+2] = 0;
+
+                // Reset rotation speeds
+                this.rotationSpeeds[idx] = (Math.random() - 0.5) * 1.0;
+                this.rotationSpeeds[idx+1] = (Math.random() - 0.5) * 1.0;
+                this.rotationSpeeds[idx+2] = (Math.random() - 0.5) * 1.0;
+
+                needsUpdate = true;
+            }
+
+            this.positions[idx] = x;
+            this.positions[idx+1] = y;
+            this.positions[idx+2] = z;
+
+            // Update Instance
+            this.dummy.position.set(x, y, z);
             this.dummy.rotation.set(
                 this.rotations[idx],
                 this.rotations[idx+1],
                 this.rotations[idx+2]
             );
-            this.dummy.scale.copy(s);
+            this.dummy.scale.set(this.scales[idx], this.scales[idx+1], this.scales[idx+2]);
             this.dummy.updateMatrix();
 
             this.mesh.setMatrixAt(i, this.dummy.matrix);
@@ -331,6 +509,20 @@ export class AsteroidFieldSystem {
 
     resetPositions(cameraX: number) {
         this.layers.forEach(l => l.resetPositions(cameraX));
+    }
+
+    hitAsteroid(worldPosition: THREE.Vector3, particleSystem: any, cameraPos: THREE.Vector3, shotDirection: THREE.Vector3 = new THREE.Vector3(1, 0, 0)): boolean {
+        if (!this.active) return false;
+
+        let hitFound = false;
+
+        for (const layer of this.layers) {
+            if (layer.hitAsteroid(worldPosition, particleSystem, cameraPos, shotDirection)) {
+                hitFound = true;
+            }
+        }
+
+        return hitFound;
     }
 
     update(delta: number, cameraX: number) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2331,20 +2331,27 @@ function animate() {
                         // Try spawn pickup
                         pickupManager.trySpawn(obs.position.clone());
                         
-                        obstacleSystem.splitAsteroid(obs); // This modifies obstacles array!
+                        obstacleSystem.splitAsteroid(obs as THREE.Mesh);
 
                         // 3. Destroy Projectile
                         proj.deactivate();
-
-                        // Break inner loop (projectile done)
-                        // Outer loop continues (next asteroid), but current 'obs' is removed?
-                        // splitAsteroid removes 'obs' from 'obstacles' array.
-                        // Since we iterate backwards, removing current index is safe for outer loop continuation?
-                        // splitAsteroid does: const idx = obstacles.indexOf(asteroid); if (idx > -1) obstacles.splice(idx, 1);
-                        // If we splice, the indices shift. Iterating backwards handles this safely.
-                        // However, 'obs' is now invalid. We must break inner loop.
                         break;
                     }
+                }
+            }
+
+            // --- CHECK BACKGROUND ASTEROIDS ---
+            for (const proj of projectiles) {
+                if (!proj.active) continue;
+                // We pass the global camera position to calculate perspective projection
+                const shotDir = new THREE.Vector3(1, 0, 0);
+                if ((proj as any).velocity) {
+                    shotDir.copy((proj as any).velocity).normalize();
+                }
+                const hit = asteroidFieldSystem.hitAsteroid(proj.mesh.position, particleSystem, camera.position, shotDir);
+                if (hit) {
+                    audioSystem.play('explode');
+                    // We DO NOT deactivate the projectile here so it doesn't get blocked by background visual elements
                 }
             }
 


### PR DESCRIPTION
Implements the parallax background asteroid fragmentation feature. When the player shoots background asteroids, they break into smaller scattering fragments using physics and typed array manipulations on the existing instanced mesh, without affecting the game's actual foreground collision logic.

---
*PR created automatically by Jules for task [868073522600855060](https://jules.google.com/task/868073522600855060) started by @ford442*