### PR TITLE
Architect: Black Hole Activation Fix

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3302,20 +3302,23 @@ function animate() {
     }
 
     // BLACK HOLE SYSTEM (Level 2 environmental hazard)
-    if (player && debugSystem.isEnabled('blackHole')) {
-        blackHoleSystem.update(delta, camera.position.x, player.position);
+    if (player && blackHoleSystem.active) {
+        // Update is now handled inside levelManager.update
 
         // Gentle player gravity pull (very light bias on desired velocity)
         const yPull = blackHoleSystem.getPlayerPullForce(player.position);
-        if (yPull !== 0 && playerState.desiredVelocityY !== undefined) {
-            playerState.desiredVelocityY += yPull;
+        if (yPull !== 0 && (playerState as any).desiredVelocityY !== undefined) {
+            (playerState as any).desiredVelocityY += yPull;
+        } else if (yPull !== 0 && !(playerState as any).inSafeHarbor && !(playerState as any).invincible) {
+            // Apply yPull directly to targetY to gently drift the player if not using custom movement system
+            playerState.targetY += yPull;
         }
 
         // Projectile accretion-disk feedback (capped internally)
         const projectiles = weaponSystem.getActiveProjectiles();
         if (projectiles.length > 0) {
             blackHoleSystem.handleProjectileInteractions(projectiles, particleSystem, () => {
-                if (juiceManager) juiceManager.triggerScreenShake(0.6);
+                if (juiceManager) juiceManager.shakeScreen(ShakeType.LIGHT, 0.6); // 0.5 is ShakeType.LIGHT
             });
         }
     }


### PR DESCRIPTION
## 🌌 Architect: Black Hole Activation Fix

### Concept
> "10. Approaching a Galactic Core / Accretion Disk"
> "A massive, slowly spinning black hole or quasar in the deep background, surrounded by an intensely glowing accretion disk that warps and distorts due to gravitational lensing. Uses slow parallax to emphasize distance."

### Implementation
- `black_hole.ts` was already implemented but integrated poorly (hidden behind a debug flag, duplicate update calls, and lacking standard config toggles).
- Added `blackHole` to `LevelConfig` in `level_config.ts`.
- Configured Level 2 to have the black hole enabled (`{ enabled: true, baseX: 2000, baseY: 100 }`).
- Updated `LevelManager.startLevel()` in `level_manager.ts` to properly activate and configure base coordinates for the Black Hole System based on config.
- Refactored `main.ts` loop to ensure gravity pulling mechanics and projectile accretion-disk feedbacks trigger when `blackHoleSystem.active` is true rather than strict debug gating.
- Fixed a bad method call to `juiceManager.triggerScreenShake()` -> `juiceManager.shakeScreen(ShakeType.LIGHT, 0.6)`.

### Visuals
- Accretion Disk: Additive blending with procedural flame colors (core white, mid orange, edge red).
- Halo lensing effect: procedural intensity masking wrapping the event horizon sphere.
- Gently pulls the player and flares up when projectiles intersect its disk plane.

### Integration
- `level_config.ts`: Added `blackHole?: { enabled: boolean; baseX?: number; baseY?: number; }` field.
- `level_manager.ts`: Hooks config in `startLevel` and calls `blackHoleSystem.update(delta, cameraX, playerPos)` in `update`.
- `main.ts`: Moved logic execution under `if (player && blackHoleSystem.active)` and fixed type constraints.

### Testing
- [x] `npm run build` passes
- [x] Tested in Level 2 at `npm run dev`
- [x] Mobile/touch controls still work

---
*PR created automatically by Jules for task [13377685805157416045](https://jules.google.com/task/13377685805157416045) started by @ford442*