### PR TITLE
Feature: Fractured Geode Mining and Safe Harbor

### DIFF
--- a/pr_description.md
+++ b/pr_description.md
@@ -1,25 +1,28 @@
-## 🌌 Architect: Cloud Interaction and Dynamic Lighting
+## 🌌 Architect: Fractured Geodes (Mining Mechanics)
 
 ### Concept
-> "The player's exhaust and weapons cast a subtle glow on nearby nebula clouds, creating a dynamic interplay of light"
-> (Adapted to Multi-Layered Cloudscapes from section 1 of future-plan.md to add player and weapon interactions to the dense volumetric clouds.)
+> "Allow players to mine internal crystals; adjust EM field strength and discharge mechanic if crystals are shot too many times. Add interior safe harbor gameplay and spawn points for resources."
 
 ### Implementation
-- Enhanced `src/clouds.ts` (`createCloudSpriteMaterial`) by integrating the `WeaponLightManager` data and computing TSL lighting that reacts dynamically to weapon projectiles and the player's engine glow.
-- Supplied `weaponLightManager` to `CloudSystem` inside `LevelManager` (`src/level_manager.ts`), which in turn passes it down to `CloudLayer`.
-- Ensured `CloudSystem.update` accurately updates `uPlayerPos` for all layers.
+- Rebuilt `createFracturedGeode` in `src/geological.ts` to spawn multiple individual crystal meshes instead of a single core. Attached `userData` containing state for `health`, `maxHealth`, `quality`, and `isDischarged`.
+- Implemented `damageGeode` helper to handle the health math and visual shrinking/hiding of individual crystals upon taking projectile hits.
+- Implemented hit detection for geodes in `src/main.ts` by checking distance against `weaponSystem.getActiveProjectiles()`. On core depletion, the geode drops floating gems based on its quality.
+- Added `inSafeHarbor` boolean to `playerState`.
+- Calculated safe harbor state in the main update loop based on player distance to active geode EM fields.
+- Updated player damage pipelines across `src/main.ts` and `src/obstacle_system.ts` to skip taking damage if the player is in a safe harbor.
 
 ### Visuals
-- Cloud layers now react realistically to passing weapons, illuminating their dense volumes with cyan light.
-- The player's engine exhaust casts an orange radial glow when passing through cloud layers.
-- Seamlessly integrates with the existing Volumetric Lightning flashes.
+- Geodes now contain multiple crystal meshes at their center that visually scale down and disappear as they take damage.
+- When struck by a projectile, a bright purple particle spark is emitted.
+- Upon depletion, the protective EM field (the outer wireframe sphere) vanishes entirely.
+- Drop multiple `OrbType.STAR` style gems (randomized) upon breaking the final crystal.
 
 ### Integration
-- `src/main.ts`: Provided `weaponLightManager` into `LevelManager`.
-- `src/level_manager.ts`: Initialized `CloudSystem` with the `weaponLightManager` and updated it with `player.position`.
-- `src/clouds.ts`: Extensively modified the `MeshBasicNodeMaterial` logic to loop through `weaponLights` and apply dynamic `smoothstep` light attenuation to the cloud rendering output.
+- `src/main.ts`: Hooked hit detection into the main geological system update loop. Updated boss snap/hit logic to respect `inSafeHarbor`.
+- `src/obstacle_system.ts`: Updated squid and asteroid collision logic to respect `inSafeHarbor`.
+- `src/game_config.ts`: Added `inSafeHarbor` to `playerState`.
+- `src/geological.ts`: Significantly modified internal geode creation and management logic.
 
 ### Testing
 - [x] `npm run build` passes
-- [ ] Tested in Levels 1-3
-- [x] Mobile/touch controls still work
+- [ ] Mobile/touch controls still work

--- a/src/game_config.ts
+++ b/src/game_config.ts
@@ -35,6 +35,7 @@ export const playerState = {
     facingRight: true,
     isRunning: false,
     autoScrollSpeed: 8, // Constant forward movement
+    inSafeHarbor: false, // Protected by geode EM field
     health: 3, // Ship can survive 3 collisions
     maxHealth: 3,
     invincible: false, // Invincibility frames after hit

--- a/src/geological.ts
+++ b/src/geological.ts
@@ -104,35 +104,44 @@ const fbm = (v: any) => {
 
 // --- GEOLOGICAL OBJECTS ---
 
+
 // 2. FRACTURED GEODE (Safe harbors with EM fields)
 export function createFracturedGeode(config: { size: number }) {
     const group = new THREE.Group();
     
     // Outer Shell (Dark rock)
     const shellGeo = new THREE.IcosahedronGeometry(config.size, 1);
-    // Cut open the geode? (Simplified: just a dark rock for now with a glowing core inside sticking out)
-    // Better: Boolean operation is hard. Let's make a shell of rock chunks.
-
     const rockMat = new THREE.MeshStandardMaterial({ color: 0x333333, roughness: 0.9 });
     const shell = new THREE.Mesh(shellGeo, rockMat);
     group.add(shell);
 
-    // Inner Core (Glowing Crystal)
-    const coreGeo = new THREE.OctahedronGeometry(config.size * 0.6, 0);
+    // Inner Core (Multiple Glowing Crystals)
     const coreMat = new MeshStandardNodeMaterial({
         emissive: new THREE.Color(0x8844ff),
         roughness: 0.2,
         metalness: 0.5
     });
 
-    // Pulse effect
     const uTime = time;
     const pulse = sin(uTime.mul(2.0)).add(1.0).mul(0.5); // 0 to 1
     const baseEmit = color(0x8844ff);
-    coreMat.emissiveNode = baseEmit.mul(pulse.add(0.5)); // vary intensity
+    coreMat.emissiveNode = baseEmit.mul(pulse.add(0.5));
 
-    const core = new THREE.Mesh(coreGeo, coreMat);
-    group.add(core);
+    const coreGroup = new THREE.Group();
+    const crystalCount = 5;
+    for (let i = 0; i < crystalCount; i++) {
+        const crystalGeo = new THREE.OctahedronGeometry(config.size * 0.3, 0);
+        const crystal = new THREE.Mesh(crystalGeo, coreMat);
+
+        // Position crystals around center
+        const angle = (i / crystalCount) * Math.PI * 2;
+        const radius = config.size * 0.4;
+        crystal.position.set(Math.cos(angle) * radius, (Math.random() - 0.5) * radius, Math.sin(angle) * radius);
+        crystal.rotation.set(Math.random() * Math.PI, Math.random() * Math.PI, Math.random() * Math.PI);
+
+        coreGroup.add(crystal);
+    }
+    group.add(coreGroup);
 
     // EM Field (Transparent Sphere)
     const fieldGeo = new THREE.SphereGeometry(config.size * 2.5, 32, 32);
@@ -147,16 +156,23 @@ export function createFracturedGeode(config: { size: number }) {
 
     group.userData.isGeode = true;
     group.userData.fieldRadius = config.size * 2.5;
+    group.userData.health = 100;
+    group.userData.maxHealth = 100;
+    group.userData.quality = 0.5 + Math.random() * 0.5; // Random initial quality between 0.5 and 1.0
+    group.userData.isDischarged = false;
+    group.userData.crystalCount = crystalCount;
 
     return group;
 }
 
 export function updateGeode(group: THREE.Group, delta: number, timeVal: number) {
-    // Rotate core differently than shell
-    const core = group.children[1];
-    if (core) {
-        core.rotation.y -= delta * 0.5;
-        core.rotation.z += delta * 0.2;
+    if (group.userData.isDischarged) return;
+
+    // Rotate core Group
+    const coreGroup = group.children[1];
+    if (coreGroup) {
+        coreGroup.rotation.y -= delta * 0.5;
+        coreGroup.rotation.z += delta * 0.2;
     }
 
     // Pulse field opacity
@@ -166,6 +182,43 @@ export function updateGeode(group: THREE.Group, delta: number, timeVal: number) 
         field.rotation.y += delta * 0.1;
     }
 }
+
+export function damageGeode(group: THREE.Group, amount: number): boolean {
+    if (group.userData.isDischarged) return false;
+
+    group.userData.health -= amount;
+
+    // Note: Quality remains static so it can be used for reward calculation upon depletion
+
+    // Visually remove/shrink crystals based on health
+    const coreGroup = group.children[1] as THREE.Group;
+    if (coreGroup) {
+        const activeCrystals = Math.ceil((group.userData.health / group.userData.maxHealth) * group.userData.crystalCount);
+        for (let i = 0; i < coreGroup.children.length; i++) {
+            if (i >= activeCrystals) {
+                coreGroup.children[i].visible = false;
+            } else {
+                // Shrink remaining slightly
+                const scale = 0.5 + 0.5 * (group.userData.health / group.userData.maxHealth);
+                coreGroup.children[i].scale.setScalar(scale);
+            }
+        }
+    }
+
+    if (group.userData.health <= 0) {
+        group.userData.isDischarged = true;
+
+        // Hide EM field
+        const field = group.children[2] as THREE.Mesh;
+        if (field) {
+            field.visible = false;
+        }
+        return true; // Indicates just depleted
+    }
+
+    return false;
+}
+
 
 
 // 3. NEBULA JELLY-MOSS (Advanced Behavior)

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,7 @@ import { ParticleSystem, DebrisSystem } from './particles';
 import { CloudSystem } from './clouds';
 import {
     SporeCloud,
-    createFracturedGeode,
+    createFracturedGeode, damageGeode,
     updateGeode,
     createNebulaJellyMoss,
     updateNebulaJellyMoss,
@@ -2384,7 +2384,7 @@ function animate() {
                     },
                     onPlayerHit: () => {
                         // Boss hit player
-                        if (!playerState.invincible) {
+                        if (!playerState.invincible && !playerState.inSafeHarbor) {
                             playerState.health--;
                             audioSystem.play('hit');
                             updateHealthDisplay(playerState);
@@ -2762,8 +2762,58 @@ function animate() {
 
 
 
-        // Update geodes (EM field pulse)
-        geodes.forEach(geode => updateGeode(geode, delta, time));
+        // Update geodes and check for projectile hits & safe harbor
+        playerState.inSafeHarbor = false;
+
+        geodes.forEach(geode => {
+            updateGeode(geode, delta, time);
+
+            // Check safe harbor distance
+            if (player && !geode.userData.isDischarged && geode.userData.fieldRadius) {
+                const distToPlayer = player.position.distanceTo(geode.position);
+                if (distToPlayer < geode.userData.fieldRadius) {
+                    playerState.inSafeHarbor = true;
+                }
+            }
+
+            // Check projectile hits
+            if (!geode.userData.isDischarged) {
+                const projectiles = weaponSystem.getActiveProjectiles();
+                for (const proj of projectiles) {
+                    if (!proj.active) continue;
+
+                    const distToProj = proj.mesh.position.distanceTo(geode.position);
+                    // Hit the core
+                    if (distToProj < (geode.userData.fieldRadius * 0.4)) {
+                        // Deactivate projectile
+                        proj.deactivate();
+
+                        // Spawn sparks
+                        particleSystem.emit(proj.mesh.position.clone(), 0x8844ff, 10, 3.0, 0.5, 0.8);
+
+                        // Apply damage
+                        const justDepleted = damageGeode(geode, 20); // 5 hits to deplete
+                        if (justDepleted) {
+                            audioSystem.playCollect(); // Or a breaking sound
+                            // Release gems (Void Gems) based on quality
+                            const gemCount = Math.floor(3 + Math.random() * 3 * geode.userData.quality);
+                            for (let i = 0; i < gemCount; i++) {
+                                // Add small offset
+                                const offset = new THREE.Vector3(
+                                    (Math.random() - 0.5) * 2,
+                                    (Math.random() - 0.5) * 2,
+                                    (Math.random() - 0.5) * 2
+                                );
+                                const orbPos = geode.position.clone().add(offset);
+                                // Spawn a valuable floating orb
+                                orbManager.spawnRandomOrb(orbPos.x, orbPos.y, orbPos.z);
+                            }
+                        }
+                        break; // Only hit once per frame per projectile
+                    }
+                }
+            }
+        });
 
         // Update nebula jelly-moss (pulsing and drifting)
         // Use reverse loop so we can remove items safely

--- a/src/obstacle_system.ts
+++ b/src/obstacle_system.ts
@@ -20,7 +20,7 @@ type ObstacleSystemOptions = {
     scene: THREE.Scene;
     getPlayer: () => THREE.Group | null;
     getCurrentConfig: () => LevelConfig | undefined;
-    playerState: { health: number; invincible: boolean; velocity: THREE.Vector3 };
+    playerState: { health: number; invincible: boolean; inSafeHarbor?: boolean; velocity: THREE.Vector3 };
     getWasm: () => { exports: any; memory: Float32Array | null };
     setWasmMemory: (memory: Float32Array | null) => void;
     sporeClouds: SporeCloud[];
@@ -175,7 +175,7 @@ export class ObstacleSystem {
             squid.update(delta, playerX, playerY);
 
             // Player-squid collision (simple distance check)
-            if (!this.options.playerState.invincible) {
+            if (!this.options.playerState.invincible && !this.options.playerState.inSafeHarbor) {
                 const dist = squid.getPosition().distanceTo(new THREE.Vector3(playerX, playerY, 0));
                 if (dist < squid.getRadius() + 1.0) {
                     this.handleSquidCollision(squid);
@@ -216,7 +216,7 @@ export class ObstacleSystem {
                 const modifiers = this.options.getPowerUpModifiers ? this.options.getPowerUpModifiers() : { shieldActive: false, shieldBouncesAsteroids: false };
                 if (modifiers.shieldBouncesAsteroids && this.bounceCooldown <= 0) {
                     this.handleBounce(activeObstacles[hitIndex]);
-                } else if (!this.options.playerState.invincible) {
+                } else if (!this.options.playerState.invincible && !this.options.playerState.inSafeHarbor) {
                     this.handleCollision(activeObstacles[hitIndex]);
                 }
             }


### PR DESCRIPTION
## 🌌 Architect: Fractured Geodes (Mining Mechanics)
 
### Concept 
> "Allow players to mine internal crystals; adjust EM field strength and discharge mechanic if crystals are shot too many times. Add interior safe harbor gameplay and spawn points for resources."
 
### Implementation 
- Rebuilt `createFracturedGeode` in `src/geological.ts` to spawn multiple individual crystal meshes instead of a single core. Attached `userData` containing state for `health`, `maxHealth`, `quality`, and `isDischarged`.
- Implemented `damageGeode` helper to handle the health math and visual shrinking/hiding of individual crystals upon taking projectile hits.
- Implemented hit detection for geodes in `src/main.ts` by checking distance against `weaponSystem.getActiveProjectiles()`. On core depletion, the geode drops floating gems based on its quality.
- Added `inSafeHarbor` boolean to `playerState`.
- Calculated safe harbor state in the main update loop based on player distance to active geode EM fields.
- Updated player damage pipelines across `src/main.ts` and `src/obstacle_system.ts` to skip taking damage if the player is in a safe harbor.

### Visuals 
- Geodes now contain multiple crystal meshes at their center that visually scale down and disappear as they take damage.
- When struck by a projectile, a bright purple particle spark is emitted.
- Upon depletion, the protective EM field (the outer wireframe sphere) vanishes entirely.
- Drop multiple `OrbType.STAR` style gems (randomized) upon breaking the final crystal.
 
### Integration 
- `src/main.ts`: Hooked hit detection into the main geological system update loop. Updated boss snap/hit logic to respect `inSafeHarbor`.
- `src/obstacle_system.ts`: Updated squid and asteroid collision logic to respect `inSafeHarbor`.
- `src/game_config.ts`: Added `inSafeHarbor` to `playerState`.
- `src/geological.ts`: Significantly modified internal geode creation and management logic.
 
### Testing 
- [x] `npm run build` passes 
- [ ] Mobile/touch controls still work

---
*PR created automatically by Jules for task [18196930530521046445](https://jules.google.com/task/18196930530521046445) started by @ford442*