### PR TITLE
Fix TDZ init-order crashes on rocket load and level manager

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -88,7 +88,7 @@ import {
   initializeSceneAndRenderer,
   attachLightsAndEnv,
 } from './scene_context';
-import { player, playerLoadCallbacks } from './player_loader';
+import { player, onPlayerLoaded } from './player_loader';
 import { IndustrialGeometryManager } from './industrial_geometry';
 import { LEVEL_CONFIG, LEVEL_DISTANCE_BOUNDARIES, type LevelConfig } from './level_config';
 import { ObstacleSystem } from './obstacle_system';
@@ -268,17 +268,7 @@ loadWasm();
 // =============================================================================
 // player_loader imports the shared scene from scene_context and does scene.add(player).
 // We removed the 100+ line duplication that used to live here (and in player_loader.ts).
-// Register post-load hooks for systems that depend on the player existing.
-playerLoadCallbacks.push((loadedPlayer: THREE.Group, rocketModelOrGroup: any) => {
-    effectManager.setTarget(loadedPlayer);
-    const dogTarget = rocketModelOrGroup || loadedPlayer;
-    try {
-        dogController.initialize(dogTarget);
-    } catch {
-        dogController.initialize(loadedPlayer);
-    }
-    console.log('🚀 Rocket loaded via player_loader onto canonical scene');
-});
+// Post-load hooks registered after effectManager/dogController init (see below).
 
 // `player` (imported from player_loader) is a live binding; code below uses the name directly.
 // (local `let player` + gltfLoader + load() body deleted to eliminate duplication + dual loads)
@@ -388,7 +378,6 @@ const industrialSystem = new IndustrialBackgroundSystem(scene, weaponLightManage
 const nebulaSystem = new NebulaSystem(scene, weaponLightManager);
 const cosmicDustSystem = new CosmicDustSystem(scene);
 nebulaSystem.setCamera(camera);
-levelManager.cloudSystem.setCamera(camera);
 
 // === GHOST DEBRIS (new Cosmic Architect feature) ===
 const ghostDebrisSystem = new GhostDebrisSystem(scene);
@@ -794,6 +783,18 @@ slingableObjectSystem.onSpecialEffect = (effect) => {
 const tempTarget = new THREE.Group();
 const effectManager = new EffectManager(scene, audioSystem, tempTarget);
 
+// Register post-load hooks now that effectManager and dogController exist.
+onPlayerLoaded((loadedPlayer: THREE.Group, rocketModelOrGroup: any) => {
+    effectManager.setTarget(loadedPlayer);
+    const dogTarget = rocketModelOrGroup || loadedPlayer;
+    try {
+        dogController.initialize(dogTarget);
+    } catch {
+        dogController.initialize(loadedPlayer);
+    }
+    console.log('🚀 Rocket loaded via player_loader onto canonical scene');
+});
+
 // SWARM #4: Victory and Tutorial Systems
 const victorySystem = new VictorySystem(scene, camera, audioSystem, hudManager, juiceManager);
 const tutorialSystem = new TutorialSystem(scene, hudManager, audioSystem, dogController);
@@ -1036,6 +1037,7 @@ const levelManager = new LevelManager({
         if (levelDiv) levelDiv.innerHTML = `Level ${levelIndex}: ${name}`;
     }
 });
+levelManager.cloudSystem.setCamera(camera);
 
 function handleGameOver() {
     if (player) {

--- a/src/player_loader.ts
+++ b/src/player_loader.ts
@@ -11,6 +11,15 @@ export const gltfLoader = new GLTFLoader();
 
 export const playerLoadCallbacks: ((player: THREE.Group, rocketModel: THREE.Object3D) => void)[] = [];
 
+/** Register a callback; runs immediately if the rocket is already loaded. */
+export function onPlayerLoaded(cb: (player: THREE.Group, rocketModel: THREE.Object3D) => void): void {
+    playerLoadCallbacks.push(cb);
+    if (player) {
+        const rocketModel = (player.children[0] as THREE.Object3D | undefined) ?? player;
+        cb(player, rocketModel);
+    }
+}
+
 // Load the rocket GLB model
 gltfLoader.load(
     'rocket.glb',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Production builds were throwing `ReferenceError: Cannot access '…' before initialization` at startup:

1. **`levelManager` used before declaration** — `levelManager.cloudSystem.setCamera(camera)` ran at module init (line ~391) before `const levelManager = new LevelManager(...)` (line ~976).
2. **Player load callback ran too early** — `playerLoadCallbacks` referenced `effectManager` and `dogController` before those `const` bindings were initialized. When `rocket.glb` loaded quickly (cache), the callback hit the temporal dead zone.

## Fix

- Move `levelManager.cloudSystem.setCamera(camera)` to immediately after `LevelManager` construction.
- Register player load hooks only after `effectManager` and `dogController` are created.
- Add `onPlayerLoaded()` in `player_loader.ts` that replays the callback immediately if the rocket already finished loading before registration.

## Verification

- `npm run build` succeeds (brace check + WASM + Vite production bundle).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-394d6559-9cf3-4b29-9340-101e7d13cd85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-394d6559-9cf3-4b29-9340-101e7d13cd85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

