### PR TITLE
Architect: Dynamic Starfield Parallax & Trail Colors

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,27 +1,26 @@
-## 🌌 Architect: Lightning Bolt System
+## 🌌 Architect: Dynamic Starfield Parallax & Trail Colors
 
 ### Concept
-> "1. Flying Through Multi-Layered Cloudscapes
-> ...
-> - Lightning flashes that briefly illuminate the cloud layers from within, creating dynamic lighting"
+> "Dynamic starfield parallax - 3-4 layers of stars with speed scaling based on thrust. Occasional shooting stars."
+> "Dynamic Trail Colors - Instant visual feedback: blue (glide) → red (dive) → green (boost)."
+From `ideas.md` Quick Wins and Whimsical Edition.
 
 ### Implementation
-- Implemented `LightningBoltSystem` using `InstancedMesh` to render procedural jagged lightning bolts.
-- The TSL shader computes multiple sine waves with different frequencies to displace UV coordinates and generate a branching line effect.
-- Integrated into `level_manager.ts` and activated for levels 1, 2, and 3 where clouds and atmospheric phenomena are prevalent.
-- `cleanup()` logic included to properly dispose of geometry and material data.
+- Activated the existing `StarfieldSystem` (which was hidden behind a debug flag) globally in `main.ts` and removed the legacy static `createStars(3000)` implementation.
+- Implemented **Dynamic Trail Colors** by adjusting the engine exhaust particle emitter colors based on the player's movement state (Up/Thrust = Green, Down/Dive = Red, Idle/Glide = Blue).
+- The Starfield features 4 parallax layers with varying densities, sizes, and base speeds, configured with a dreamy pastel color palette.
 
 ### Visuals
-- Procedural bolts that dynamically appear in the deep background (`z: -30` to `-10`).
-- TSL fragment shader employs distance fields from the jagged center line, mixed with a glowing blue edge and bright white core.
-- Timed fading mimics rapid high-frequency flashing synchronized with the game's clock.
+- 4 star layers at varying `zRange`s, utilizing `THREE.Points` and TSL for twinkling animation and heart-shaped rendering.
+- Speed dynamically scales based on `playerState.currentSpeedY` relative to thrust, creating a sensation of blazing fast vertical momentum.
+- Occasional bright shooting stars streak across the screen using `THREE.Line`.
+- The player ship emits vivid particle trails providing intuitive motion feedback.
 
 ### Integration
-- `game_systems.ts`: Instantiated and exported `lightningBoltSystem`.
-- `level_manager.ts`: Checked `levelIndex === 1 || levelIndex === 2 || levelIndex === 3` inside `startLevel()` to trigger `lightningBoltSystem.activate()`, and called `update` inside the main `update` loop.
+- `main.ts`: Removed `debugSystem.isEnabled('starfield')` guard, ensuring `starfield.update()` is called every frame. Deleted legacy static `stars`. Added conditional trail color emitting in `updatePlayer()`.
 - `level_config.ts`: N/A
 
 ### Testing
 - [x] `npm run build` passes
-- [x] Tested in Level 1, 2, and 3 (where clouds are present)
+- [x] Tested globally across levels
 - [x] Mobile/touch controls still work

--- a/src/main.ts
+++ b/src/main.ts
@@ -463,10 +463,6 @@ let obstacleSystem: ObstacleSystem;
 // SPACE ENVIRONMENT (Stars, Galaxies, Moon)
 // =============================================================================
 
-// Add stars to the scene
-const stars = createStars(3000);
-scene.add(stars);
-uStarOpacity.value = 0.8; // Make stars visible
 
 // Create distant galaxies/nebulae
 // createGalaxy moved to ./visuals
@@ -1828,7 +1824,7 @@ function updatePlayer(delta: number) {
                 const exhaustPos = player.position.clone();
                 exhaustPos.x -= 0.5;
                 exhaustPos.y -= 0.5;
-                particleSystem.emit(exhaustPos, 0xffaa00, 2, 5.0, 0.8, 0.2);
+                particleSystem.emit(exhaustPos, 0x00ff00, 2, 5.0, 0.8, 0.2); // Green for boost/thrust
             } else if (isMovingDown) {
                 // Diving → very small, dim flame + extra downward particle streaks
                 const flicker = 0.4 + Math.random() * 0.2;
@@ -1838,11 +1834,19 @@ function updatePlayer(delta: number) {
                 const streakPos = player.position.clone();
                 streakPos.x -= 0.5;
                 streakPos.y -= 0.3;
-                particleSystem.emit(streakPos, 0xff4400, 1, 3.0, 0.5, 0.3);
+                particleSystem.emit(streakPos, 0xff0000, 1, 3.0, 0.5, 0.3); // Red for dive
             } else {
                 // Gliding / idle → smaller, softer flame
                 const flicker = 0.5 + Math.random() * 0.2;
                 rocket.userData.flame.scale.set(flicker, flicker * 1.5, flicker);
+
+                // Blue trail for glide
+                const glidePos = player.position.clone();
+                glidePos.x -= 0.5;
+                glidePos.y -= 0.1;
+                if (Math.random() < 0.3) {
+                    particleSystem.emit(glidePos, 0x00aaff, 1, 3.0, 0.6, 0.2);
+                }
             }
         }
     }
@@ -2496,9 +2500,7 @@ function animate() {
         // --- MAGICAL SYSTEMS (from swarm) ---
         // Update starfield with speed multiplier
         const speedMultiplier = 1 + Math.abs(playerState.currentSpeedY) / 20;
-        if (debugSystem.isEnabled('starfield')) {
-            starfield.update(delta, speedMultiplier);
-        }
+        starfield.update(delta, speedMultiplier);
         
         // Update orb manager and check collection
         orbManager.update(delta, time);


### PR DESCRIPTION
## 🌌 Architect: Dynamic Starfield Parallax & Trail Colors

### Concept
> "Dynamic starfield parallax - 3-4 layers of stars with speed scaling based on thrust. Occasional shooting stars."
> "Dynamic Trail Colors - Instant visual feedback: blue (glide) → red (dive) → green (boost)."
From `ideas.md` Quick Wins and Whimsical Edition.

### Implementation
- Activated the existing `StarfieldSystem` (which was hidden behind a debug flag) globally in `main.ts` and removed the legacy static `createStars(3000)` implementation.
- Implemented **Dynamic Trail Colors** by adjusting the engine exhaust particle emitter colors based on the player's movement state (Up/Thrust = Green, Down/Dive = Red, Idle/Glide = Blue).
- The Starfield features 4 parallax layers with varying densities, sizes, and base speeds, configured with a dreamy pastel color palette.

### Visuals
- 4 star layers at varying `zRange`s, utilizing `THREE.Points` and TSL for twinkling animation and heart-shaped rendering.
- Speed dynamically scales based on `playerState.currentSpeedY` relative to thrust, creating a sensation of blazing fast vertical momentum.
- Occasional bright shooting stars streak across the screen using `THREE.Line`.
- The player ship emits vivid particle trails providing intuitive motion feedback.

### Integration
- `main.ts`: Removed `debugSystem.isEnabled('starfield')` guard, ensuring `starfield.update()` is called every frame. Deleted legacy static `stars`. Added conditional trail color emitting in `updatePlayer()`.
- `level_config.ts`: N/A

### Testing
- [x] `npm run build` passes
- [x] Tested globally across levels
- [x] Mobile/touch controls still work

---
*PR created automatically by Jules for task [4245941831325831674](https://jules.google.com/task/4245941831325831674) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Starfield system now globally active with four-layer parallax effect and twinkling animations
  * Dynamic exhaust trail colors that change based on player state: green for thrust, red for diving, blue for gliding
  * Added occasional shooting stars to the background

* **Tests**
  * Updated testing checklist to verify starfield functionality across all levels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->