### PR TITLE
🌌 Architect: Waterfall Enhancements & WebGL Fallback Cleanups

### DIFF
--- a/src/render_debug_helpers.ts
+++ b/src/render_debug_helpers.ts
@@ -143,7 +143,8 @@ function createWebGLCompatibleMaterial(source: THREE.Material): THREE.Material {
             opacity: source.opacity,
             side: source.side,
             blending: source.blending,
-            depthWrite: source.depthWrite
+            depthWrite: source.depthWrite,
+            clippingPlanes: null
         });
         copyCommonMaterialProps(source, material);
         return material;
@@ -162,7 +163,8 @@ function createWebGLCompatibleMaterial(source: THREE.Material): THREE.Material {
         opacity: source.opacity,
         side: source.side,
         blending: source.blending,
-        depthWrite: source.depthWrite
+        depthWrite: source.depthWrite,
+        clippingPlanes: null
     });
     copyCommonMaterialProps(source, material);
     return material;

--- a/src/waterfall.ts
+++ b/src/waterfall.ts
@@ -99,7 +99,9 @@ function createWaterMaterial(baseColorHex: number, opacity: number, speed: numbe
         const distToPlayer = distance(positionWorld, uPlayerPos);
         const glowIntensity = smoothstep(50.0, 0.0, distToPlayer);
         const playerGlowColor = color(0x00ffff);
-        mat.colorNode = mat.colorNode.add(playerGlowColor.mul(glowIntensity.mul(0.5)));
+        const pulse = sin(uTime.mul(10.0)).mul(0.5).add(0.5);
+        const subsurfaceGlow = playerGlowColor.mul(glowIntensity).mul(pulse.mul(0.4).add(0.8));
+        mat.colorNode = mat.colorNode.add(subsurfaceGlow);
     }
 
     // 2. Weapon Light Interaction


### PR DESCRIPTION
This pull request cleans up the previous messy branch state, reverting all temporary python debugging scripts, generated playwright artifacts, and hacky WebGL debug rendering overrides.

It cleanly reinstates the fix for the WebGL TSL `Device Lost` fallback crash by correctly appending `clippingPlanes: null` onto the mocked ThreeJS standard materials inside `src/render_debug_helpers.ts`. The previously completed Mode 7 waterfall curvature and pulsing subsurface lighting additions to `src/waterfall.ts` are left intact.

---
*PR created automatically by Jules for task [2949064219640004756](https://jules.google.com/task/2949064219640004756) started by @ford442*