### PR TITLE
🌌 Architect: Waterfall Progressive Submersion

### DIFF
--- a/src/level_manager.ts
+++ b/src/level_manager.ts
@@ -325,7 +325,10 @@ export class LevelManager {
             },
             {
                 flag: 'waterfall',
-                activate: () => waterfallSystem.activate(),
+                activate: () => {
+                    waterfallSystem.levelDistance = levelLength;
+                    waterfallSystem.activate();
+                },
                 deactivate: () => waterfallSystem.deactivate()
             },
             {

--- a/src/waterfall.ts
+++ b/src/waterfall.ts
@@ -559,6 +559,7 @@ export class WaterfallSystem {
     splash!: SplashSystem;
     submersion!: SubmersionOverlay;
     active: boolean = false;
+    levelDistance: number = 2000;
 
     constructor(scene: THREE.Scene, camera: THREE.Camera, weaponLightManager?: WeaponLightManager) {
         this.weaponLightManager = weaponLightManager;
@@ -632,9 +633,6 @@ export class WaterfallSystem {
         this.layers.forEach(l => l.mesh.visible = true);
         this.bubbles.mesh.visible = true;
         this.splash.mesh.visible = true;
-
-        // Fade in submersion
-        this.submersion.setIntensity(1.0);
     }
 
     deactivate() {
@@ -655,6 +653,9 @@ export class WaterfallSystem {
         this.splash.update(delta, playerPos);
 
         if (!this.active) return;
+
+        const progress = Math.max(0, Math.min(1, cameraX / this.levelDistance));
+        this.submersion.setIntensity(progress);
 
         this.layers.forEach(l => l.update(cameraX));
         this.bubbles.update(delta, cameraX);


### PR DESCRIPTION
Implemented progressive submersion for the `WaterfallSystem` according to the future-plan specification for Level 6.

Instead of the submersion overlay being a binary on/off state when the level loads, it now builds up gradually as the player progresses through the level (based on `cameraX`), matching the approach used in `reentry.ts`.

---
*PR created automatically by Jules for task [13831379923442622971](https://jules.google.com/task/13831379923442622971) started by @ford442*