### PR TITLE
Enhance Volumetric Lightning Shader with Organic Crackle Noise

### DIFF
--- a/src/lightning_bolt.ts
+++ b/src/lightning_bolt.ts
@@ -83,6 +83,7 @@ function createLightningMaterial(uColor: any, weaponLights?: any, uPlayerPos?: a
     const flashPulse = sin(uTime.mul(40.0)).mul(0.5).add(0.5);
     // Afterglow baseline
     const glowIntensity = flashPulse.mul(0.8).add(0.2);
+    const crackleNoise = sin(y.mul(80.0).add(uTime.mul(60.0))).mul(0.15).add(0.85);
 
     // Thin inner core vs thick outer glow
     const coreColor = color(0xffffff);
@@ -113,7 +114,7 @@ function createLightningMaterial(uColor: any, weaponLights?: any, uPlayerPos?: a
         colorMix = colorMix.add(vec3(0.0, 1.0, 1.0).mul(weaponGlow));
     }
 
-    const alpha = viewDot.pow(2.0).mul(glowIntensity);
+    const alpha = viewDot.pow(2.0).mul(glowIntensity).mul(crackleNoise);
 
 
     mat.colorNode = vec4(colorMix, alpha);


### PR DESCRIPTION
## 🌌 Architect: Volumetric Lightning Enhancement

### Concept
> "A significant enhancement of an existing visual system's shaders or mechanics (e.g., volumetric lightning) rather than creating an entirely new file." (Reference: `future-plan.md` Audit Fallback)

### Implementation
- **Enhanced Volumetric Lightning:** Added a procedural `crackleNoise` variable to the `alpha` channel within the `createLightningMaterial` TSL shader located in `src/lightning_bolt.ts`.
- **How it works:** Uses `sin(y.mul(80.0).add(uTime.mul(60.0))).mul(0.15).add(0.85)` to introduce dynamic, high-frequency brightness flickering that mimics real lightning plasma crackle, modifying the existing `glowIntensity` calculation.
- **Which levels are affected:** Any level utilizing the Lightning environment plugin (e.g. Level 2: The Stormy Seas and Level 5: The Astral Leviathan).

### Visuals
- Shader effects: Volumetric bolts now have a rapid, organic flicker pattern along their length (`y` axis) and over time (`uTime`), preventing the plasma tube from looking static and flat while still preserving the soft volumetric gradient falloff (`normalView.z.abs()`).
- Dynamic lighting: (Pre-existing) continues to dynamically illuminate based on player engine proximity and projectile flashes.

### Integration
- `src/lightning_bolt.ts`: Edited `createLightningMaterial` directly, merging changes cleanly without disrupting the existing instantiation architecture.
- `level_config.ts`: No new fields required.

### Testing
- [x] `npm run build` passes
- [x] Tested via `npm run dev` and visually verified with Playwright in `verify_lightning.py`
- [x] WebGL volumetric blending behavior is stable with the modified `alpha` calculations

---
*PR created automatically by Jules for task [13407698795612771121](https://jules.google.com/task/13407698795612771121) started by @ford442*