### PR TITLE
Fix animation-loop crashes + Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,13 @@ Useful URL flags:
 - `?collisionDebug`
 
 See `docs/RENDERER_FALLBACK.md` for the implementation details.
+
+## Cursor Cloud specific instructions
+
+Standard commands live in `README.md` / `package.json` / `CLAUDE.md` (`npm run dev` on :5173, `npm run build`, brace-check gate `node tools/check_braces.cjs`). `predev`/`prebuild` rebuild the AssemblyScript WASM automatically, so no separate WASM step is needed for normal dev. There is no lint or test suite.
+
+Non-obvious caveats for headless/cloud verification:
+
+- The cloud VM has no GPU and no WebGPU adapter, so the default WebGPU path renders nothing. Always open the app with `?renderer=webgl` to force the WebGL2 fallback.
+- Even with `?renderer=webgl`, a normally-launched headless/virtual Chrome shows a black canvas. Launch Chrome with software-GL flags so WebGL2 actually rasterizes: `--use-gl=angle --use-angle=swiftshader --enable-unsafe-swiftshader --ignore-gpu-blocklist`. Confirm via `window.usingWebGL === true`. Under SwiftShader, TSL/node-material shaders fall back to plain standard materials (per `docs/RENDERER_FALLBACK.md`), so visuals look flatter/grayer than on a real GPU — this is expected, not a regression.
+- Playwright is already a dev dependency; for screenshots/video point `executablePath` at the system Chrome (`/usr/local/bin/google-chrome`) and pass the flags above. Video capture additionally needs `npx playwright install ffmpeg` (one-off, not part of the update script).

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -51,6 +51,9 @@ export function createGeodeAtPosition(x: number, y: number, z: number) {
     return geode;
 }
 
+// Chroma-Shift Rocks - tracked for cleanup behind the camera
+export const chromaRocks: THREE.Group[] = [];
+
 // Nebula Jelly-Moss - floating gelatinous organisms with fractal moss
 export const jellyMosses: THREE.Group[] = [];
 

--- a/src/flower_constellations.ts
+++ b/src/flower_constellations.ts
@@ -179,13 +179,15 @@ class HeartPollenSystem {
     }
 
     cleanup() {
-        this.hearts.forEach(heart => {
-            heart.geometry.dispose();
-            (heart.material as THREE.Material).dispose();
-            this.scene.remove(heart);
-        });
-        this.hearts = [];
-        this.heartData = [];
+        // Soft reset: deactivate all pooled hearts but keep the reusable pool intact.
+        // The pool is created once in the constructor and is never rebuilt, so destroying
+        // it here (as a per-level reset) would leave update()/emit() iterating over an
+        // empty array up to maxHearts and dereferencing undefined entries.
+        for (let i = 0; i < this.hearts.length; i++) {
+            this.hearts[i].visible = false;
+            this.heartData[i].life = 0;
+        }
+        this.poolIndex = 0;
     }
 }
 
@@ -707,13 +709,13 @@ class GoldenSparkleSystem {
     }
 
     cleanup() {
-        this.sparkles.forEach(sparkle => {
-            sparkle.geometry.dispose();
-            (sparkle.material as THREE.Material).dispose();
-            this.scene.remove(sparkle);
-        });
-        this.sparkles = [];
-        this.sparkleData = [];
+        // Soft reset: deactivate all pooled sparkles but keep the reusable pool intact.
+        // (See HeartPollenSystem.cleanup — the pool is only built once in the constructor.)
+        for (let i = 0; i < this.sparkles.length; i++) {
+            this.sparkles[i].visible = false;
+            this.sparkleData[i].life = 0;
+        }
+        this.poolIndex = 0;
     }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,8 @@ import {
   generateEnvironment,
   // Canonical geological helpers + cleanup (single copy; adds to shared scene)
   sporeClouds,
+  jellyMosses,
+  solarSails,
   geodes,
   voidRootBalls,
   vacuumKelps,
@@ -3260,19 +3262,21 @@ function animate() {
         }
 
         // Update solar sails (iridescent rippling, unfold near player)
-        solarSails.forEach(solarSail => updateSolarSail(solarSail, delta, time, player.position));
+        if (player) {
+            solarSails.forEach(solarSail => updateSolarSail(solarSail, delta, time, player.position));
 
-        // Update new geological objects from plan.md
-        voidRootBalls.forEach(rootBall => {
-            const interaction = updateVoidRootBall(rootBall, delta, time, player);
-            if (interaction.isLatched) {
-                playerState.velocity.add(interaction.force);
-                // Visual feedback
-                if (interaction.hitPoint && Math.random() < 0.2) {
-                    particleSystem.emit(interaction.hitPoint, 0x8800ff, 2, 2.0, 0.5);
+            // Update new geological objects from plan.md
+            voidRootBalls.forEach(rootBall => {
+                const interaction = updateVoidRootBall(rootBall, delta, time, player);
+                if (interaction.isLatched) {
+                    playerState.velocity.add(interaction.force);
+                    // Visual feedback
+                    if (interaction.hitPoint && Math.random() < 0.2) {
+                        particleSystem.emit(interaction.hitPoint, 0x8800ff, 2, 2.0, 0.5);
+                    }
                 }
-            }
-        });
+            });
+        }
         vacuumKelps.forEach(kelp => updateVacuumKelp(kelp, delta, time));
         iceNeedleClusters.forEach(cluster => updateIceNeedleCluster(cluster, delta, time));
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the runtime errors that were freezing the game's animation loop (reported via the WebGPU console: `chromaRocks is not defined`, `jellyMosses is not defined`, …), and sets up / documents the Cursor Cloud dev environment.

### Bug fixes (renderer-agnostic — affect both WebGPU and WebGL2)

1. **`chromaRocks is not defined`** (`src/environment.ts`) — `cleanupGeologicalObjects()` iterated over `chromaRocks`, which was never declared. Added the missing exported array (matching its sibling geological pools).
2. **`jellyMosses` / `solarSails` not defined** (`src/main.ts`) — both were used in the animate loop but never imported from `./environment`. Added the imports.
3. **Null `player` deref** (`src/main.ts`) — solar-sail and void-root-ball updates read `player.position` before the rocket GLB finishes loading (`Cannot read properties of null (reading 'position')`). Guarded those updates with `if (player)`, matching the existing pattern used elsewhere.
4. **Pollen/sparkle pools destroyed on level reset** (`src/flower_constellations.ts`) — `ConstellationManager.cleanup()` (called on every level start) emptied the `HeartPollenSystem`/`GoldenSparkleSystem` object pools, but `update()` still iterated up to `maxHearts`/`maxSparkles`, dereferencing `undefined` (`Cannot read properties of undefined (reading 'visible')`). These pools are built once in the constructor and never rebuilt, so `cleanup()` now soft-resets (hide + reset life) instead of emptying them.

Each was independently freezing the `setAnimationLoop` callback before the scene could render.

### Environment setup

- Update script: `npm install` (the `predev`/`prebuild` hooks rebuild the AssemblyScript WASM automatically).
- `AGENTS.md` → added `## Cursor Cloud specific instructions` with the non-obvious headless-rendering caveats (force `?renderer=webgl`; launch Chrome with SwiftShader flags or the canvas stays black; SwiftShader flattens TSL shaders; Playwright + ffmpeg for capture).

## Evidence

Before — animation loop crashes on the first frame (`chromaRocks is not defined`); canvas stays black, distance frozen at 5000m:

![Before fix - black canvas](https://cursor.com/artifacts/c/art-bd80a3a1-1f17-472d-8929-47d86247ef30)

After — loop completes a full frame of gameplay logic and the 3D scene renders (Level 1, asteroids, crystal shards, planet horizon):

![After fix - 3D scene rendered](https://cursor.com/artifacts/c/art-ee0eae73-42f2-4eba-8cbb-19c3be267bcd)

Before/after console-error summary:

[before_after_errors.txt](https://cursor.com/artifacts/c/art-b4bbb570-9002-4f18-b8b4-e30177920156)

## Verification notes

Captured via the WebGL2 fallback under SwiftShader (the cloud VM has no GPU and `navigator.gpu` is unavailable headlessly, so the user's WebGPU path can't be exercised here). After the fixes, the only remaining console error in the WebGL path is a Three.js shader-include error (`reading 'replace'`) thrown inside the final `renderGameFrame()` draw — i.e. **after** all gameplay update logic ran for the frame. It is internal to three's `WebGLProgram`/`resolveIncludes`, exists only on the WebGL2 debug-fallback, and does not occur on the WebGPU renderer the user runs. It is unrelated to these fixes and left out of scope.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37c2e2b3-2660-4787-812b-88a8c5f85f7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37c2e2b3-2660-4787-812b-88a8c5f85f7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential crashes by adding null safety checks in animation logic
  * Optimized particle system cleanup for improved performance and stability

* **Documentation**
  * Added development environment configuration and testing documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->