### PR TITLE
Implement Star-Eater Pitcher L6 capstone boss

### DIFF
--- a/src/audio_system/sound_configs.ts
+++ b/src/audio_system/sound_configs.ts
@@ -41,6 +41,22 @@ export const SOUND_CONFIGS: Record<SoundType, SoundConfig> = {
             volume: 0.5,
             slide: -40
         },
+        boss_phase: {
+            type: 'boss_phase',
+            frequency: 120,
+            duration: 0.9,
+            waveform: 'sawtooth',
+            volume: 0.45,
+            slide: 220
+        },
+        boss_suction: {
+            type: 'boss_suction',
+            frequency: 55,
+            duration: 1.2,
+            waveform: 'sine',
+            volume: 0.35,
+            slide: -30
+        },
         engine: {
             type: 'engine',
             frequency: 60,

--- a/src/audio_system/types.ts
+++ b/src/audio_system/types.ts
@@ -6,6 +6,8 @@ export type SoundType =
     | 'hit' 
     | 'powerup' 
     | 'boss_roar' 
+    | 'boss_phase'
+    | 'boss_suction'
     | 'engine' 
     | 'alert' 
     | 'ui_click'

--- a/src/boss_system.ts
+++ b/src/boss_system.ts
@@ -1,7 +1,17 @@
 import * as THREE from 'three';
-import { ParticleSystem } from './particles';
+import { decorationBudget } from './decoration_budget';
 
 export type BossPhase = 'entering' | 'phase1' | 'phase2' | 'phase3' | 'defeated';
+
+export const BOSS_DISPLAY_NAME = 'STAR-EATER PITCHER';
+
+const PHASE_NAMES: Record<BossPhase, string> = {
+    entering: 'APPROACH',
+    phase1: 'SUCTION',
+    phase2: 'ENRAGED',
+    phase3: 'DESPERATION',
+    defeated: 'DEFEATED'
+};
 
 export interface BossConfig {
     spawnX: number;
@@ -9,40 +19,130 @@ export interface BossConfig {
     health: number;
 }
 
+export interface BossHitboxEntry {
+    x: number;
+    y: number;
+    radius: number;
+    /** 'boss' = uvula weak point; number = minion index */
+    target: 'boss' | number;
+    dealsDamage: boolean;
+}
+
+/** Smaller orbiting pitcher minion — destroying one shaves 10% off the main boss. */
+class PitcherMinion {
+    group: THREE.Group;
+    orbitAngle: number;
+    orbitRadius: number;
+    orbitSpeed: number;
+    health = 30;
+    alive = true;
+
+    constructor(parent: THREE.Group, index: number, total: number) {
+        this.orbitAngle = (index / total) * Math.PI * 2;
+        this.orbitRadius = 28 + Math.random() * 12;
+        this.orbitSpeed = 0.25 + Math.random() * 0.15;
+
+        this.group = new THREE.Group();
+        const body = new THREE.Mesh(
+            new THREE.CapsuleGeometry(1.8, 3, 6, 8),
+            new THREE.MeshStandardMaterial({
+                color: 0x2a1040,
+                emissive: 0x660044,
+                emissiveIntensity: 0.5,
+                roughness: 0.85
+            })
+        );
+        body.rotation.z = Math.PI / 2;
+        this.group.add(body);
+
+        const mouth = new THREE.Mesh(
+            new THREE.ConeGeometry(1.2, 2, 12, 1, true),
+            new THREE.MeshStandardMaterial({
+                color: 0x110011,
+                emissive: 0xff0044,
+                emissiveIntensity: 0.8,
+                side: THREE.DoubleSide
+            })
+        );
+        mouth.rotation.z = -Math.PI / 2;
+        mouth.position.x = 1.5;
+        this.group.add(mouth);
+
+        parent.add(this.group);
+        decorationBudget.reportSpawn('star_eater_minions');
+    }
+
+    update(delta: number, center: THREE.Vector3, time: number): void {
+        if (!this.alive) return;
+        this.orbitAngle += delta * this.orbitSpeed;
+        this.group.position.set(
+            center.x + Math.cos(this.orbitAngle) * this.orbitRadius,
+            center.y + Math.sin(this.orbitAngle) * this.orbitRadius * 0.55,
+            center.z + Math.sin(time * 0.7 + this.orbitAngle) * 4
+        );
+        this.group.lookAt(center);
+    }
+
+    takeDamage(amount: number): boolean {
+        if (!this.alive) return false;
+        this.health -= amount;
+        if (this.health <= 0) {
+            this.alive = false;
+            this.group.visible = false;
+            decorationBudget.reportDestroy('star_eater_minions');
+            return true;
+        }
+        return false;
+    }
+
+    getHitbox(): { x: number; y: number; radius: number } {
+        return {
+            x: this.group.position.x,
+            y: this.group.position.y,
+            radius: 2.5
+        };
+    }
+
+    destroy(): void {
+        if (this.alive) {
+            decorationBudget.reportDestroy('star_eater_minions');
+            this.alive = false;
+        }
+    }
+}
+
 export class StarEaterBoss {
     scene: THREE.Scene;
     group: THREE.Group;
     config: BossConfig;
-    
-    // State
+
     phase: BossPhase = 'entering';
     health: number;
     maxHealth: number;
-    isActive: boolean = false;
-    time: number = 0;
-    
-    // Visual components
-    mouth: THREE.Mesh;
-    jaw: THREE.Mesh;
-    uvula: THREE.Mesh;
+    isActive = false;
+    time = 0;
+
+    mouth!: THREE.Mesh;
+    jaw!: THREE.Mesh;
+    uvula!: THREE.Mesh;
     teeth: THREE.Mesh[] = [];
-    accretionDisk: THREE.Points;
-    glowLight: THREE.PointLight;
-    
-    // Attack timers
-    debrisTimer: number = 0;
-    mouthOpenTimer: number = 0;
-    weakPointExposed: boolean = false;
-    weakPointTimer: number = 0;
-    
-    // Pull force
-    pullStrength: number = 0;
-    
-    // Callbacks
+    accretionDisk!: THREE.Points;
+    glowLight!: THREE.PointLight;
+
+    minions: PitcherMinion[] = [];
+    rageTimer = 0;
+    private lastPhase: BossPhase = 'entering';
+
+    debrisTimer = 0;
+    weakPointExposed = false;
+
+    pullStrength = 0;
+
     onDefeated: () => void;
     onPlayerHit: () => void;
+    onPhaseChange?: (phase: BossPhase) => void;
     getPlayerPosition: () => THREE.Vector3 | null;
-    spawnDebris: (pos: THREE.Vector3) => void;
+    spawnDebris: (pos: THREE.Vector3, homing?: boolean) => void;
 
     constructor(
         scene: THREE.Scene,
@@ -50,8 +150,9 @@ export class StarEaterBoss {
         callbacks: {
             onDefeated: () => void;
             onPlayerHit: () => void;
+            onPhaseChange?: (phase: BossPhase) => void;
             getPlayerPosition: () => THREE.Vector3 | null;
-            spawnDebris: (pos: THREE.Vector3) => void;
+            spawnDebris: (pos: THREE.Vector3, homing?: boolean) => void;
         }
     ) {
         this.scene = scene;
@@ -59,18 +160,18 @@ export class StarEaterBoss {
         this.health = config.health;
         this.maxHealth = config.health;
         this.onDefeated = callbacks.onDefeated;
-        onPlayerHit: callbacks.onPlayerHit;
+        this.onPlayerHit = callbacks.onPlayerHit;
+        this.onPhaseChange = callbacks.onPhaseChange;
         this.getPlayerPosition = callbacks.getPlayerPosition;
         this.spawnDebris = callbacks.spawnDebris;
-        
+
         this.group = new THREE.Group();
         this.createVisuals();
         this.group.visible = false;
         scene.add(this.group);
     }
 
-    private createVisuals() {
-        // Main body - dark organic mass
+    private createVisuals(): void {
         const bodyGeo = new THREE.CapsuleGeometry(6, 12, 8, 16);
         const bodyMat = new THREE.MeshStandardMaterial({
             color: 0x1a0a2e,
@@ -83,7 +184,6 @@ export class StarEaterBoss {
         body.rotation.z = Math.PI / 2;
         this.group.add(body);
 
-        // Mouth opening - the dangerous part
         const mouthGeo = new THREE.ConeGeometry(5, 8, 32, 1, true);
         const mouthMat = new THREE.MeshStandardMaterial({
             color: 0x000000,
@@ -97,7 +197,6 @@ export class StarEaterBoss {
         this.mouth.position.x = 8;
         this.group.add(this.mouth);
 
-        // Lower jaw (animated)
         const jawGeo = new THREE.ConeGeometry(4.5, 6, 32, 1, true);
         const jawMat = new THREE.MeshStandardMaterial({
             color: 0x1a0a2e,
@@ -110,7 +209,6 @@ export class StarEaterBoss {
         this.jaw.position.y = -2;
         this.group.add(this.jaw);
 
-        // Uvula (weak point) - exposed when mouth opens
         const uvulaGeo = new THREE.SphereGeometry(1.5, 16, 16);
         const uvulaMat = new THREE.MeshStandardMaterial({
             color: 0xff0044,
@@ -123,7 +221,6 @@ export class StarEaterBoss {
         this.uvula.visible = false;
         this.group.add(this.uvula);
 
-        // Teeth - reflective crystalline
         for (let i = 0; i < 8; i++) {
             const toothGeo = new THREE.ConeGeometry(0.4, 1.5, 8);
             const toothMat = new THREE.MeshStandardMaterial({
@@ -134,7 +231,7 @@ export class StarEaterBoss {
                 emissiveIntensity: 0.3
             });
             const tooth = new THREE.Mesh(toothGeo, toothMat);
-            
+
             const angle = (i / 8) * Math.PI;
             const radius = 4;
             tooth.position.set(
@@ -143,35 +240,33 @@ export class StarEaterBoss {
                 0
             );
             tooth.rotation.z = angle - Math.PI / 2;
-            
+
             this.teeth.push(tooth);
             this.group.add(tooth);
         }
 
-        // Accretion disk particles
         const diskGeo = new THREE.BufferGeometry();
         const particleCount = 2000;
         const positions = new Float32Array(particleCount * 3);
         const colors = new Float32Array(particleCount * 3);
-        
+
         for (let i = 0; i < particleCount; i++) {
             const angle = Math.random() * Math.PI * 2;
             const radius = 8 + Math.random() * 12;
             const height = (Math.random() - 0.5) * 2;
-            
+
             positions[i * 3] = Math.cos(angle) * radius;
             positions[i * 3 + 1] = height;
             positions[i * 3 + 2] = Math.sin(angle) * radius;
-            
-            // Purple/pink colors
+
             colors[i * 3] = 0.8 + Math.random() * 0.2;
             colors[i * 3 + 1] = 0.2 + Math.random() * 0.3;
             colors[i * 3 + 2] = 0.6 + Math.random() * 0.4;
         }
-        
+
         diskGeo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
         diskGeo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
-        
+
         const diskMat = new THREE.PointsMaterial({
             size: 0.15,
             vertexColors: true,
@@ -179,192 +274,203 @@ export class StarEaterBoss {
             transparent: true,
             opacity: 0.8
         });
-        
+
         this.accretionDisk = new THREE.Points(diskGeo, diskMat);
         this.group.add(this.accretionDisk);
 
-        // Glow light
         this.glowLight = new THREE.PointLight(0xff0044, 3, 50);
         this.glowLight.position.set(8, 0, 0);
         this.group.add(this.glowLight);
     }
 
-    activate(startX: number) {
+    activate(startX: number): void {
+        if (!decorationBudget.canSpawn('star_eater_boss')) {
+            console.warn('Star-Eater Pitcher blocked by decoration budget');
+            return;
+        }
+        decorationBudget.reportSpawn('star_eater_boss');
+
         this.isActive = true;
         this.group.visible = true;
         this.group.position.set(startX + 50, 0, -20);
         this.phase = 'entering';
+        this.lastPhase = 'entering';
         this.health = this.maxHealth;
         this.time = 0;
+        this.rageTimer = 0;
+        this.debrisTimer = 0;
+
+        const minionCount = 2 + Math.floor(Math.random() * 3);
+        this.minions = [];
+        for (let i = 0; i < minionCount; i++) {
+            this.minions.push(new PitcherMinion(this.group, i, minionCount));
+        }
+
         console.log('👹 Star-Eater Pitcher ACTIVATED!');
     }
 
     update(delta: number): { pullForce: number; isSnapping: boolean } {
         if (!this.isActive) return { pullForce: 0, isSnapping: false };
-        
-        this.time += delta;
-        const result = { pullForce: 0, isSnapping: false };
 
-        // Accretion disk rotation
+        this.time += delta;
+        if (this.rageTimer > 0) this.rageTimer -= delta;
+
+        const result = { pullForce: 0, isSnapping: false };
+        const rageMult = this.rageTimer > 0 ? 1.25 : 1;
+
         this.accretionDisk.rotation.y += delta * 0.2;
         this.accretionDisk.rotation.x = Math.sin(this.time * 0.5) * 0.1;
 
-        // Teeth rotation (disco effect)
         this.teeth.forEach((tooth, i) => {
             tooth.rotation.z += delta * (0.5 + i * 0.1);
         });
+
+        const center = this.group.position;
+        for (const minion of this.minions) {
+            minion.update(delta, center, this.time);
+        }
 
         switch (this.phase) {
             case 'entering':
                 this.updateEntering(delta);
                 break;
             case 'phase1':
-                result.pullForce = this.updatePhase1(delta);
+                result.pullForce = this.updatePhase1(delta) * rageMult;
                 break;
             case 'phase2':
-                result.pullForce = this.updatePhase2(delta);
+                result.pullForce = this.updatePhase2(delta) * rageMult;
                 result.isSnapping = this.checkMouthSnap();
                 break;
             case 'phase3':
-                result.pullForce = this.updatePhase3(delta);
+                result.pullForce = this.updatePhase3(delta) * rageMult;
                 break;
             case 'defeated':
                 this.updateDefeated(delta);
                 break;
         }
 
-        // Update glow intensity based on phase
+        this.maybeFirePhaseStinger();
+
         const pulse = Math.sin(this.time * 3) * 0.3 + 0.7;
-        this.glowLight.intensity = 2 + pulse * 2;
-        
+        this.glowLight.intensity = (2 + pulse * 2) * (this.rageTimer > 0 ? 1.4 : 1);
+
         return result;
     }
 
-    private updateEntering(delta: number) {
-        // Move boss into position
+    private maybeFirePhaseStinger(): void {
+        if (this.phase !== this.lastPhase && this.phase !== 'entering' && this.phase !== 'defeated') {
+            this.onPhaseChange?.(this.phase);
+            this.lastPhase = this.phase;
+        }
+    }
+
+    private updateEntering(delta: number): void {
         const targetX = this.config.spawnX + 30;
         this.group.position.x += (targetX - this.group.position.x) * delta;
-        
-        // Fade in
-        const dist = Math.abs(targetX - this.group.position.x);
-        if (dist < 1) {
-            this.phase = 'phase1';
+
+        if (Math.abs(targetX - this.group.position.x) < 1) {
+            this.setPhase('phase1');
             console.log('👹 Boss entering Phase 1 - SUCTION');
         }
     }
 
-    private updatePhase1(delta: number): number {
-        // Phase 1: Moderate pull, debris every 4s, uvula exposed 2s every 8s
-        
-        // Pull force ramps from 5 to 8 over 10s
+    private setPhase(next: BossPhase): void {
+        this.phase = next;
+        this.time = 0;
+        this.debrisTimer = 0;
+    }
+
+    private updatePhase1(_delta: number): number {
+        // Pull 5→8 m/s²; uvula exposed ~2s every 8s; debris every 4s
         this.pullStrength = THREE.MathUtils.lerp(5, 8, Math.min(1, this.time / 10));
-        
-        // Mouth opens and closes
-        const mouthOpen = Math.sin(this.time * 0.8) * 0.5 + 0.5;
+
+        const cycle = this.time % 8;
+        const mouthOpen = cycle < 2 ? 0.85 : 0.25 + Math.sin(this.time * 0.8) * 0.15;
         this.mouth.scale.y = 0.3 + mouthOpen * 0.7;
         this.jaw.rotation.z = -Math.PI / 2 - mouthOpen * 0.5;
-        
-        // Uvula exposed when mouth open
-        this.weakPointExposed = mouthOpen > 0.7;
+
+        this.weakPointExposed = cycle < 2;
         this.uvula.visible = this.weakPointExposed;
-        
-        // Spawn debris
-        this.debrisTimer += delta;
+        (this.mouth.material as THREE.MeshStandardMaterial).emissiveIntensity =
+            this.weakPointExposed ? 1.2 : 0.5;
+
+        this.debrisTimer += _delta;
         if (this.debrisTimer > 4) {
             this.debrisTimer = 0;
             this.spawnMouthDebris();
         }
-        
-        // Check phase transition
+
         if (this.health / this.maxHealth <= 0.7) {
-            this.phase = 'phase2';
-            this.time = 0;
+            this.setPhase('phase2');
             console.log('👹 Boss entering Phase 2 - ENRAGED!');
         }
-        
+
         return this.pullStrength;
     }
 
-    private updatePhase2(delta: number): number {
-        // Phase 2: Stronger pull (12), faster debris (6s), mouth snaps
-        
+    private updatePhase2(_delta: number): number {
         this.pullStrength = 12;
-        
-        // Faster mouth movement
-        const mouthOpen = Math.sin(this.time * 1.2) * 0.5 + 0.5;
+
+        const cycle = this.time % 6;
+        const mouthOpen = cycle < 1 ? 0.9 : 0.2 + Math.sin(this.time * 1.2) * 0.2;
         this.mouth.scale.y = 0.2 + mouthOpen * 0.8;
         this.jaw.rotation.z = -Math.PI / 2 - mouthOpen * 0.7;
-        
-        // Uvula exposed briefly
-        this.weakPointExposed = mouthOpen > 0.8;
+
+        this.weakPointExposed = cycle < 1;
         this.uvula.visible = this.weakPointExposed;
-        
-        // Faster debris (3-shot burst)
-        this.debrisTimer += delta;
+
+        this.debrisTimer += _delta;
         if (this.debrisTimer > 6) {
             this.debrisTimer = 0;
-            // Burst of 3
             for (let i = 0; i < 3; i++) {
                 setTimeout(() => this.spawnMouthDebris(), i * 300);
             }
         }
-        
-        // Check phase transition
+
         if (this.health / this.maxHealth <= 0.3) {
-            this.phase = 'phase3';
-            this.time = 0;
+            this.setPhase('phase3');
             console.log('👹 Boss entering Phase 3 - DESPERATION!');
         }
-        
+
         return this.pullStrength;
     }
 
     private checkMouthSnap(): boolean {
-        // Mouth snaps every 5s in phase 2
         const snapCycle = this.time % 5;
-        return snapCycle < 0.5; // Snapping closed for 0.5s
+        return snapCycle < 0.5;
     }
 
-    private updatePhase3(delta: number): number {
-        // Phase 3: Weaker pull (3) but adds tangential swirl, continuous debris
-        
+    private updatePhase3(_delta: number): number {
         const swirl = Math.sin(this.time * 2) * 5;
         this.pullStrength = 3;
-        
-        // Mouth stays mostly open, pulsing
+
         const pulse = Math.sin(this.time * 4) * 0.3 + 0.7;
         this.mouth.scale.y = 0.6 + pulse * 0.4;
         this.jaw.rotation.z = -Math.PI / 2 - pulse * 0.5;
-        
-        // Uvula always exposed but surrounded by rotating shield
+
         this.weakPointExposed = true;
         this.uvula.visible = true;
-        
-        // Rotate teeth to form shield gaps
+
         this.teeth.forEach((tooth, i) => {
             const angle = (this.time * 2 + i * Math.PI / 4) % (Math.PI * 2);
             tooth.position.x = 6 + Math.cos(angle) * 3;
             tooth.position.y = Math.sin(angle) * 3;
         });
-        
-        // Continuous debris stream
-        this.debrisTimer += delta;
+
+        this.debrisTimer += _delta;
         if (this.debrisTimer > 2) {
             this.debrisTimer = 0;
             this.spawnMouthDebris();
-            // + Homing plasma (simplified as fast debris)
             this.spawnMouthDebris(true);
         }
-        
+
         return this.pullStrength + swirl * 0.5;
     }
 
-    private updateDefeated(delta: number) {
-        // Death animation
+    private updateDefeated(_delta: number): void {
         this.group.scale.multiplyScalar(0.95);
-        this.group.rotation.z += delta * 2;
-        
-        // Flash and fade
+        this.group.rotation.z += _delta * 2;
+
         const flash = Math.sin(this.time * 20) > 0;
         this.group.traverse((child) => {
             if (child instanceof THREE.Mesh && child.material) {
@@ -372,29 +478,56 @@ export class StarEaterBoss {
                 mat.emissiveIntensity = flash ? 5 : 0;
             }
         });
-        
+
         if (this.group.scale.x < 0.01) {
             this.destroy();
         }
     }
 
-    private spawnMouthDebris(homing: boolean = false) {
+    private spawnMouthDebris(homing = false): void {
         const mouthPos = new THREE.Vector3(
             this.group.position.x + 8,
             this.group.position.y + (Math.random() - 0.5) * 4,
             (Math.random() - 0.5) * 4
         );
-        this.spawnDebris(mouthPos);
+        this.spawnDebris(mouthPos, homing);
     }
 
-    takeDamage(amount: number): boolean {
+    /** Apply damage to uvula weak point or a minion hitbox index. Returns true if damage landed. */
+    takeDamage(amount: number, target: 'boss' | number = 'boss'): boolean {
         if (!this.isActive || this.phase === 'defeated') return false;
-        if (!this.weakPointExposed) return false; // Invulnerable when mouth closed
-        
+
+        if (typeof target === 'number') {
+            const minion = this.minions[target];
+            if (!minion?.alive) return false;
+            if (minion.takeDamage(amount)) {
+                this.health = Math.max(0, this.health - this.maxHealth * 0.1);
+                this.rageTimer = 15;
+                this.flashGroup();
+                if (this.health <= 0) {
+                    this.health = 0;
+                    this.setPhase('defeated');
+                    this.onDefeated();
+                }
+            }
+            return true;
+        }
+
+        if (!this.weakPointExposed) return false;
+
         this.health -= amount;
-        console.log(`👹 Boss health: ${this.health}/${this.maxHealth}`);
-        
-        // Flash white
+        this.flashGroup();
+
+        if (this.health <= 0) {
+            this.health = 0;
+            this.setPhase('defeated');
+            this.onDefeated();
+        }
+
+        return true;
+    }
+
+    private flashGroup(): void {
         this.group.traverse((child) => {
             if (child instanceof THREE.Mesh && child.material) {
                 const mat = child.material as THREE.MeshStandardMaterial;
@@ -407,15 +540,33 @@ export class StarEaterBoss {
                 }, 100);
             }
         });
-        
-        if (this.health <= 0) {
-            this.health = 0;
-            this.phase = 'defeated';
-            this.time = 0;
-            this.onDefeated();
+    }
+
+    /** All WASM-ready hitboxes: uvula (when exposed), body shield, and living minions. */
+    collectWasmHitboxes(): BossHitboxEntry[] {
+        const boxes: BossHitboxEntry[] = [];
+        const mouthX = this.group.position.x + 8;
+        const mouthY = this.group.position.y;
+
+        if (this.weakPointExposed) {
+            boxes.push({ x: mouthX, y: mouthY, radius: 2, target: 'boss', dealsDamage: true });
+        } else {
+            boxes.push({ x: mouthX, y: mouthY, radius: 6, target: 'boss', dealsDamage: false });
         }
-        
-        return true;
+
+        for (let i = 0; i < this.minions.length; i++) {
+            const minion = this.minions[i];
+            if (minion.alive) {
+                const hb = minion.getHitbox();
+                boxes.push({ ...hb, target: i, dealsDamage: true });
+            }
+        }
+
+        return boxes;
+    }
+
+    resolveHitboxEntry(hitboxIndex: number): BossHitboxEntry | null {
+        return this.collectWasmHitboxes()[hitboxIndex] ?? null;
     }
 
     getHitbox(): { center: THREE.Vector3; radius: number } {
@@ -429,11 +580,29 @@ export class StarEaterBoss {
         };
     }
 
-    destroy() {
+    getHealthRatio(): number {
+        return this.maxHealth > 0 ? this.health / this.maxHealth : 0;
+    }
+
+    getPhase(): BossPhase {
+        return this.phase;
+    }
+
+    getPhaseName(): string {
+        return PHASE_NAMES[this.phase] ?? this.phase.toUpperCase();
+    }
+
+    isRaging(): boolean {
+        return this.rageTimer > 0;
+    }
+
+    destroy(): void {
         this.isActive = false;
+        for (const minion of this.minions) minion.destroy();
+        this.minions = [];
+        decorationBudget.reportDestroy('star_eater_boss');
         this.scene.remove(this.group);
-        
-        // Cleanup geometries/materials
+
         this.group.traverse((child) => {
             if (child instanceof THREE.Mesh) {
                 child.geometry.dispose();
@@ -442,16 +611,18 @@ export class StarEaterBoss {
                 } else {
                     child.material.dispose();
                 }
+            } else if (child instanceof THREE.Points) {
+                child.geometry.dispose();
+                (child.material as THREE.Material).dispose();
             }
         });
     }
 }
 
-// Boss Manager to handle spawning and integration
 export class BossManager {
     private scene: THREE.Scene;
     private currentBoss: StarEaterBoss | null = null;
-    private bossSpawned: boolean = false;
+    private bossSpawned = false;
 
     constructor(scene: THREE.Scene) {
         this.scene = scene;
@@ -460,39 +631,42 @@ export class BossManager {
     checkBossSpawn(
         playerX: number,
         level: number,
+        levelDistance: number | undefined,
         callbacks: {
             onDefeated: () => void;
             onPlayerHit: () => void;
+            onPhaseChange?: (phase: BossPhase) => void;
             getPlayerPosition: () => THREE.Vector3 | null;
-            spawnDebris: (pos: THREE.Vector3) => void;
+            spawnDebris: (pos: THREE.Vector3, homing?: boolean) => void;
             onBossStart: () => void;
         }
     ): boolean {
-        // Level 1 boss at x=3000
-        if (level === 1 && !this.bossSpawned && playerX >= 3000) {
-            this.bossSpawned = true;
-            
-            this.currentBoss = new StarEaterBoss(
-                this.scene,
-                {
-                    spawnX: playerX,
-                    arenaWidth: 60,
-                    health: 100
-                },
-                callbacks
-            );
-            
-            this.currentBoss.activate(playerX);
-            callbacks.onBossStart();
-            return true;
-        }
-        
-        return false;
+        // Level 6 capstone: Star-Eater Pitcher near the end of the aqua expanse
+        const isLevel6Capstone = level === 6 && !this.bossSpawned && levelDistance
+            && playerX > levelDistance - 750;
+
+        if (!isLevel6Capstone) return false;
+
+        this.bossSpawned = true;
+
+        this.currentBoss = new StarEaterBoss(
+            this.scene,
+            {
+                spawnX: playerX,
+                arenaWidth: 60,
+                health: 300
+            },
+            callbacks
+        );
+
+        this.currentBoss.activate(playerX);
+        callbacks.onBossStart();
+        return true;
     }
 
-    update(delta: number): { 
-        bossActive: boolean; 
-        pullForce: number; 
+    update(delta: number): {
+        bossActive: boolean;
+        pullForce: number;
         isSnapping: boolean;
         boss?: StarEaterBoss;
     } {
@@ -501,7 +675,7 @@ export class BossManager {
         }
 
         const result = this.currentBoss.update(delta);
-        
+
         return {
             bossActive: this.currentBoss.isActive,
             pullForce: result.pullForce,
@@ -510,7 +684,7 @@ export class BossManager {
         };
     }
 
-    reset() {
+    reset(): void {
         if (this.currentBoss) {
             this.currentBoss.destroy();
             this.currentBoss = null;

--- a/src/decoration_budget.ts
+++ b/src/decoration_budget.ts
@@ -284,4 +284,14 @@ export function registerDefaultDecorationBudgets(): void {
         category: 'background3d',
         maxActive: 24
     });
+    decorationBudget.register('star_eater_boss', {
+        label: 'Star-Eater Pitcher (boss)',
+        category: 'creatures',
+        maxActive: 1
+    });
+    decorationBudget.register('star_eater_minions', {
+        label: 'Star-Eater minion orbiters',
+        category: 'creatures',
+        maxActive: 4
+    });
 }

--- a/src/main/boss_health_ui.ts
+++ b/src/main/boss_health_ui.ts
@@ -1,54 +1,94 @@
 import type { NebulaKraken } from '../space_robot_squid';
-import { BOSS_DISPLAY_NAME } from '../space_robot_squid';
+import { BOSS_DISPLAY_NAME as KRAKEN_NAME } from '../space_robot_squid';
+import type { StarEaterBoss } from '../boss_system';
+import { BOSS_DISPLAY_NAME as PITCHER_NAME } from '../boss_system';
 
 // BOSS HEALTH BAR UI
 // =============================================================================
 let bossHealthBar: HTMLDivElement | null = null;
 let bossHealthFill: HTMLDivElement | null = null;
 let bossHealthLabel: HTMLDivElement | null = null;
+let activeBossKind: 'kraken' | 'pitcher' | null = null;
 
-export function updateBossHealthBar(squids: NebulaKraken[]): void {
+function ensureBossHealthBar(borderColor: string, gradient: string): void {
+    if (bossHealthBar) return;
+
+    bossHealthBar = document.createElement('div');
+    bossHealthBar.id = 'boss-health-bar';
+    bossHealthBar.style.cssText = `
+        position: fixed; top: 20px; left: 50%; transform: translateX(-50%);
+        width: 320px; height: 18px; background: #111; border: 2px solid ${borderColor};
+        border-radius: 9px; overflow: hidden; z-index: 100;
+        box-shadow: 0 0 15px ${borderColor}55, inset 0 0 6px #000;
+    `;
+
+    bossHealthFill = document.createElement('div');
+    bossHealthFill.style.cssText = `
+        width: 100%; height: 100%; background: ${gradient};
+        transition: width 0.3s ease; border-radius: 7px;
+    `;
+    bossHealthBar.appendChild(bossHealthFill);
+
+    bossHealthLabel = document.createElement('div');
+    bossHealthLabel.style.cssText = `
+        position: fixed; top: 4px; left: 50%; transform: translateX(-50%);
+        color: #cc88ff; font-family: monospace; font-size: 11px;
+        text-transform: uppercase; letter-spacing: 2px; z-index: 101;
+        text-shadow: 0 0 8px ${borderColor};
+    `;
+    document.body.appendChild(bossHealthLabel);
+    document.body.appendChild(bossHealthBar);
+}
+
+function hideBossHealthBar(): void {
+    if (bossHealthBar) bossHealthBar.style.display = 'none';
+    if (bossHealthLabel) bossHealthLabel.style.display = 'none';
+    activeBossKind = null;
+}
+
+export function updateBossHealthBar(squids: NebulaKraken[], pitcher?: StarEaterBoss | null): void {
     const activeSquid = squids.find(s => !s.isDestroyed);
+    const activePitcher = pitcher?.isActive && pitcher.phase !== 'defeated' ? pitcher : null;
 
-    if (!activeSquid) {
-        // No active boss: hide the bar
-        if (bossHealthBar) {
-            bossHealthBar.style.display = 'none';
+    if (activePitcher) {
+        if (activeBossKind !== 'pitcher') {
+            bossHealthBar = null;
+            bossHealthFill = null;
+            bossHealthLabel = null;
+            activeBossKind = 'pitcher';
+        }
+        ensureBossHealthBar('#ff0044', 'linear-gradient(90deg, #660022, #ff0044, #ff66aa)');
+
+        bossHealthBar!.style.display = 'block';
+        if (bossHealthLabel) bossHealthLabel.style.display = 'block';
+
+        const ratio = activePitcher.getHealthRatio();
+        if (bossHealthFill) {
+            bossHealthFill.style.width = `${Math.max(0, ratio * 100)}%`;
+        }
+
+        const rageTag = activePitcher.isRaging() ? ' [RAGE]' : '';
+        if (bossHealthLabel) {
+            bossHealthLabel.textContent =
+                `⚠ ${PITCHER_NAME} — ${activePitcher.getPhaseName()}${rageTag} ⚠`;
         }
         return;
     }
 
-    // Create UI elements if they don't exist yet
-    if (!bossHealthBar) {
-        bossHealthBar = document.createElement('div');
-        bossHealthBar.id = 'boss-health-bar';
-        bossHealthBar.style.cssText = `
-            position: fixed; top: 20px; left: 50%; transform: translateX(-50%);
-            width: 320px; height: 18px; background: #111; border: 2px solid #9900ff;
-            border-radius: 9px; overflow: hidden; z-index: 100;
-            box-shadow: 0 0 15px #9900ff55, inset 0 0 6px #000;
-        `;
-
-        bossHealthFill = document.createElement('div');
-        bossHealthFill.style.cssText = `
-            width: 100%; height: 100%; background: linear-gradient(90deg, #8A2BE2, #ff00ff, #9400D3);
-            transition: width 0.3s ease; border-radius: 7px;
-        `;
-        bossHealthBar.appendChild(bossHealthFill);
-
-        bossHealthLabel = document.createElement('div');
-        bossHealthLabel.style.cssText = `
-            position: fixed; top: 4px; left: 50%; transform: translateX(-50%);
-            color: #cc88ff; font-family: monospace; font-size: 11px;
-            text-transform: uppercase; letter-spacing: 2px; z-index: 101;
-            text-shadow: 0 0 8px #9900ff;
-        `;
-        bossHealthLabel.textContent = `⚠ ${BOSS_DISPLAY_NAME} ⚠`;
-        document.body.appendChild(bossHealthLabel);
-        document.body.appendChild(bossHealthBar);
+    if (!activeSquid) {
+        hideBossHealthBar();
+        return;
     }
 
-    bossHealthBar.style.display = 'block';
+    if (activeBossKind !== 'kraken') {
+        bossHealthBar = null;
+        bossHealthFill = null;
+        bossHealthLabel = null;
+        activeBossKind = 'kraken';
+    }
+    ensureBossHealthBar('#9900ff', 'linear-gradient(90deg, #8A2BE2, #ff00ff, #9400D3)');
+
+    bossHealthBar!.style.display = 'block';
     if (bossHealthLabel) bossHealthLabel.style.display = 'block';
 
     const ratio = activeSquid.getHealthRatio();
@@ -56,11 +96,11 @@ export function updateBossHealthBar(squids: NebulaKraken[]): void {
         bossHealthFill.style.width = `${Math.max(0, ratio * 100)}%`;
     }
 
-    // Change label per phase
     if (bossHealthLabel) {
         const phase = activeSquid.getPhase();
         const personality = activeSquid.getPersonality();
         const phaseNames = ['', 'VOID SWEEP', 'INK PROTOCOL', 'FRENZY'];
-        bossHealthLabel.textContent = `⚠ ${BOSS_DISPLAY_NAME} — ${phaseNames[phase]} [${personality.toUpperCase()}] ⚠`;
+        bossHealthLabel.textContent =
+            `⚠ ${KRAKEN_NAME} — ${phaseNames[phase]} [${personality.toUpperCase()}] ⚠`;
     }
 }

--- a/src/main/loop_combat.ts
+++ b/src/main/loop_combat.ts
@@ -22,6 +22,8 @@ import { FlotillaMember } from '../space_friends';
 import { getCandySlingComboBonus, CANDY_FLAVOR_COLORS, updateCandyMaterialGlobals } from '../candy_materials';
 import type { CandyAsteroidVariant, CandyFlavor } from '../candy_materials';
 import { updateBossHealthBar } from './boss_health_ui';
+import { writeBossHitboxesToWasm } from '../physics_utils';
+import type { WasmHandle } from '../wasm_loader';
 export function updateLoopCombat(_rawDelta: number, delta: number, time: number): boolean {
         // --- BOSS SYSTEM ---
         if (player) {
@@ -30,6 +32,7 @@ export function updateLoopCombat(_rawDelta: number, delta: number, time: number)
                 const bossSpawned = game.bossManager.checkBossSpawn(
                     player.position.x,
                     playerState.level,
+                    game.levelManager.config[game.levelManager.currentLevel]?.distance,
                     {
                         onDefeated: () => {
                             // Boss defeated - give rewards and continue
@@ -43,17 +46,47 @@ export function updateLoopCombat(_rawDelta: number, delta: number, time: number)
                             game.saveManager.recordBossDefeated();
                             game.audioSystem.play('boss_defeat');
                             playerState.bossActive = false;
-                            
+
                             // Resume auto-scroll
                             playerState.autoScrollSpeed = game.saveManager.applyToSpeed(8);
-    
-                            // 'boss' objective (L6): defeating the boss completes the chapter
+
+                            // 'boss' objective (L6): defeating the Star-Eater completes the chapter
                             const objective = game.levelManager.config[game.levelManager.currentLevel]?.objective;
                             if (objective?.type === 'boss') {
                                 game.hudManager.updateObjectiveProgress(objective.target, objective.target);
+                                game.hudManager.onObjectiveComplete?.();
+
+                                if (game.levelManager.currentLevel === 6 && !game.level6BossDefeated) {
+                                    game.level6BossDefeated = true;
+                                    game.particleSystem.emit(
+                                        player!.position.clone(), 0xeeffff, 25, 5.0, 1.2, 1.4
+                                    );
+                                    game.particleSystem.emit(
+                                        player!.position.clone(), 0xff0044, 20, 4.0, 1.4, 1.6
+                                    );
+                                    game.waterfallSystem.triggerSplash(player!.position.clone(), 35);
+                                    game.audioSystem.playWhaleSong();
+
+                                    game.juiceManager.showFloatingText(
+                                        'The Path to the Moon Opens!',
+                                        player!.position.clone(),
+                                        '#aaffff',
+                                        30
+                                    );
+                                    game.juiceManager.burstMagic(player!.position.clone());
+                                    game.dogController.triggerAnimation(DogAnimationState.VICTORY, 2.0);
+
+                                    const bossPos = game.bossManager.getBoss()?.group.position
+                                        ?? player!.position.clone();
+                                    game.planetaryHorizonSystem.activateMoonGate(
+                                        new THREE.Vector3(bossPos.x + 120, 0, -30)
+                                    );
+                                    game.friendsManager.triggerVictoryFlyby(4.0);
+                                    game.moonGateSequenceActive = true;
+                                    game.moonGateSequenceTimer = 0;
+                                }
                             }
-    
-                            // Show victory message briefly
+
                             console.log('🎉 BOSS DEFEATED! +50 Cores');
                         },
                         onPlayerHit: () => {
@@ -73,10 +106,20 @@ export function updateLoopCombat(_rawDelta: number, delta: number, time: number)
                             }
                         },
                         getPlayerPosition: () => player ? player.position : null,
-                        spawnDebris: (pos) => {
-                            // Spawn debris from boss mouth
-                            game.obstacleSystem.createAsteroid(pos.x, pos.y, pos.z, 1.0, 
-                                new THREE.Vector3(-5 - Math.random() * 5, (Math.random() - 0.5) * 5, 0));
+                        spawnDebris: (pos, homing) => {
+                            const speed = homing ? 12 : 8;
+                            game.obstacleSystem.createAsteroid(
+                                pos.x, pos.y, pos.z, homing ? 0.8 : 1.0,
+                                new THREE.Vector3(-speed - Math.random() * 5, (Math.random() - 0.5) * 5, 0)
+                            );
+                        },
+                        onPhaseChange: (phase) => {
+                            if (phase === 'phase1') {
+                                game.audioSystem.play('boss_suction');
+                            } else {
+                                game.audioSystem.play('boss_phase');
+                            }
+                            game.juiceManager.shakeScreen(ShakeType.HEAVY);
                         },
                         onBossStart: () => {
                             playerState.bossActive = true;
@@ -124,22 +167,56 @@ export function updateLoopCombat(_rawDelta: number, delta: number, time: number)
                         }
                     }
                     
-                    // Check projectile hits on boss
+                    // Check projectile hits on boss (WASM hitboxes)
                     const projectiles = game.weaponSystem.getActiveProjectiles();
-                    for (const proj of projectiles) {
-                        if (!proj.active) continue;
-                        const hitbox = boss.getHitbox();
-                        const dist = proj.mesh.position.distanceTo(hitbox.center);
-                        if (dist < hitbox.radius) {
-                            if (boss.takeDamage(10)) {
-                                // Hit registered
+                    const hitboxes = boss.collectWasmHitboxes();
+                    if (hitboxes.length > 0 && game.wasmExports) {
+                        const wasmHandle = {
+                            exports: game.wasmExports,
+                            memory: game.wasmMemory
+                        } as WasmHandle;
+                        const count = writeBossHitboxesToWasm(wasmHandle, hitboxes);
+                        if (game.wasmMemory?.buffer !== (game.wasmExports as { memory: WebAssembly.Memory }).memory.buffer) {
+                            game.wasmMemory = new Float32Array(
+                                (game.wasmExports as { memory: WebAssembly.Memory }).memory.buffer
+                            );
+                        }
+
+                        for (const proj of projectiles) {
+                            if (!proj.active) continue;
+                            const hitIndex = (game.wasmExports as {
+                                checkBossCollision: (x: number, y: number, r: number, n: number) => number;
+                            }).checkBossCollision(
+                                proj.mesh.position.x,
+                                proj.mesh.position.y,
+                                0.5,
+                                count
+                            );
+                            if (hitIndex === -1) continue;
+
+                            const entry = boss.resolveHitboxEntry(hitIndex);
+                            if (!entry?.dealsDamage) {
+                                proj.deactivate();
+                                continue;
+                            }
+
+                            const damage = entry.target === 'boss' ? 10 : 15;
+                            if (boss.takeDamage(damage, entry.target)) {
                                 game.audioSystem.play('hit');
+                                game.particleSystem.emit(
+                                    proj.mesh.position.clone(),
+                                    entry.target === 'boss' ? 0xff0044 : 0xff66aa,
+                                    12, 4.0, 0.8, 1.2
+                                );
                                 proj.deactivate();
                             }
                         }
                     }
                 }
             }
+
+            // Boss health bar (Star-Eater Pitcher or Kraken)
+            updateBossHealthBar(game.obstacleSystem.getSquids(), game.bossManager.getBoss());
             
             // --- PICKUP SYSTEM ---
             const collected = game.pickupManager.update(delta, time, player.position);
@@ -535,43 +612,17 @@ export function updateLoopCombat(_rawDelta: number, delta: number, time: number)
                                 }
                             }
     
-                            // Aquatic capstone: an ink + bubble burst marks the
-                            // wounded Kraken's defeat - the L6 "boss" objective.
+                            // Kraken defeated — bonus rewards only (L6 capstone is Star-Eater Pitcher)
                             if (squid.isDestroyed) {
                                 game.particleSystem.emit(squid.getPosition().clone(), 0xeeffff, 25, 5.0, 1.2, 1.4);
                                 game.particleSystem.emit(squid.getPosition().clone(), 0x440088, 20, 4.0, 1.4, 1.6);
                                 game.waterfallSystem.triggerSplash(squid.getPosition().clone(), 35);
                                 game.audioSystem.playWhaleSong();
-    
-                                const objective6 = game.levelManager.config[game.levelManager.currentLevel]?.objective;
-                                if (game.levelManager.currentLevel === 6 && objective6?.type === 'boss' && !game.level6BossDefeated) {
-                                    game.level6BossDefeated = true;
-                                    game.saveManager.addCores(50);
-                                    game.hudManager.updateObjectiveProgress(objective6.target, objective6.target);
-                                    game.hudManager.onObjectiveComplete?.();
-    
-                                    if (player) {
-                                        game.juiceManager.showFloatingText('The Path to the Moon Opens!', player.position.clone(), '#aaffff', 30);
-                                        game.juiceManager.burstMagic(player.position.clone());
-                                    }
-                                    game.dogController.triggerAnimation(DogAnimationState.VICTORY, 2.0);
-    
-                                    // Open the Moon Gate ahead and begin the celebratory pull-back
-                                    game.planetaryHorizonSystem.activateMoonGate(
-                                        new THREE.Vector3(squid.getPosition().x + 120, 0, -30)
-                                    );
-                                    game.friendsManager.triggerVictoryFlyby(4.0);
-                                    game.moonGateSequenceActive = true;
-                                    game.moonGateSequenceTimer = 0;
-                                }
                             }
                             break;
                         }
                     }
                 }
-    
-                // Update boss health bar UI
-                updateBossHealthBar(squids);
     
                 // Tarsiers panic when a projectile passes near a gravity anchor
                 if (game.debugSystem.isEnabled('spaceFriends') && gravityAnchors.length > 0) {

--- a/src/obstacle_system/manager.ts
+++ b/src/obstacle_system/manager.ts
@@ -178,9 +178,8 @@ export class ObstacleSystem implements ObstacleSystemHost {
 
         const squidRate = currentCfg?.squidSpawnRate || 0;
         const currentLevel = this.options.getCurrentLevel();
-        const isLevel6Capstone = currentLevel === 6 && !this.level6KrakenSpawned
-            && this.squids.length === 0 && currentCfg?.distance
-            && playerX > currentCfg.distance - 750;
+        // L6 capstone is the Star-Eater Pitcher (boss_system); Kraken still spawns randomly elsewhere.
+        const isLevel6Capstone = false;
 
         if (isLevel6Capstone || (squidRate > 0 && this.squids.length === 0 && Math.random() < squidRate)) {
             const spawnX = playerX + 55;

--- a/src/physics_utils.ts
+++ b/src/physics_utils.ts
@@ -39,3 +39,27 @@ export function writeObjectsToWasm(wasm: WasmHandle, objects: { position: { x: n
     
     return count;
 }
+
+/** Writes boss hitbox circles into the WASM allocBossHitboxes buffer. */
+export function writeBossHitboxesToWasm(
+    wasm: WasmHandle,
+    hitboxes: { x: number; y: number; radius: number }[]
+): number {
+    if (!wasm.exports.allocBossHitboxes || hitboxes.length === 0) return 0;
+
+    const ptr = wasm.exports.allocBossHitboxes(hitboxes.length);
+
+    if (!wasm.memory || wasm.memory.buffer !== wasm.exports.memory.buffer) {
+        wasm.memory = new Float32Array(wasm.exports.memory.buffer);
+    }
+
+    const startIdx = ptr >>> 2;
+    for (let i = 0; i < hitboxes.length; i++) {
+        const offset = startIdx + i * 3;
+        wasm.memory[offset] = hitboxes[i].x;
+        wasm.memory[offset + 1] = hitboxes[i].y;
+        wasm.memory[offset + 2] = hitboxes[i].radius;
+    }
+
+    return hitboxes.length;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the **Star-Eater Pitcher** as the Level 6 capstone boss described in `docs/plans/plan.md`, replacing the Nebula Kraken as the objective-completion encounter.

### Boss encounter (`src/boss_system.ts`)
- **3 playable phases**: Suction (70–100% HP), Enraged (30–70%), Desperation (0–30%)
- **Uvula weak points** with telegraphed mouth glow; phase 3 adds rotating teeth shield gaps
- **2–4 orbiting minion pitchers** — destroying one shaves 10% boss HP and triggers a 15s rage buff (+25% stats)
- **Accretion disk** particle VFX (2000 points, WebGL2-safe `PointsMaterial`)
- **Mouth snap** instant-death check in phase 2
- Spawns near end of L6 (`distance - 750`)

### Integration
- **WASM hitboxes** via `writeBossHitboxesToWasm()` + `checkBossCollision` for projectile hits (uvula, body shield, minions)
- **Decoration budget** entries: `star_eater_boss` (max 1), `star_eater_minions` (max 4)
- **Audio stingers**: `boss_suction` on phase 1 entry, `boss_phase` on phase transitions
- **Boss health bar** shows pitcher name, phase, and rage state
- **L6 victory**: defeating the pitcher completes the `boss` objective, opens the Moon Gate, and triggers the victory flyby sequence
- Nebula Kraken still spawns randomly but no longer completes the L6 objective

### Testing
- `npm run build` — pass
- `npm run test:smoke` — pass (WebGL2/SwiftShader path)
- Boss uses `MeshStandardMaterial` throughout for WebGL2 fallback compatibility

## Acceptance criteria
- [x] Boss spawns on L6
- [x] 3 phases playable
- [x] Completes `boss` objective
- [x] WebGL2 fallback works (standard materials, no TSL-only nodes on boss meshes)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24811246-6567-45e4-8410-02462de6ddf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24811246-6567-45e4-8410-02462de6ddf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

