### PR TITLE
Fix aurora weaponLightManager.getUniforms runtime error

### DIFF
--- a/src/aurora.ts
+++ b/src/aurora.ts
@@ -16,7 +16,9 @@ import {
     smoothstep,
     positionLocal,
     positionWorld,
-    length
+    length,
+    distance,
+    Loop
 } from 'three/tsl';
 import { WeaponLightManager } from './lighting';
 
@@ -86,15 +88,20 @@ function createAuroraMaterial(weaponLights?: any, uPlayerPos?: any) {
 
     // Weapon Projectile Interactions
     if (weaponLights) {
-        for (let i = 0; i < 10; i++) {
-            const lightPos = weaponLights.positions[i];
-            const lightColor = weaponLights.colors[i];
-            const dist = length(positionWorld.sub(lightPos));
+        const uWeaponColor = uniform(new THREE.Color(0x00ffff));
+        const weaponGlow = float(0.0).toVar();
 
-            // Plasma storm reacts intensely to nearby projectiles
-            const lightFactor = smoothstep(80.0, 0.0, dist).mul(1.5);
-            finalColorWithInteraction = finalColorWithInteraction.add(lightColor.mul(lightFactor));
-        }
+        Loop({ start: 0, end: 20 }, ({ i }) => {
+            const lightData = weaponLights.element(i);
+            const lightPos = lightData.xyz;
+            const lightIntensity = lightData.w;
+
+            const distToLight = distance(positionWorld, lightPos);
+            const lightFactor = smoothstep(80.0, 0.0, distToLight).mul(lightIntensity).mul(1.5);
+            weaponGlow.addAssign(lightFactor);
+        });
+
+        finalColorWithInteraction = finalColorWithInteraction.add(uWeaponColor.mul(weaponGlow));
     }
 
     mat.colorNode = vec4(finalColorWithInteraction, finalAlpha);
@@ -137,7 +144,7 @@ export class AuroraSystem {
 
         // Long, curved ribbon base geometry
         const geo = new THREE.PlaneGeometry(800, 100, 64, 8);
-        const weaponLights = this.weaponLightManager ? this.weaponLightManager.getUniforms() : undefined;
+        const weaponLights = this.weaponLightManager ? this.weaponLightManager.storageNode : undefined;
         const mat = createAuroraMaterial(weaponLights, this.uPlayerPos);
 
         this.mesh = new THREE.InstancedMesh(geo, mat, this.maxCount);

--- a/src/clouds.ts
+++ b/src/clouds.ts
@@ -228,8 +228,6 @@ export class CloudLayer {
             width: number,
             detail?: number,
             weaponLights?: any,
-            uPlayerPos?: any,
-            weaponLights?: any,
             uPlayerPos?: any
         }
     ) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `Uncaught TypeError: this.weaponLightManager.getUniforms is not a function` when `AuroraSystem` initializes.

`WeaponLightManager` exposes projectile light data via `storageNode` (a TSL storage buffer), not a `getUniforms()` helper. Aurora was still using a stale API that expected `positions[]` / `colors[]` arrays.

## Changes

- **`src/aurora.ts`**: Pass `weaponLightManager.storageNode` into `createAuroraMaterial`, and sample weapon lights with the same `Loop` + `element(i)` pattern used by clouds, nebula, asteroids, waterfall, and industrial backgrounds.
- **`src/clouds.ts`**: Remove duplicated `weaponLights` / `uPlayerPos` fields in `CloudLayer` config typing (copy-paste mistake).

## Verification

- `npm run build` succeeds (brace check, WASM build, Vite production build).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-798a406b-395c-41e0-b139-a0592bfe4e42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-798a406b-395c-41e0-b139-a0592bfe4e42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

