### PR TITLE
🌌 Architect: Nebula Activation Fix

### DIFF
--- a/src/level_manager.ts
+++ b/src/level_manager.ts
@@ -203,6 +203,10 @@ export class LevelManager {
         }
     }
 
+    setMagicActive(active: boolean) {
+        nebulaSystem.setMagicActive(active);
+    }
+
     startLevel(levelIndex: number) {
         this.currentLevel = levelIndex;
         const cfg = this.config[levelIndex];

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,7 @@ import { WaterfallSystem } from './waterfall';
 import { AsteroidFieldSystem } from './asteroid_field';
 import { PlanetaryHorizonSystem } from './planetary_horizon';
 import { IndustrialBackgroundSystem } from './industrial_background';
-import { NebulaSystem } from './nebula';
+
 import { CosmicDustSystem } from './cosmic_dust';
 import { BiologicalBackgroundSystem } from './biological_background';
 import { AtmosphereSystem } from './sky';
@@ -378,9 +378,9 @@ const planetaryHorizonSystem = new PlanetaryHorizonSystem(scene, camera);
 // INDUSTRIAL BACKGROUND SYSTEM (Megastructures)
 
 // NEBULA SYSTEM (Volumetric Clouds & Particles)
-const nebulaSystem = new NebulaSystem(scene, weaponLightManager);
+
 const cosmicDustSystem = new CosmicDustSystem(scene);
-nebulaSystem.setCamera(camera);
+
 
 // === GHOST DEBRIS (new Cosmic Architect feature) ===
 const ghostDebrisSystem = new GhostDebrisSystem(scene);
@@ -2750,7 +2750,7 @@ function animate() {
         // Pass magic state to Nebula
         const isMagicActive = effectManager.hasEffect(MagicalEffectType.RAINBOW_TRAIL) ||
                               effectManager.hasEffect(MagicalEffectType.HEART_BUBBLE);
-        nebulaSystem.setMagicActive(isMagicActive);
+        levelManager.setMagicActive(isMagicActive);
 
         // SWARM #4: Update victory and tutorial systems
         victorySystem.update(delta);


### PR DESCRIPTION
## 🌌 Architect: Nebula Activation Fix

### Concept
> "The entire level is set inside a glowing purple and pink nebula... Multiple transparent cloud layers drift in different directions... The nebula pulses with a slow, rhythmic brightness change." 

### Implementation
- Fixed a duplicate instance of `NebulaSystem` created locally inside `main.ts` which blocked it from correctly displaying in level 5, causing visual bugs and a circular import issue.
- Re-routed `isMagicActive` state directly through `LevelManager` and down to `nebulaSystem`, eliminating duplicate state manipulation from `main.ts`.
- Verified Level 5 configuration and `startLevel` hook properly calls `nebulaSystem.activate()` via the environment system configuration.

### Visuals
- No changes to visuals; standard 3 cloud layers at different Z offsets with dynamic lighting are correctly enabled now in Level 5.

### Integration
- `main.ts`: Removed duplicate instantiation of `NebulaSystem`.
- `level_manager.ts`: Added `setMagicActive` method to pass `isMagicActive` state downward.

### Testing
- [x] `npm run build` passes
- [x] Tested logic and instantiation fixes

---
*PR created automatically by Jules for task [1040008754622517704](https://jules.google.com/task/1040008754622517704) started by @ford442*