### PR TITLE
Improve side-scroller object placement and scene wiring

### DIFF
--- a/docs/SIDE_SCROLLER_OBJECTS.md
+++ b/docs/SIDE_SCROLLER_OBJECTS.md
@@ -1,0 +1,98 @@
+# Side-Scroller Objects & Creatures
+
+Dog Dash scrolls along **+X**. **Y** is vertical flight space. **Z** is depth (negative = into the screen).
+
+## Depth bands
+
+Use `src/depth_layers.ts` for consistent placement:
+
+| Layer | Z range | Examples |
+|-------|---------|----------|
+| `FAR_BACKGROUND` | -80 … -55 | Far castles, galaxies |
+| `BACKGROUND` | -50 … -30 | Flowers, spore clouds, tissue walls |
+| `MIDGROUND` | -28 … -8 | Ferns, trees, geological props |
+| `NEAR` | -10 … 5 | Candy belt, friends |
+| `GAMEPLAY` | -2 … 2 | Player, collision obstacles |
+
+```ts
+import { DEPTH_LAYERS, randomZInLayer } from './depth_layers';
+
+const z = randomZInLayer('MIDGROUND');
+```
+
+## How objects get into the world
+
+### 1. Streaming foliage (`level_manager.ts`)
+
+`LevelManager.spawnOpenFoliage()` scatters decorative plants from `foliage.ts` ahead of the camera. Zones stream continuously as the player moves (not just once at level start).
+
+- Density keys live in `level_config.ts` → `foliageDensity`
+- Catalogable species need `userData.speciesId` and an entry in `discovery_system.ts` → `SPECIES_NAMES`
+- Animated plants are tracked in `visuals.ts` → `moonPlants`
+
+**Add a new plant species**
+
+1. Create `createMyPlant()` in `foliage.ts`
+2. Add a density key to `LevelConfig.foliageDensity` and each level block in `level_config.ts`
+3. Add a `spawn()` line in `LevelManager.spawnOpenFoliage()`
+4. Register `speciesId` in `discovery_system.ts` if scannable
+
+### 2. Dreamy layers (flowers, castles, candy)
+
+Spawned once per level in `LevelManager.startLevel()` using the **actual level segment** from `LEVEL_DISTANCE_BOUNDARIES` (via `getLevelSpan()`), not `cfg.distance`.
+
+| Manager | Module | Placement |
+|---------|--------|-----------|
+| `ConstellationManager` | `flower_constellations.ts` | Giant background blooms |
+| `CastleBackgroundManager` | `cloud_castles.ts` | Parallax cloud castles |
+| `CandyBeltManager` | `candy_obstacles.ts` | Bouncy sweet obstacles |
+
+### 3. Parallax backgrounds (infinite wrap)
+
+Clouds, stars, asteroid fields, biological tissue, ghost debris, butterflies — fixed instance pools that wrap when the camera passes.
+
+Pattern: `activate()` on level start → `update(delta, cameraX)` each frame.
+
+### 4. Rare bestiary (`creature_manager.ts`)
+
+Per-frame probabilistic spawn gated by `LevelConfig` rates (`crystalTarsierRate`, `geodeTitanRate`).
+
+### 5. Streaming companions (`space_friends.ts`)
+
+`FriendsManager.maybeSpawnFriends()` places kitty/bunny/lantern ahead of the player every ~100 units.
+
+### 6. Level-specific batches
+
+Examples: Level 6 `AquaticLifeManager.spawnForLevel6()`, trapped friends for rescue objectives.
+
+## Level configuration
+
+`level_config.ts` controls:
+
+- `foliageDensity` — decorative plant counts per zone chunk
+- `asteroidRate` — hazard interval + parallax asteroid belt density
+- `levelType` — `open`, `tunnel`, or `organic_tunnel` (constrains Y and spawns rib geometry)
+- Atmosphere: `skyColors`, `fogDensity`, `godRays`, `aurora`, `lightning`, `meteorShower`
+- Creature/hazard rates: `squidSpawnRate`, `crystalTarsierRate`, etc.
+
+Level transitions use `LEVEL_DISTANCE_BOUNDARIES` (cumulative X positions). `cfg.distance` is still used for HUD “distance to moon” flavor text — prefer `getLevelSpan()` for placement math.
+
+## Wiring checklist (important)
+
+All spawned meshes must be added to the **same** `THREE.Scene` that `main.ts` renders. `LevelManager` receives scene, managers, spawners, and `getPlayer` via its constructor — do not import a parallel scene from `scene_setup.ts` when extending placement code.
+
+## Debug
+
+- Backquote → debug panel (wireframe, collision radii)
+- `?collisionDebug` — collision sphere overlay
+- `?renderer=webgl` — WebGL2 fallback
+
+## Related files
+
+| Domain | Files |
+|--------|-------|
+| Placement orchestration | `level_manager.ts`, `depth_layers.ts`, `level_config.ts` |
+| Plants & props | `foliage.ts`, `foliage_shared.ts`, `geological.ts`, `environment.ts` |
+| Creatures | `space_friends.ts`, `creature_manager.ts`, `aquatic_life.ts`, `butterfly_swarm.ts` |
+| Dreamy decor | `flower_constellations.ts`, `cloud_castles.ts`, `candy_obstacles.ts` |
+| Parallax BG | `clouds.ts`, `stars.ts`, `biological_background.ts`, `asteroid_field.ts` |

--- a/src/candy_obstacles.ts
+++ b/src/candy_obstacles.ts
@@ -700,25 +700,29 @@ export class CandyBeltManager {
     // GENERATION
     // ========================================================================
 
-    generateCandyBelt(length: number, density: number): void {
+    generateCandyBelt(
+        startX: number,
+        length: number,
+        density: number,
+        zBand: { min: number; max: number } = { min: -7.5, max: 7.5 }
+    ): void {
         this.beltLength = length;
-        this.beltStartX = 0;
-        
+        this.beltStartX = startX;
+
         const count = Math.floor(length * density);
-        
+
         for (let i = 0; i < count; i++) {
-            const x = (Math.random() - 0.3) * length;
-            const y = (Math.random() - 0.5) * 30;
-            const z = (Math.random() - 0.5) * 15;
-            
-            // Weighted random type
+            const x = startX + Math.random() * length;
+            const y = (Math.random() - 0.5) * 28;
+            const z = zBand.min + Math.random() * (zBand.max - zBand.min);
+
             const type = this.getRandomCandyType();
             const flavor = this.getRandomFlavor();
-            
+
             this.spawnCandyAsteroid(x, y, z, type, flavor);
         }
-        
-        console.log(`🍭 Generated candy belt with ${count} sweet treats!`);
+
+        console.log(`🍭 Generated candy belt with ${count} sweet treats along x=${startX.toFixed(0)}..${(startX + length).toFixed(0)}`);
     }
 
     spawnCandyAsteroid(

--- a/src/depth_layers.ts
+++ b/src/depth_layers.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared Z-depth bands for side-scroller placement.
+ * X = scroll axis, Y = vertical flight, Z = depth (negative = into screen).
+ */
+export const DEPTH_LAYERS = {
+    /** Deepest parallax — galaxies, far castles */
+    FAR_BACKGROUND: { min: -80, max: -55 } as const,
+    /** Clouds, tissue walls, flower constellations */
+    BACKGROUND: { min: -50, max: -30 } as const,
+    /** Foliage, geological props, mid castles */
+    MIDGROUND: { min: -28, max: -8 } as const,
+    /** Candy, friends, near obstacles */
+    NEAR: { min: -10, max: 5 } as const,
+    /** Player plane */
+    GAMEPLAY: { min: -2, max: 2 } as const,
+} as const;
+
+export type DepthLayer = keyof typeof DEPTH_LAYERS;
+
+export function randomZInLayer(layer: DepthLayer): number {
+    const band = DEPTH_LAYERS[layer];
+    return band.min + Math.random() * (band.max - band.min);
+}
+
+export function randomZInRange(range: readonly [number, number]): number {
+    return range[0] + Math.random() * (range[1] - range[0]);
+}
+
+import { LEVEL_DISTANCE_BOUNDARIES } from './level_config';
+
+/** Level segment length from cumulative boundaries. */
+export function getLevelSpan(levelIndex: number): { startX: number; endX: number; length: number } {
+    const startX = LEVEL_DISTANCE_BOUNDARIES[levelIndex - 1] ?? 0;
+    const endX = LEVEL_DISTANCE_BOUNDARIES[levelIndex] ?? startX;
+    return { startX, endX, length: Math.max(0, endX - startX) };
+}

--- a/src/level_manager.ts
+++ b/src/level_manager.ts
@@ -9,32 +9,16 @@ import {
     createShrub,
     createVine,
     createPuffballFlower,
-    createFiberOpticWillow,
     createGlowingFlower,
     createStarDustFern,
     createNebulaRose,
     createFloweringTree,
     createFloatingOrb
 } from './foliage';
-import {
-    createSporeCloudAtPosition,
-    createVoidRootBallAtPosition,
-    createVacuumKelpAtPosition,
-    createIceNeedleClusterAtPosition,
-    createLiquidMetalBlobAtPosition,
-    createMagmaHeartAtPosition,
-    createGravityAnchorAtPosition,
-    sporeClouds,
-    voidRootBalls,
-    vacuumKelps,
-    iceNeedleClusters,
-    magmaHearts,
-    gravityAnchors
-} from './environment';
-import { scene, camera, butterflySwarmSystem } from './scene_setup';
+import { DEPTH_LAYERS, getLevelSpan, randomZInLayer, randomZInRange } from './depth_layers';
 import { playerState } from './game_config';
-import { player } from './player_loader';
-import { moonPlants, disposeObject } from './environment';
+import { moonPlants } from './visuals';
+import { disposeObject } from './utils';
 import {
     blackHoleSystem,
     waterfallSystem,
@@ -47,16 +31,18 @@ import {
     meteorShowerSystem,
     asteroidFieldSystem,
     planetaryHorizonSystem,
-    reEntrySystem,
-    flowerManager,
-    castleManager,
-    candyManager
+    reEntrySystem
 } from './game_systems';
 import { GodRaySystem } from './godrays';
 import { AuroraSystem } from './aurora';
 import { GhostDebrisSystem } from './ghost_debris';
 import { DebugSystem } from './debug_system';
 import { FriendsManager } from './space_friends';
+import { ButterflySwarmSystem } from './butterfly_swarm';
+import { WeaponLightManager } from './lighting';
+import type { ConstellationManager } from './flower_constellations';
+import type { CastleBackgroundManager } from './cloud_castles';
+import type { CandyBeltManager } from './candy_obstacles';
 
 // =============================================================================
 // LEVEL MANAGER
@@ -65,6 +51,49 @@ const DEFAULT_FOG_FAR = 80;
 const DEFAULT_FOG_NEAR = 20;
 const FOG_FAR_DENSITY_FACTOR = 5;
 const FOG_NEAR_DENSITY_FACTOR = 3;
+
+const STREAM_AHEAD_START = 80;
+const STREAM_AHEAD_END = 550;
+
+export type GeologicalSpawners = {
+    createSporeCloudAtPosition: (x: number, y: number, z: number) => unknown;
+    createVoidRootBallAtPosition: (x: number, y: number, z: number) => unknown;
+    createVacuumKelpAtPosition: (x: number, y: number, z: number) => unknown;
+    createIceNeedleClusterAtPosition: (x: number, y: number, z: number) => unknown;
+    createLiquidMetalBlobAtPosition: (x: number, y: number, z: number) => unknown;
+    createMagmaHeartAtPosition: (x: number, y: number, z: number) => unknown;
+    createGravityAnchorAtPosition: (x: number, y: number, z: number, biome?: number) => unknown;
+};
+
+export type GeologicalCounts = {
+    sporeClouds: () => number;
+    voidRootBalls: () => number;
+    vacuumKelps: () => number;
+    iceNeedleClusters: () => number;
+    magmaHearts: () => number;
+    gravityAnchors: () => number;
+};
+
+export type LevelManagerOptions = {
+    scene: THREE.Scene;
+    camera: THREE.PerspectiveCamera;
+    weaponLightManager: WeaponLightManager;
+    godRaySystem: GodRaySystem;
+    auroraSystem: AuroraSystem;
+    ghostDebrisSystem: GhostDebrisSystem;
+    debugSystem?: DebugSystem;
+    friendsManager?: FriendsManager;
+    industrialGeometryManager: IndustrialGeometryManager;
+    butterflySwarmSystem: ButterflySwarmSystem;
+    flowerManager: ConstellationManager;
+    castleManager: CastleBackgroundManager;
+    candyManager: CandyBeltManager;
+    getPlayer: () => THREE.Group | null;
+    spawners: GeologicalSpawners;
+    geologicalCounts: GeologicalCounts;
+    onLevelStart?: (cfg: LevelConfig) => void;
+    onUpdateLevelDisplay?: (levelIndex: number, name: string) => void;
+};
 
 export class LevelManager {
     currentLevel: number;
@@ -80,6 +109,17 @@ export class LevelManager {
     friendsManager?: FriendsManager;
     industrialGeometryManager: IndustrialGeometryManager;
     objectDensityMultiplier: number;
+    private readonly scene: THREE.Scene;
+    private readonly camera: THREE.PerspectiveCamera;
+    private readonly butterflySwarmSystem: ButterflySwarmSystem;
+    private readonly flowerManager: ConstellationManager;
+    private readonly castleManager: CastleBackgroundManager;
+    private readonly candyManager: CandyBeltManager;
+    private readonly getPlayer: () => THREE.Group | null;
+    private readonly spawners: GeologicalSpawners;
+    private readonly geologicalCounts: GeologicalCounts;
+    private readonly onLevelStart?: (cfg: LevelConfig) => void;
+    private readonly onUpdateLevelDisplay?: (levelIndex: number, name: string) => void;
     private baseAsteroidDensity = 0;
     /** True once this level's objective has been completed and the "fast lane"
      *  (reduced hazard density, bonus orbs) toward the level exit is active. */
@@ -96,11 +136,22 @@ export class LevelManager {
         gravityAnchor: 6
     } as const;
 
-    constructor(options: any) {
-        this.cloudSystem = new CloudSystem(scene, options.weaponLightManager);
-        this.atmosphereSystem = new AtmosphereSystem(scene);
+    constructor(options: LevelManagerOptions) {
+        this.scene = options.scene;
+        this.camera = options.camera;
+        this.butterflySwarmSystem = options.butterflySwarmSystem;
+        this.flowerManager = options.flowerManager;
+        this.castleManager = options.castleManager;
+        this.candyManager = options.candyManager;
+        this.getPlayer = options.getPlayer;
+        this.spawners = options.spawners;
+        this.geologicalCounts = options.geologicalCounts;
+        this.onLevelStart = options.onLevelStart;
+        this.onUpdateLevelDisplay = options.onUpdateLevelDisplay;
 
-        // Link LightningBoltSystem to CloudSystem for synchronized volumetric lighting
+        this.cloudSystem = new CloudSystem(this.scene, options.weaponLightManager);
+        this.atmosphereSystem = new AtmosphereSystem(this.scene);
+
         lightningBoltSystem.onBoltStrike = (pos, color) => {
             this.cloudSystem.triggerLightningAt(pos, color);
             this.godRaySystem.triggerLightningFlash(1.0, color);
@@ -114,7 +165,6 @@ export class LevelManager {
         this.currentLevel = 1;
         this.config = LEVEL_CONFIG;
 
-        // Track planted objects to cleanup
         this.levelObjects = [];
         this.lastPopulatedEndX = -Infinity;
         this.objectDensityMultiplier = 1.0;
@@ -127,12 +177,6 @@ export class LevelManager {
         }
     }
 
-    /**
-     * Open the "fast lane" toward the level exit once the chapter objective
-     * is complete: thins out the background asteroid field as a reward for
-     * finishing the mission (called once per level via main.ts's
-     * hudManager.onObjectiveComplete hook).
-     */
     enterFastLane() {
         if (this.fastLaneActive) return;
         this.fastLaneActive = true;
@@ -149,10 +193,14 @@ export class LevelManager {
 
         this.fastLaneActive = false;
         this.fastLaneDensityFactor = 1.0;
+        this.lastPopulatedEndX = -Infinity;
 
         console.log(`Starting Level ${levelIndex}: ${cfg.name}`);
 
-        // Update Game State
+        const player = this.getPlayer();
+        const playerX = player ? player.position.x : 0;
+        const { startX: levelStartX, endX: levelEndX, length: levelLength } = getLevelSpan(levelIndex);
+
         playerState.autoScrollSpeed = cfg.speed;
         playerState.distanceToMoon = cfg.distance;
 
@@ -168,46 +216,34 @@ export class LevelManager {
             this.auroraSystem.deactivate();
         }
 
-        // --- ATMOSPHERE UPDATE ---
         let transitionDuration = 2.0;
         if (levelIndex === 3) {
-            // Level 3 "Orbital Descent" should take ~100s to fully transition to blue
-            // 1000m / 10m/s = 100s
             transitionDuration = 100.0;
         }
 
         this.atmosphereSystem.transitionTo(cfg.skyColors.top, cfg.skyColors.bottom, transitionDuration);
-        // Note: AtmosphereSystem handles fog color now.
 
-        if (scene.fog) {
-            // scene.fog.color is updated by AtmosphereSystem
-            // Apply custom fog density for Memory Fog effect (Level 5)
-            if (scene.fog instanceof THREE.Fog) {
+        if (this.scene.fog) {
+            if (this.scene.fog instanceof THREE.Fog) {
                 if (cfg.fogDensity) {
-                    // Adjust fog near/far based on density (higher density = closer fog)
-                    scene.fog.far = DEFAULT_FOG_FAR * (1 - cfg.fogDensity * FOG_FAR_DENSITY_FACTOR);
-                    scene.fog.near = DEFAULT_FOG_NEAR * (1 - cfg.fogDensity * FOG_NEAR_DENSITY_FACTOR);
+                    this.scene.fog.far = DEFAULT_FOG_FAR * (1 - cfg.fogDensity * FOG_FAR_DENSITY_FACTOR);
+                    this.scene.fog.near = DEFAULT_FOG_NEAR * (1 - cfg.fogDensity * FOG_NEAR_DENSITY_FACTOR);
                 } else {
-                    // Reset to default fog
-                    scene.fog.far = DEFAULT_FOG_FAR;
-                    scene.fog.near = DEFAULT_FOG_NEAR;
+                    this.scene.fog.far = DEFAULT_FOG_FAR;
+                    this.scene.fog.near = DEFAULT_FOG_NEAR;
                 }
             }
         }
 
-        // Update UI
         const levelDiv = document.getElementById('level-display');
         if (levelDiv) levelDiv.innerHTML = `Level ${levelIndex}: ${cfg.name}`;
+        this.onUpdateLevelDisplay?.(levelIndex, cfg.name);
+        this.onLevelStart?.(cfg);
 
-        // Populate new zone ahead of player
-        this.populateZone(player!.position.x + 50, player!.position.x + 600, cfg);
-
-        // Configure clouds based on level type/name
-        // Update cloud layers based on density and color
+        this.populateZone(playerX + STREAM_AHEAD_START, playerX + STREAM_AHEAD_END, cfg);
 
         this.cloudSystem.setLevel(cfg);
 
-        // Reset and activate systems based on level configuration
         chromaShiftSystem.clearRocks();
         if (cfg.chromaShiftDensity && cfg.chromaShiftDensity > 0) {
             chromaShiftSystem.activate();
@@ -227,33 +263,27 @@ export class LevelManager {
             lightningBoltSystem.deactivate();
         }
 
-
-        // Special Effects per Level
         if (levelIndex === 1) {
-            butterflySwarmSystem.activate();
+            this.butterflySwarmSystem.activate();
         } else {
-            butterflySwarmSystem.deactivate();
+            this.butterflySwarmSystem.deactivate();
         }
 
         if (levelIndex === 3) {
-            // Activate Planetary Horizon in Level 3
-            planetaryHorizonSystem.levelDistance = cfg.distance;
+            planetaryHorizonSystem.levelDistance = levelLength;
             planetaryHorizonSystem.activate();
-            // Activate Re-Entry Heat in Level 3 "Orbital Descent"
-            reEntrySystem.levelDistance = cfg.distance;
+            reEntrySystem.levelDistance = levelLength;
             reEntrySystem.activate();
 
-            // Seed the "Rescue" objective: scatter trapped friends along the descent
             if (this.friendsManager && cfg.objective?.type === 'rescue') {
                 this.friendsManager.spawnTrappedFriendsAlong(
-                    player!.position.x + 100,
-                    cfg.distance - 200,
+                    playerX + 100,
+                    levelLength - 200,
                     cfg.objective.target
                 );
             }
         } else {
             planetaryHorizonSystem.deactivate();
-            // Only deactivate reentry if not in level 3 (handled below generally, but explicit here for clarity)
             if (levelIndex !== 3) reEntrySystem.deactivate();
         }
 
@@ -264,7 +294,6 @@ export class LevelManager {
         }
 
         if (levelIndex === 4) {
-            // Industrial Tunnel
             industrialSystem.activate();
         } else {
             industrialSystem.deactivate();
@@ -276,13 +305,11 @@ export class LevelManager {
             waterfallSystem.deactivate();
         }
 
-        // Activate Asteroid Fields dynamically based on density
         if (cfg.asteroidRate && cfg.asteroidRate > 0) {
             asteroidFieldSystem.activate();
-            // Scale density relative to default levels
             this.baseAsteroidDensity = cfg.asteroidRate * 0.5;
             asteroidFieldSystem.setDensity(this.baseAsteroidDensity * this.objectDensityMultiplier);
-            asteroidFieldSystem.resetPositions(camera.position.x);
+            asteroidFieldSystem.resetPositions(this.camera.position.x);
         } else {
             this.baseAsteroidDensity = 0;
             asteroidFieldSystem.deactivate();
@@ -294,20 +321,15 @@ export class LevelManager {
             this.ghostDebrisSystem.deactivate();
         }
 
-
         if (levelIndex === 2) {
             blackHoleSystem.activate();
         } else {
             blackHoleSystem.deactivate();
         }
+
         if (levelIndex === 5) {
-            // Activate Biological System for Space Whale Interior
             biologicalSystem.activate();
-
-            // Level 5: Nebula Activation (fixed)
-            // Correct behavior - was previously deactivate() in old main.ts
             nebulaSystem.activate();
-
             cosmicDustSystem.activate();
             this.cloudSystem.layers.forEach(l => l.mesh.visible = false);
         } else {
@@ -319,29 +341,42 @@ export class LevelManager {
             }
         }
 
-        // SWARM #3: Generate Magical Dreamy Environments (for levels 1-3 and 6-7)
-        const currentX = player ? player.position.x : 0;
+        // Dreamy side-scroller layers — span the actual level segment, not cfg.distance
+        const dreamyPadding = 80;
+        const dreamyStart = levelStartX + dreamyPadding;
+        const dreamyEnd = levelEndX - dreamyPadding;
+
         if (levelIndex <= 3 || levelIndex >= 6) {
-            // Flower Constellations - giant glowing space flowers
-            flowerManager.generateConstellation(15, currentX + 100, currentX + cfg.distance - 100, -40, 40);
-            
-            // Cloud Castles - dreamy floating castles in background
-            castleManager.generateCastleField(8, currentX + 200, currentX + cfg.distance - 200);
+            this.flowerManager.cleanup();
+            this.flowerManager.generateConstellation(
+                15,
+                dreamyStart,
+                dreamyEnd,
+                DEPTH_LAYERS.BACKGROUND.min,
+                DEPTH_LAYERS.BACKGROUND.max
+            );
+
+            this.castleManager.clear();
+            this.castleManager.generateCastleField(8, dreamyStart + 50, dreamyEnd - 50);
         }
-        
-        // Candy Belt - sweet treat obstacles (all levels except serious ones)
+
         if (levelIndex !== 4 && levelIndex !== 5) {
-            candyManager.generateCandyBelt(cfg.distance * 0.8, 0.25);
+            this.candyManager.clear();
+            this.candyManager.generateCandyBelt(
+                dreamyStart,
+                levelLength * 0.85,
+                0.22,
+                DEPTH_LAYERS.NEAR
+            );
         }
     }
 
-    // Phase 1 FPS Fixes - Quick Wins: object cleanup with geometry disposal
     cleanupBehind(cameraX: number) {
         const cutoff = cameraX - 100;
         for (let i = this.levelObjects.length - 1; i >= 0; i--) {
             const obj = this.levelObjects[i];
             if (obj.position.x < cutoff) {
-                scene.remove(obj);
+                this.scene.remove(obj);
                 const mpIdx = moonPlants.indexOf(obj);
                 if (mpIdx !== -1) moonPlants.splice(mpIdx, 1);
                 disposeObject(obj);
@@ -350,248 +385,251 @@ export class LevelManager {
         }
     }
 
+    /** Stream decorative foliage ahead as the player progresses. */
+    private maybeStreamFoliage(cameraX: number) {
+        const cfg = this.config[this.currentLevel];
+        if (!cfg) return;
+
+        const targetEnd = cameraX + STREAM_AHEAD_END;
+        if (targetEnd <= this.lastPopulatedEndX) return;
+
+        const startX = Math.max(this.lastPopulatedEndX, cameraX + STREAM_AHEAD_START);
+        this.populateZone(startX, targetEnd, cfg);
+    }
+
     update(delta: number, cameraX: number, speed: number, isFiring: boolean = false, fireDir?: THREE.Vector3) {
+        this.maybeStreamFoliage(cameraX);
         this.cleanupBehind(cameraX);
-        this.atmosphereSystem.update(delta, new THREE.Vector3(cameraX, 0, 0)); // Only X matters for now
-        this.cloudSystem.update(delta, cameraX, speed, player ? player.position : undefined);
+        this.atmosphereSystem.update(delta, new THREE.Vector3(cameraX, 0, 0));
+        this.cloudSystem.update(delta, cameraX, speed, this.getPlayer()?.position);
         lightningBoltSystem.update(delta, cameraX, speed);
 
         const dbg = this.debugSystem;
         const enabled = (name: string) => !dbg || dbg.isEnabled(name);
+        const playerPos = this.getPlayer()?.position;
 
-        if (enabled('waterfall')) waterfallSystem.update(cameraX, delta, player ? player.position : undefined);
-        if (enabled('industrialBg')) industrialSystem.update(cameraX, delta, player ? player.position : undefined);
+        if (enabled('waterfall')) waterfallSystem.update(cameraX, delta, playerPos);
+        if (enabled('industrialBg')) industrialSystem.update(cameraX, delta, playerPos);
         if (enabled('biological')) biologicalSystem.update(delta, cameraX);
-        // Pass player position to NebulaSystem for interactive lighting
-        if (enabled('nebula')) nebulaSystem.update(delta, cameraX, player ? player.position : undefined);
+        if (enabled('nebula')) nebulaSystem.update(delta, cameraX, playerPos);
         if (enabled('meteorShower')) meteorShowerSystem.update(delta, cameraX);
-        if (enabled('cosmicDust')) cosmicDustSystem.update(delta, cameraX, player ? player.position : undefined);
-        if (this.currentLevel === 5) {
-            // nebulaSystem.updateLights(weaponSystem.getActiveProjectiles());
-        }
+        if (enabled('cosmicDust')) cosmicDustSystem.update(delta, cameraX, playerPos);
         if (enabled('asteroidField') && asteroidFieldSystem) asteroidFieldSystem.update(delta, cameraX);
         if (enabled('planetaryHorizon') && planetaryHorizonSystem) planetaryHorizonSystem.update(cameraX, delta);
         if (enabled('ghostDebris') && this.ghostDebrisSystem) this.ghostDebrisSystem.update(delta, cameraX);
         if (blackHoleSystem) blackHoleSystem.update(delta, cameraX);
-        if (enabled('chromaShift')) chromaShiftSystem.update(delta, player ? player.position : undefined);
-        if (enabled('stormGeodes') && stormGeodeSystem) stormGeodeSystem.update(delta, cameraX, player ? player.position : undefined);
-        if (enabled('godRays') && this.godRaySystem) this.godRaySystem.update(delta, cameraX, speed, player ? player.position : undefined, isFiring, fireDir);
-        if (enabled('reEntry') && reEntrySystem) reEntrySystem.update(delta, cameraX, camera.position.y, player ? player : undefined);
+        if (enabled('chromaShift')) chromaShiftSystem.update(delta, playerPos);
+        if (enabled('stormGeodes') && stormGeodeSystem) stormGeodeSystem.update(delta, cameraX, playerPos);
+        if (enabled('godRays') && this.godRaySystem) this.godRaySystem.update(delta, cameraX, speed, playerPos, isFiring, fireDir);
+        if (enabled('reEntry') && reEntrySystem) reEntrySystem.update(delta, cameraX, this.camera.position.y, this.getPlayer() ?? undefined);
 
-        if (enabled('aurora') && this.auroraSystem) this.auroraSystem.update(delta, cameraX, speed, player ? player.position : undefined);
+        if (enabled('aurora') && this.auroraSystem) this.auroraSystem.update(delta, cameraX, speed, playerPos);
     }
 
     populateZone(startX: number, endX: number, config: LevelConfig) {
-        // Guard against re-populating the same zone
         if (endX <= this.lastPopulatedEndX) return;
         this.lastPopulatedEndX = endX;
 
         const width = endX - startX;
+        if (width <= 0) return;
+
         const density = config.foliageDensity;
         const levelType = config.levelType || 'open';
 
-        // For tunnel levels, spawn structural sections at fixed intervals
         if (levelType === 'tunnel') {
             const interval = config.obstacleInterval || 20;
             const sectionCount = Math.floor(width / interval);
-            
+
             for (let i = 0; i < sectionCount; i++) {
                 const xPos = startX + i * interval;
                 this.industrialGeometryManager.createIndustrialSection(xPos);
             }
-            
-            // Spawn minimal foliage inside tunnel bounds (constrained Y range)
+
             const tunnelHeight = config.tunnelHeight || 15;
             const yRange: [number, number] = [-tunnelHeight / 2 + 2, tunnelHeight / 2 - 2];
-            
-            this.spawnOpenFoliage(startX, width, density, yRange);
+            this.spawnOpenFoliage(startX, width, density, config, yRange);
             return;
         }
-        
+
         if (levelType === 'organic_tunnel') {
             const interval = config.obstacleInterval || 25;
             const sectionCount = Math.floor(width / interval);
-            
+
             for (let i = 0; i < sectionCount; i++) {
                 const xPos = startX + i * interval;
                 this.industrialGeometryManager.createWhaleRibSection(xPos);
             }
-            
-            // Spawn organic foliage inside whale bounds
+
             const tunnelHeight = config.tunnelHeight || 20;
             const yRange: [number, number] = [-tunnelHeight / 2 + 3, tunnelHeight / 2 - 3];
-            
-            this.spawnOpenFoliage(startX, width, density, yRange);
+            this.spawnOpenFoliage(startX, width, density, config, yRange);
             return;
         }
 
-        // Default 'open' level type - use existing random scatter logic
-        this.spawnOpenFoliage(startX, width, density);
+        this.spawnOpenFoliage(startX, width, density, config);
     }
 
-    // Helper method to spawn foliage with open scatter logic
-    spawnOpenFoliage(startX: number, width: number, density: LevelConfig['foliageDensity'], yRange: [number, number] = [-20, 20]) {
+    spawnOpenFoliage(
+        startX: number,
+        width: number,
+        density: LevelConfig['foliageDensity'],
+        levelConfig: LevelConfig,
+        yRange: [number, number] = [-20, 20]
+    ) {
         const scaledCount = (count: number) => Math.max(0, Math.floor(count * this.objectDensityMultiplier));
+        const foliageZ: [number, number] = [DEPTH_LAYERS.MIDGROUND.min, DEPTH_LAYERS.MIDGROUND.max];
+        const geoZ: [number, number] = [DEPTH_LAYERS.BACKGROUND.min + 5, DEPTH_LAYERS.MIDGROUND.max];
 
-        // Helper to spawn
-        const spawn = (count: number, creatorFn: () => THREE.Object3D, customYRange = yRange, zRange: [number, number] = [-30, 0], speciesId?: string) => {
+        const spawn = (
+            count: number,
+            creatorFn: () => THREE.Object3D,
+            customYRange = yRange,
+            zRange: [number, number] = foliageZ,
+            speciesId?: string
+        ) => {
             for (let i = 0; i < scaledCount(count); i++) {
                 const x = startX + Math.random() * width;
                 const y = customYRange[0] + Math.random() * (customYRange[1] - customYRange[0]);
-                const z = zRange[0] + Math.random() * (zRange[1] - zRange[0]);
+                const z = randomZInRange(zRange);
 
                 const obj = creatorFn();
                 obj.position.set(x, y, z);
 
-                // Random scale
                 const s = 0.8 + Math.random() * 0.5;
                 obj.scale.set(s, s, s);
 
                 if (speciesId) obj.userData.speciesId = speciesId;
 
-                scene.add(obj);
+                this.scene.add(obj);
                 this.levelObjects.push(obj);
-
-                // Add to moonPlants for animation update loop
                 moonPlants.push(obj);
             }
         };
 
-        // Spawn all types
-        if (density.fern) spawn(density.fern, () => createStarDustFern({ color: 0x8A2BE2 }), yRange, [-30, 0], 'fern');
-        if (density.rose) spawn(density.rose, () => createNebulaRose({ color: 0xFF1493 }), yRange, [-30, 0], 'rose');
-        if (density.lotus) spawn(density.lotus, () => createSubwooferLotus({ color: 0x00ff88 }), yRange, [-30, 0], 'lotus');
-        if (density.glowingFlower) spawn(density.glowingFlower, () => createGlowingFlower({ color: 0x00ffff, intensity: 2.0 }), yRange, [-30, 0], 'glowingFlower');
+        if (density.fern) spawn(density.fern, () => createStarDustFern({ color: 0x8A2BE2 }), yRange, foliageZ, 'fern');
+        if (density.rose) spawn(density.rose, () => createNebulaRose({ color: 0xFF1493 }), yRange, foliageZ, 'rose');
+        if (density.lotus) spawn(density.lotus, () => createSubwooferLotus({ color: 0x00ff88 }), yRange, foliageZ, 'lotus');
+        if (density.glowingFlower) spawn(density.glowingFlower, () => createGlowingFlower({ color: 0x00ffff, intensity: 2.0 }), yRange, foliageZ, 'glowingFlower');
 
-        // Standard foliage (trees at lower positions)
         const treeYRange: [number, number] = [Math.max(yRange[0], -20), Math.min(yRange[1], -5)];
-        if (density.tree) spawn(density.tree, () => createFloweringTree({ color: 0x44ffaa }), treeYRange, [-30, 0], 'tree');
-        if (density.floweringTree) spawn(density.floweringTree, () => createFloweringTree({ color: 0xffaa44 }), treeYRange, [-30, 0], 'floweringTree');
+        if (density.tree) spawn(density.tree, () => createFloweringTree({ color: 0x44ffaa }), treeYRange, foliageZ, 'tree');
+        if (density.floweringTree) spawn(density.floweringTree, () => createFloweringTree({ color: 0xffaa44 }), treeYRange, foliageZ, 'floweringTree');
 
-        if (density.shrub) spawn(density.shrub, () => createShrub({ color: 0x32CD32 }), yRange, [-30, 0], 'shrub');
-        if (density.vine) spawn(density.vine, () => createVine({ color: 0x228B22 }), yRange, [-30, 0], 'vine');
-        if (density.mushroom) spawn(density.mushroom, () => createPuffballFlower({ color: 0xFF4500 }), yRange, [-30, 0], 'mushroom');
+        if (density.shrub) spawn(density.shrub, () => createShrub({ color: 0x32CD32 }), yRange, foliageZ, 'shrub');
+        if (density.vine) spawn(density.vine, () => createVine({ color: 0x228B22 }), yRange, foliageZ, 'vine');
+        if (density.mushroom) spawn(density.mushroom, () => createPuffballFlower({ color: 0xFF4500 }), yRange, foliageZ, 'mushroom');
+        if (density.orb) spawn(density.orb, () => createFloatingOrb({ color: 0x88ccff }), yRange, foliageZ, 'orb');
 
-        // Floating items
-        if (density.orb) spawn(density.orb, () => createFloatingOrb({ color: 0x88ccff }), yRange, [-30, 0], 'orb');
-
-        // Add clouds manually because they need the specific class wrapper
         if (density.cloud) {
             const targetCount = Math.min(
                 scaledCount(density.cloud),
-                Math.max(0, this.GEOLOGICAL_SPAWN_CAPS.cloud - sporeClouds.length)
+                Math.max(0, this.GEOLOGICAL_SPAWN_CAPS.cloud - this.geologicalCounts.sporeClouds())
             );
-            for(let i = 0; i < targetCount; i++) {
+            for (let i = 0; i < targetCount; i++) {
                 const x = startX + Math.random() * width;
                 const y = yRange[0] + Math.random() * (yRange[1] - yRange[0]);
-                const z = -40 + Math.random() * 30;
-                createSporeCloudAtPosition(x, y, z);
+                const z = randomZInLayer('BACKGROUND');
+                this.spawners.createSporeCloudAtPosition(x, y, z);
             }
         }
 
-        // Geological objects from plan.md
         if (density.voidRootBall) {
             const targetCount = Math.min(
                 scaledCount(density.voidRootBall),
-                Math.max(0, this.GEOLOGICAL_SPAWN_CAPS.voidRootBall - voidRootBalls.length)
+                Math.max(0, this.GEOLOGICAL_SPAWN_CAPS.voidRootBall - this.geologicalCounts.voidRootBalls())
             );
-            for(let i = 0; i < targetCount; i++) {
+            for (let i = 0; i < targetCount; i++) {
                 const x = startX + Math.random() * width;
                 const y = yRange[0] + Math.random() * (yRange[1] - yRange[0]);
-                const z = -35 + Math.random() * 25;
-                createVoidRootBallAtPosition(x, y, z);
+                const z = randomZInRange(geoZ);
+                this.spawners.createVoidRootBallAtPosition(x, y, z);
             }
         }
 
         if (density.vacuumKelp) {
             const targetCount = Math.min(
                 scaledCount(density.vacuumKelp),
-                Math.max(0, this.GEOLOGICAL_SPAWN_CAPS.vacuumKelp - vacuumKelps.length)
+                Math.max(0, this.GEOLOGICAL_SPAWN_CAPS.vacuumKelp - this.geologicalCounts.vacuumKelps())
             );
-            for(let i = 0; i < targetCount; i++) {
+            for (let i = 0; i < targetCount; i++) {
                 const x = startX + Math.random() * width;
                 const y = yRange[0] + Math.random() * 15;
-                const z = -35 + Math.random() * 25;
-                createVacuumKelpAtPosition(x, y, z);
+                const z = randomZInRange(geoZ);
+                this.spawners.createVacuumKelpAtPosition(x, y, z);
             }
         }
 
         if (density.iceNeedle) {
             const targetCount = Math.min(
                 scaledCount(density.iceNeedle),
-                Math.max(0, this.GEOLOGICAL_SPAWN_CAPS.iceNeedle - iceNeedleClusters.length)
+                Math.max(0, this.GEOLOGICAL_SPAWN_CAPS.iceNeedle - this.geologicalCounts.iceNeedleClusters())
             );
-            for(let i = 0; i < targetCount; i++) {
+            for (let i = 0; i < targetCount; i++) {
                 const x = startX + Math.random() * width;
                 const y = yRange[0] + Math.random() * (yRange[1] - yRange[0]);
-                const z = -35 + Math.random() * 25;
-                createIceNeedleClusterAtPosition(x, y, z);
+                const z = randomZInRange(geoZ);
+                this.spawners.createIceNeedleClusterAtPosition(x, y, z);
             }
         }
 
-        if (config.chromaShiftDensity && config.chromaShiftDensity > 0) {
-            const count = Math.min(scaledCount(config.chromaShiftDensity), this.GEOLOGICAL_SPAWN_CAPS.chromaShift || 200);
+        if (levelConfig.chromaShiftDensity && levelConfig.chromaShiftDensity > 0) {
+            const count = Math.min(scaledCount(levelConfig.chromaShiftDensity), 200);
             for (let i = 0; i < count; i++) {
                 const x = startX + Math.random() * width;
                 const y = Math.random() * (yRange[1] - yRange[0]) + yRange[0];
-                const z = -20 + Math.random() * 40; // Bring them closer so they react to the player (distance < 20)
+                const z = randomZInLayer('NEAR');
 
                 chromaShiftSystem.addRock(new THREE.Vector3(x, y, z), 2 + Math.random() * 2);
             }
         }
+
         if (density.liquidMetal) {
             const targetCount = Math.min(scaledCount(density.liquidMetal), this.GEOLOGICAL_SPAWN_CAPS.liquidMetal);
-            for(let i = 0; i < targetCount; i++) {
+            for (let i = 0; i < targetCount; i++) {
                 const x = startX + Math.random() * width;
                 const y = yRange[0] + Math.random() * (yRange[1] - yRange[0]);
-                const z = -35 + Math.random() * 25;
-                createLiquidMetalBlobAtPosition(x, y, z);
+                const z = randomZInRange(geoZ);
+                this.spawners.createLiquidMetalBlobAtPosition(x, y, z);
             }
         }
 
         if (density.magmaHeart) {
             const targetCount = Math.min(
                 scaledCount(density.magmaHeart),
-                Math.max(0, this.GEOLOGICAL_SPAWN_CAPS.magmaHeart - magmaHearts.length)
+                Math.max(0, this.GEOLOGICAL_SPAWN_CAPS.magmaHeart - this.geologicalCounts.magmaHearts())
             );
-            for(let i = 0; i < targetCount; i++) {
+            for (let i = 0; i < targetCount; i++) {
                 const x = startX + Math.random() * width;
                 const y = yRange[0] + Math.random() * (yRange[1] - yRange[0]);
-                const z = -35 + Math.random() * 25;
-                createMagmaHeartAtPosition(x, y, z);
+                const z = randomZInRange(geoZ);
+                this.spawners.createMagmaHeartAtPosition(x, y, z);
             }
         }
 
         if (density.gravityAnchor) {
             const targetCount = Math.min(
                 scaledCount(density.gravityAnchor),
-                Math.max(0, this.GEOLOGICAL_SPAWN_CAPS.gravityAnchor - gravityAnchors.length)
+                Math.max(0, this.GEOLOGICAL_SPAWN_CAPS.gravityAnchor - this.geologicalCounts.gravityAnchors())
             );
             for (let i = 0; i < targetCount; i++) {
                 const x = startX + Math.random() * width;
                 const y = yRange[0] + Math.random() * (yRange[1] - yRange[0]);
-                const z = -35 + Math.random() * 25;
-                createGravityAnchorAtPosition(x, y, z, this.currentLevel);
+                const z = randomZInRange(geoZ);
+                this.spawners.createGravityAnchorAtPosition(x, y, z, this.currentLevel);
             }
         }
     }
 
     checkProgress(playerX: number) {
-        // Transition to the next level once the player crosses its starting boundary
         const nextBoundary = LEVEL_DISTANCE_BOUNDARIES[this.currentLevel];
         if (this.currentLevel < 6 && nextBoundary !== undefined && playerX > nextBoundary) {
             this.startLevel(this.currentLevel + 1);
         }
     }
 
-    /**
-     * Overall progress toward the Moon (0-100%), for the HUD journey map.
-     */
     getJourneyProgress(playerX: number): { percent: number; level: number } {
         const total = LEVEL_DISTANCE_BOUNDARIES[LEVEL_DISTANCE_BOUNDARIES.length - 1];
         const percent = Math.min(100, Math.max(0, (playerX / total) * 100));
         return { percent, level: this.currentLevel };
     }
 }
-
-// levelManager is now instantiated in main.ts

--- a/src/main.ts
+++ b/src/main.ts
@@ -1274,34 +1274,18 @@ const industrialGeometryManager = new IndustrialGeometryManager(scene);
 const levelManager = new LevelManager({
     weaponLightManager,
     scene,
-    camera: camera,
+    camera,
     getPlayer: () => player,
     friendsManager,
     industrialGeometryManager,
-    planetaryHorizonSystem,
     ghostDebrisSystem,
     godRaySystem,
     auroraSystem,
-    reEntrySystem,
-    industrialSystem,
-    waterfallSystem,
-    asteroidFieldSystem,
-    biologicalSystem,
-    nebulaSystem,
-    cosmicDustSystem,
     butterflySwarmSystem,
     flowerManager,
     castleManager,
     candyManager,
     debugSystem,
-    creators: {
-        createStarDustFern,
-        createNebulaRose,
-        createSubwooferLotus,
-        createGlowingFlower,
-        createFloweringTree,
-        createFloatingOrb
-    },
     spawners: {
         createSporeCloudAtPosition,
         createVoidRootBallAtPosition,
@@ -1310,6 +1294,14 @@ const levelManager = new LevelManager({
         createLiquidMetalBlobAtPosition,
         createMagmaHeartAtPosition,
         createGravityAnchorAtPosition
+    },
+    geologicalCounts: {
+        sporeClouds: () => sporeClouds.length,
+        voidRootBalls: () => voidRootBalls.length,
+        vacuumKelps: () => vacuumKelps.length,
+        iceNeedleClusters: () => iceNeedleClusters.length,
+        magmaHearts: () => magmaHearts.length,
+        gravityAnchors: () => gravityAnchors.length
     },
     onLevelStart: (cfg) => {
         playerState.autoScrollSpeed = cfg.speed;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Explored how decorative side-scroller objects (foliage, candy, castles, flowers, geological props) are created and placed, then fixed several wiring and placement bugs that kept content from appearing in the rendered scene or from spanning levels correctly.

## Changes

- **Scene wiring**: `LevelManager` now uses the `main.ts` scene, player getter, dreamy-environment managers, and geological spawners via constructor injection — no more spawning into the orphaned `scene_setup` scene.
- **Streaming foliage**: Decorative plants populate continuously ahead of the camera instead of a single 550-unit batch at level start.
- **Depth bands**: New `depth_layers.ts` with shared Z presets (`BACKGROUND`, `MIDGROUND`, `NEAR`, etc.) used for foliage and candy placement.
- **Level-span placement**: Flowers, castles, and candy use `LEVEL_DISTANCE_BOUNDARIES` (via `getLevelSpan()`) so they cover the actual chapter, not misleading `cfg.distance` values.
- **Candy belt fix**: `generateCandyBelt(startX, length, …)` places treats along the current level segment instead of absolute X from world origin.
- **Bug fix**: `chromaShiftDensity` referenced undefined `config` in `spawnOpenFoliage` — now passes full `LevelConfig`.
- **Docs**: Added `docs/SIDE_SCROLLER_OBJECTS.md` — how to add plants, creatures, and parallax layers.

## Follow-up issues created

- #141 — Consolidate duplicate environment managers
- #142 — Unify render scene (retire `scene_setup.ts` duplicate)
- #143 — Config-driven level environment activation
- #144 — Creature registry for bestiary spawn patterns
- #145 — Foliage clustering / biome vignettes
- #146 — Expand discovery scan to geology and friends

## Testing

- `node tools/check_braces.cjs` — pass
- Full `npm run build` not run (requires `asc` WASM toolchain in CI/dev env)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88963754-ec68-449c-ba55-b79b1bbd6106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88963754-ec68-449c-ba55-b79b1bbd6106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

