### PR TITLE
Add Grav-Lenses slingshot puzzle system (levels 2–3)

### DIFF
--- a/src/discovery_system.ts
+++ b/src/discovery_system.ts
@@ -20,6 +20,7 @@ export const SPECIES_NAMES: Record<string, string> = {
     magmaHeart: 'Magma Heart',
     iceNeedleCluster: 'Ice Needle Cluster',
     gravityAnchor: 'Gravity Anchor',
+    gravLens: 'Grav-Lens',
     sporeCloud: 'Spore Cloud',
     vacuumKelp: 'Vacuum Kelp',
     liquidMetalBlob: 'Liquid Metal Blob',

--- a/src/game_config.ts
+++ b/src/game_config.ts
@@ -49,7 +49,9 @@ export const playerState = {
     vineTetherActive: false,
     vineBleedTimer: 0,
     vineBleedDps: 0,
-    penguinSlideAssistTimer: 0
+    penguinSlideAssistTimer: 0,
+    gravLensBoostTimer: 0,
+    gravLensBoostMultiplier: 1
 };
 
 export let isGamePaused = false;

--- a/src/game_systems.ts
+++ b/src/game_systems.ts
@@ -34,6 +34,7 @@ import type { MeteorShowerSystem } from './meteor_shower';
 import type { IndustrialBackgroundSystem } from './industrial_background';
 import type { CosmicDustSystem } from './cosmic_dust';
 import type { BlackHoleSystem } from './black_hole';
+import { GravLensManager } from './grav_lens';
 import type { BiologicalBackgroundSystem } from './biological_background';
 import type { LiquidMetalSystem } from './geological';
 import type { BossManager } from './boss_system';
@@ -281,6 +282,7 @@ export let stormGeodeSystem: StormGeodeSystem = createStormGeodeSystemStub();
 export const crystalChimeManager = new CrystalChimeManager(scene, particleSystem, audioSystem);
 
 export let blackHoleSystem: BlackHoleSystem = createBlackHoleSystemStub();
+export const gravLensManager = new GravLensManager(scene);
 
 export type LevelEnvironmentSystemExports = {
     reEntrySystem: ReEntrySystem;

--- a/src/grav_lens.ts
+++ b/src/grav_lens.ts
@@ -1,0 +1,493 @@
+/**
+ * Grav-Lenses — gravitational slingshot puzzle nodes (plan §III).
+ *
+ * Inverse-square pull, stable ~15 m orbit ring, graded slingshot exits,
+ * crush zone on failed approaches, Cryo detune, and shatter → micro black hole.
+ * Force logic is CPU-side (WebGL2-safe).
+ */
+
+import * as THREE from 'three';
+import type { SlingQuality } from './sling_combo';
+
+// --- Tunables (plan-aligned) ---
+const CORE_RADIUS = 0.5;
+const ORBIT_RADIUS = 15;
+const ORBIT_TARGET_SPEED = 12;
+const INFLUENCE_RADIUS = 28;
+const CRUSH_RADIUS = 5;
+const FORCE_MASS = 50;
+const FORCE_SOFTENING = 2.5;
+const MAX_PULL_PER_SEC = 45;
+const CRUSH_DPS = 20;
+const SHATTER_DAMAGE_THRESHOLD = 150;
+const SHATTER_DAMAGE_WINDOW = 3;
+const DETUNE_DURATION = 10;
+const PERFECT_ANGLE_DEG = 75;
+const PARTIAL_ANGLE_DEG = 45;
+const PERFECT_BOOST_MULT = 3;
+const PARTIAL_BOOST_MULT = 1.5;
+const BOOST_DURATION_PERFECT = 8;
+const BOOST_DURATION_PARTIAL = 5;
+const CHAIN_TIMEOUT = 6;
+const MICRO_BH_DURATION = 3;
+const MICRO_BH_PULL_RADIUS = 2;
+
+export type SlingshotGrade = 'perfect' | 'partial' | 'failed' | 'none';
+
+export interface GravLensPlacement {
+    offsetX: number;
+    y: number;
+    z?: number;
+    mass?: number;
+}
+
+export interface GravLensCorridorConfig {
+    startX: number;
+    lenses: GravLensPlacement[];
+}
+
+export interface GravLensUpdateResult {
+    forceX: number;
+    forceY: number;
+    inCrushZone: boolean;
+    slingshotExits: {
+        grade: SlingshotGrade;
+        position: THREE.Vector3;
+        chain: number;
+        boostMult: number;
+        boostDuration: number;
+    }[];
+    failedExits: THREE.Vector3[];
+}
+
+export interface GravLensUpdateCallbacks {
+    onGrade?: (grade: SlingshotGrade, position: THREE.Vector3, chain: number) => void;
+    onCrushDamage?: (amount: number, position: THREE.Vector3) => void;
+    onDetune?: (position: THREE.Vector3) => void;
+    onShatter?: (position: THREE.Vector3) => void;
+    onApproachAngle?: (angleDeg: number, inRange: boolean) => void;
+}
+
+export interface GravLensPlayerState {
+    position: THREE.Vector3;
+    velocityX: number;
+    velocityY: number;
+    autoScrollSpeed: number;
+    currentSpeedY: number;
+    invincible?: boolean;
+    inSafeHarbor?: boolean;
+}
+
+interface DamageWindow {
+    total: number;
+    timer: number;
+}
+
+interface MicroBlackHole {
+    group: THREE.Group;
+    timer: number;
+    position: THREE.Vector3;
+}
+
+interface GravLensInstance {
+    group: THREE.Group;
+    mass: number;
+    detuneTimer: number;
+    wasInField: boolean;
+    peakEntryAngle: number;
+    crushAccum: number;
+    damageWindow: DamageWindow;
+    microBh: MicroBlackHole | null;
+    chainEligible: boolean;
+}
+
+function createLensMesh(): THREE.Group {
+    const group = new THREE.Group();
+
+    const coreGeo = new THREE.SphereGeometry(CORE_RADIUS, 16, 16);
+    const coreMat = new THREE.MeshBasicMaterial({ color: 0x110022 });
+    group.add(new THREE.Mesh(coreGeo, coreMat));
+
+    const haloGeo = new THREE.SphereGeometry(CORE_RADIUS * 2.2, 12, 12);
+    const haloMat = new THREE.MeshBasicMaterial({
+        color: 0xaa66ff,
+        transparent: true,
+        opacity: 0.35,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false
+    });
+    group.add(new THREE.Mesh(haloGeo, haloMat));
+
+    const orbitGeo = new THREE.RingGeometry(ORBIT_RADIUS - 0.15, ORBIT_RADIUS + 0.15, 48);
+    const orbitMat = new THREE.MeshBasicMaterial({
+        color: 0x44ccff,
+        transparent: true,
+        opacity: 0.55,
+        side: THREE.DoubleSide,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false
+    });
+    const orbitRing = new THREE.Mesh(orbitGeo, orbitMat);
+    orbitRing.rotation.x = Math.PI * 0.5;
+    group.add(orbitRing);
+
+    const crushGeo = new THREE.RingGeometry(CRUSH_RADIUS - 0.1, CRUSH_RADIUS + 0.1, 32);
+    const crushMat = new THREE.MeshBasicMaterial({
+        color: 0xff2244,
+        transparent: true,
+        opacity: 0.25,
+        side: THREE.DoubleSide,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false
+    });
+    const crushRing = new THREE.Mesh(crushGeo, crushMat);
+    crushRing.rotation.x = Math.PI * 0.5;
+    crushRing.userData.isCrushRing = true;
+    group.add(crushRing);
+
+    group.userData.type = 'gravLens';
+    group.userData.speciesId = 'gravLens';
+    return group;
+}
+
+function computeEntryAngleDeg(
+    playerPos: THREE.Vector3,
+    lensPos: THREE.Vector3,
+    velX: number,
+    velY: number
+): number {
+    const speed = Math.hypot(velX, velY);
+    if (speed < 0.4) return 0;
+
+    const dx = lensPos.x - playerPos.x;
+    const dy = lensPos.y - playerPos.y;
+    const radialLen = Math.hypot(dx, dy);
+    if (radialLen < 0.01) return 0;
+
+    const dot = Math.abs((velX / speed) * (dx / radialLen) + (velY / speed) * (dy / radialLen));
+    return Math.acos(THREE.MathUtils.clamp(dot, 0, 1)) * (180 / Math.PI);
+}
+
+function gradeFromAngle(angleDeg: number): SlingshotGrade {
+    if (angleDeg >= PERFECT_ANGLE_DEG) return 'perfect';
+    if (angleDeg >= PARTIAL_ANGLE_DEG) return 'partial';
+    return 'failed';
+}
+
+function slingQualityFromGrade(grade: SlingshotGrade): SlingQuality {
+    if (grade === 'perfect') return 'perfect';
+    if (grade === 'partial') return 'good';
+    return 'messy';
+}
+
+export class GravLensManager {
+    private readonly scene: THREE.Scene;
+    private lenses: GravLensInstance[] = [];
+    private chainCount = 0;
+    private chainTimer = 0;
+    private lastHudAngle = 0;
+    private nearestInfluence = false;
+
+    constructor(scene: THREE.Scene) {
+        this.scene = scene;
+    }
+
+    getLenses(): THREE.Group[] {
+        return this.lenses.map(l => l.group);
+    }
+
+    getScannables(): THREE.Object3D[] {
+        return this.lenses.map(l => l.group);
+    }
+
+    clear(): void {
+        for (const lens of this.lenses) {
+            this.scene.remove(lens.group);
+            lens.group.traverse(child => {
+                if (child instanceof THREE.Mesh) {
+                    child.geometry.dispose();
+                    const mat = child.material;
+                    if (Array.isArray(mat)) mat.forEach(m => m.dispose());
+                    else mat.dispose();
+                }
+            });
+            if (lens.microBh) {
+                this.scene.remove(lens.microBh.group);
+            }
+        }
+        this.lenses = [];
+        this.chainCount = 0;
+        this.chainTimer = 0;
+    }
+
+    spawnCorridor(config: GravLensCorridorConfig): void {
+        for (const placement of config.lenses) {
+            const group = createLensMesh();
+            group.position.set(
+                config.startX + placement.offsetX,
+                placement.y,
+                placement.z ?? -6
+            );
+            this.scene.add(group);
+            this.lenses.push({
+                group,
+                mass: placement.mass ?? FORCE_MASS,
+                detuneTimer: 0,
+                wasInField: false,
+                peakEntryAngle: 0,
+                crushAccum: 0,
+                damageWindow: { total: 0, timer: 0 },
+                microBh: null,
+                chainEligible: true
+            });
+        }
+    }
+
+    handleProjectileHits(
+        projectiles: { active: boolean; mesh: THREE.Mesh }[],
+        activeUpgrade: string,
+        onDetune?: (position: THREE.Vector3) => void
+    ): void {
+        const isCryo = activeUpgrade === 'cryo';
+        for (const lens of this.lenses) {
+            if (lens.detuneTimer > 0 && !isCryo) continue;
+            const pos = lens.group.position;
+            for (const proj of projectiles) {
+                if (!proj.active) continue;
+                const dist = pos.distanceTo(proj.mesh.position);
+                if (dist > ORBIT_RADIUS) continue;
+
+                lens.damageWindow.total += 25;
+                lens.damageWindow.timer = SHATTER_DAMAGE_WINDOW;
+
+                if (isCryo) {
+                    lens.detuneTimer = DETUNE_DURATION;
+                    onDetune?.(pos.clone());
+                }
+
+                if (lens.damageWindow.total >= SHATTER_DAMAGE_THRESHOLD) {
+                    this._spawnMicroBlackHole(lens);
+                    lens.damageWindow.total = 0;
+                    lens.damageWindow.timer = 0;
+                }
+            }
+        }
+    }
+
+    update(
+        delta: number,
+        player: GravLensPlayerState,
+        callbacks: GravLensUpdateCallbacks = {}
+    ): GravLensUpdateResult {
+        let totalFx = 0;
+        let totalFy = 0;
+        let inCrushZone = false;
+        let bestAngle = 0;
+        this.nearestInfluence = false;
+        const slingshotExits: GravLensUpdateResult['slingshotExits'] = [];
+        const failedExits: THREE.Vector3[] = [];
+
+        if (this.chainCount > 0) {
+            this.chainTimer += delta;
+            if (this.chainTimer >= CHAIN_TIMEOUT) {
+                this.chainCount = 0;
+                this.chainTimer = 0;
+            }
+        }
+
+        const velX = player.velocityX || player.autoScrollSpeed;
+        const velY = player.velocityY || player.currentSpeedY;
+
+        for (const lens of this.lenses) {
+            if (lens.detuneTimer > 0) {
+                lens.detuneTimer = Math.max(0, lens.detuneTimer - delta);
+            }
+
+            if (lens.damageWindow.timer > 0) {
+                lens.damageWindow.timer = Math.max(0, lens.damageWindow.timer - delta);
+                if (lens.damageWindow.timer <= 0) lens.damageWindow.total = 0;
+            }
+
+            this._animateLens(lens, delta);
+
+            if (lens.microBh) {
+                this._updateMicroBlackHole(lens, delta, player, callbacks);
+            }
+
+            const pos = lens.group.position;
+            const dist = pos.distanceTo(player.position);
+            const inField = dist < INFLUENCE_RADIUS && lens.detuneTimer <= 0;
+
+            if (inField) {
+                this.nearestInfluence = true;
+                const entryAngle = computeEntryAngleDeg(player.position, pos, velX, velY);
+                lens.peakEntryAngle = Math.max(lens.peakEntryAngle, entryAngle);
+                if (entryAngle > bestAngle) bestAngle = entryAngle;
+
+                const soft2 = FORCE_SOFTENING * FORCE_SOFTENING;
+                const rawMag = (lens.mass * FORCE_MASS) / (dist * dist + soft2);
+                const edgeFade = 1 - dist / INFLUENCE_RADIUS;
+                const forceMag = Math.min(rawMag, MAX_PULL_PER_SEC) * edgeFade;
+
+                const dirX = (pos.x - player.position.x) / Math.max(dist, 0.01);
+                const dirY = (pos.y - player.position.y) / Math.max(dist, 0.01);
+                totalFx += dirX * forceMag * delta;
+                totalFy += dirY * forceMag * delta;
+
+                // Stable orbit assist near 15 m
+                if (dist > ORBIT_RADIUS * 0.85 && dist < ORBIT_RADIUS * 1.15) {
+                    const tangentX = -dirY;
+                    const tangentY = dirX;
+                    const orbitAssist = ORBIT_TARGET_SPEED * 0.08 * delta;
+                    totalFx += tangentX * orbitAssist;
+                    totalFy += tangentY * orbitAssist;
+                }
+
+                const grade = gradeFromAngle(lens.peakEntryAngle);
+                if (dist < CRUSH_RADIUS && grade === 'failed' && !player.invincible && !player.inSafeHarbor) {
+                    inCrushZone = true;
+                    lens.crushAccum += CRUSH_DPS * delta;
+                    if (lens.crushAccum >= 1) {
+                        const damage = Math.floor(lens.crushAccum);
+                        lens.crushAccum -= damage;
+                        callbacks.onCrushDamage?.(damage, player.position.clone());
+                    }
+                } else {
+                    lens.crushAccum = 0;
+                }
+            } else if (lens.wasInField) {
+                const grade = gradeFromAngle(lens.peakEntryAngle);
+                if (grade === 'failed') {
+                    failedExits.push(lens.group.position.clone());
+                    this.chainCount = 0;
+                } else {
+                    const exit = this._buildSlingshotExit(lens, grade);
+                    if (exit) slingshotExits.push(exit);
+                }
+                lens.peakEntryAngle = 0;
+                lens.crushAccum = 0;
+            }
+
+            lens.wasInField = inField;
+        }
+
+        this.lastHudAngle = bestAngle;
+        callbacks.onApproachAngle?.(bestAngle, this.nearestInfluence);
+
+        return { forceX: totalFx, forceY: totalFy, inCrushZone, slingshotExits, failedExits };
+    }
+
+    getChainCount(): number {
+        return this.chainCount;
+    }
+
+    getLastApproachAngle(): number {
+        return this.lastHudAngle;
+    }
+
+    isInInfluence(): boolean {
+        return this.nearestInfluence;
+    }
+
+    static slingQualityFromGrade(grade: SlingshotGrade): SlingQuality {
+        return slingQualityFromGrade(grade);
+    }
+
+    private _buildSlingshotExit(
+        lens: GravLensInstance,
+        grade: SlingshotGrade
+    ): GravLensUpdateResult['slingshotExits'][number] | null {
+        if (grade === 'none' || grade === 'failed') return null;
+
+        this.chainCount++;
+        this.chainTimer = 0;
+
+        const mult = grade === 'perfect' ? PERFECT_BOOST_MULT : PARTIAL_BOOST_MULT;
+        const chainBonus = 1 + Math.min(this.chainCount - 1, 4) * 0.15;
+
+        return {
+            grade,
+            position: lens.group.position.clone(),
+            chain: this.chainCount,
+            boostMult: mult * chainBonus,
+            boostDuration: grade === 'perfect' ? BOOST_DURATION_PERFECT : BOOST_DURATION_PARTIAL
+        };
+    }
+
+    private _animateLens(lens: GravLensInstance, delta: number): void {
+        const t = performance.now() * 0.001;
+        lens.group.rotation.y += delta * 0.35;
+        const detuned = lens.detuneTimer > 0;
+        lens.group.children.forEach(child => {
+            if (!(child instanceof THREE.Mesh)) return;
+            if (child.userData.isCrushRing) {
+                child.material.opacity = detuned ? 0.05 : 0.2 + Math.sin(t * 4) * 0.08;
+            } else if (child.geometry.type === 'RingGeometry' && !child.userData.isCrushRing) {
+                (child.material as THREE.MeshBasicMaterial).opacity = detuned ? 0.15 : 0.45 + Math.sin(t * 2) * 0.12;
+            }
+        });
+    }
+
+    private _spawnMicroBlackHole(lens: GravLensInstance): void {
+        if (lens.microBh) return;
+        const group = new THREE.Group();
+        group.position.copy(lens.group.position);
+
+        const core = new THREE.Mesh(
+            new THREE.SphereGeometry(MICRO_BH_PULL_RADIUS * 0.4, 12, 12),
+            new THREE.MeshBasicMaterial({ color: 0x000000 })
+        );
+        group.add(core);
+
+        const disk = new THREE.Mesh(
+            new THREE.RingGeometry(MICRO_BH_PULL_RADIUS * 0.5, MICRO_BH_PULL_RADIUS * 1.8, 24),
+            new THREE.MeshBasicMaterial({
+                color: 0xff6600,
+                transparent: true,
+                opacity: 0.7,
+                side: THREE.DoubleSide,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false
+            })
+        );
+        disk.rotation.x = -Math.PI * 0.35;
+        group.add(disk);
+
+        this.scene.add(group);
+        lens.microBh = { group, timer: MICRO_BH_DURATION, position: lens.group.position.clone() };
+    }
+
+    private _updateMicroBlackHole(
+        lens: GravLensInstance,
+        delta: number,
+        player: GravLensPlayerState,
+        callbacks: GravLensUpdateCallbacks
+    ): void {
+        const bh = lens.microBh!;
+        bh.timer -= delta;
+        bh.group.rotation.z += delta * 2.5;
+
+        const dist = bh.position.distanceTo(player.position);
+        if (dist < MICRO_BH_PULL_RADIUS * 4 && lens.detuneTimer <= 0) {
+            const pull = (8 / Math.max(dist * dist, 0.5)) * delta;
+            const dx = (bh.position.x - player.position.x) / Math.max(dist, 0.01);
+            const dy = (bh.position.y - player.position.y) / Math.max(dist, 0.01);
+            player.currentSpeedY += dy * pull;
+            player.autoScrollSpeed = Math.min(player.autoScrollSpeed + dx * pull * 0.3, 26);
+        }
+
+        if (bh.timer <= 0) {
+            this.scene.remove(bh.group);
+            bh.group.traverse(c => {
+                if (c instanceof THREE.Mesh) {
+                    c.geometry.dispose();
+                    const m = c.material;
+                    if (Array.isArray(m)) m.forEach(x => x.dispose());
+                    else m.dispose();
+                }
+            });
+            lens.microBh = null;
+            callbacks.onShatter?.(bh.position.clone());
+        }
+    }
+}

--- a/src/hud_system/hud_elements.ts
+++ b/src/hud_system/hud_elements.ts
@@ -18,6 +18,9 @@ export interface HUDElementRefs {
     grazeComboDisplay: HTMLDivElement | null;
     slingComboDisplay: HTMLDivElement | null;
     slingComboLabel: HTMLSpanElement | null;
+    gravLensMeter: HTMLDivElement | null;
+    gravLensAngleBar: HTMLDivElement | null;
+    gravLensGrade: HTMLDivElement | null;
 }
 
 export function injectHUDStyles(): void {
@@ -113,6 +116,9 @@ export class HUDElementsBuilder {
     grazeComboDisplay: HTMLDivElement | null = null;
     slingComboDisplay: HTMLDivElement | null = null;
     slingComboLabel: HTMLSpanElement | null = null;
+    gravLensMeter: HTMLDivElement | null = null;
+    gravLensAngleBar: HTMLDivElement | null = null;
+    gravLensGrade: HTMLDivElement | null = null;
 
     createAll(callbacks: HUDElementsCallbacks): void {
         this.createScoreDisplay(callbacks.updateHighScoreDisplay);
@@ -123,6 +129,7 @@ export class HUDElementsBuilder {
         this.createScanProgressDisplay();
         this.createGrazeComboDisplay();
         this.createSlingComboDisplay();
+        this.createGravLensDisplay();
         this.createJourneyMapDisplay();
     }
 
@@ -337,6 +344,76 @@ export class HUDElementsBuilder {
         this.slingComboDisplay.appendChild(icon);
         this.slingComboDisplay.appendChild(this.slingComboLabel);
         document.body.appendChild(this.slingComboDisplay);
+    }
+
+    private createGravLensDisplay(): void {
+        this.gravLensMeter = document.createElement('div');
+        this.gravLensMeter.style.cssText = `
+            position: fixed;
+            top: 50%;
+            right: 24px;
+            transform: translateY(-50%);
+            z-index: 100;
+            width: 18px;
+            height: 160px;
+            background: rgba(10, 5, 30, 0.65);
+            border-radius: 12px;
+            border: 2px solid rgba(170, 100, 255, 0.5);
+            box-shadow: 0 0 16px rgba(100, 60, 200, 0.35);
+            opacity: 0;
+            transition: opacity 0.2s;
+            pointer-events: none;
+            overflow: hidden;
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-end;
+        `;
+
+        const label = document.createElement('div');
+        label.textContent = '∠';
+        label.style.cssText = `
+            position: absolute;
+            top: 6px;
+            left: 0;
+            right: 0;
+            text-align: center;
+            font-size: 11px;
+            color: #cc99ff;
+            font-weight: bold;
+        `;
+        this.gravLensMeter.appendChild(label);
+
+        this.gravLensAngleBar = document.createElement('div');
+        this.gravLensAngleBar.style.cssText = `
+            width: 100%;
+            height: 0%;
+            background: linear-gradient(0deg, #ff2244 0%, #ffaa00 45%, #44ffcc 100%);
+            border-radius: 0 0 10px 10px;
+            transition: height 0.08s linear;
+        `;
+        this.gravLensMeter.appendChild(this.gravLensAngleBar);
+        document.body.appendChild(this.gravLensMeter);
+
+        this.gravLensGrade = document.createElement('div');
+        this.gravLensGrade.style.cssText = `
+            position: fixed;
+            top: calc(50% + 95px);
+            right: 8px;
+            z-index: 101;
+            min-width: 90px;
+            text-align: center;
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 13px;
+            font-weight: bold;
+            color: white;
+            text-shadow: 0 1px 3px rgba(0,0,0,0.5);
+            opacity: 0;
+            transform: scale(0.85);
+            transition: opacity 0.15s, transform 0.15s;
+            pointer-events: none;
+        `;
+        document.body.appendChild(this.gravLensGrade);
     }
 
     private createPowerUpDisplay(): void {

--- a/src/hud_system/hud_manager.ts
+++ b/src/hud_system/hud_manager.ts
@@ -106,6 +106,56 @@ export class HUDManager {
         display.style.animation = '';
     }
 
+    /** Approach-angle meter while inside a grav-lens field (0–90°). */
+    updateGravLensApproach(angleDeg: number, visible: boolean): void {
+        const meter = this.elements.gravLensMeter;
+        const bar = this.elements.gravLensAngleBar;
+        if (!meter || !bar) return;
+
+        if (!visible) {
+            meter.style.opacity = '0';
+            return;
+        }
+
+        meter.style.opacity = '1';
+        const pct = Math.min(100, Math.max(0, (angleDeg / 90) * 100));
+        bar.style.height = `${pct}%`;
+    }
+
+    /** Brief slingshot grade pop (Perfect / Partial / Failed). */
+    showGravLensGrade(grade: 'perfect' | 'partial' | 'failed', chain: number = 0): void {
+        const el = this.elements.gravLensGrade;
+        if (!el) return;
+
+        const labels = {
+            perfect: 'Perfect!',
+            partial: 'Partial',
+            failed: 'Failed'
+        };
+        const colors = {
+            perfect: 'linear-gradient(135deg, #44ffcc, #2288ff)',
+            partial: 'linear-gradient(135deg, #ffcc44, #ff8800)',
+            failed: 'linear-gradient(135deg, #ff2244, #880022)'
+        };
+
+        el.textContent = chain > 1 ? `${labels[grade]} ×${chain}` : labels[grade];
+        el.style.background = colors[grade];
+        el.style.opacity = '1';
+        el.style.transform = 'scale(1.05)';
+
+        window.clearTimeout((el as unknown as { _gradeTimer?: number })._gradeTimer);
+        (el as unknown as { _gradeTimer?: number })._gradeTimer = window.setTimeout(() => {
+            el.style.opacity = '0';
+            el.style.transform = 'scale(0.85)';
+        }, grade === 'perfect' ? 1400 : 900);
+    }
+
+    hideGravLensHud(): void {
+        this.updateGravLensApproach(0, false);
+        const el = this.elements.gravLensGrade;
+        if (el) el.style.opacity = '0';
+    }
+
     setObjectiveLabel(text: string): void {
         const label = document.getElementById('hud-scan-label');
         if (label) label.textContent = text;

--- a/src/juice_effects/juice_manager.ts
+++ b/src/juice_effects/juice_manager.ts
@@ -29,6 +29,10 @@ export class JuiceManager {
     // Chromatic aberration overlay element
     private chromaticElement: HTMLDivElement;
     
+    // Sustained gravitational lens crush distortion
+    private distortionElement: HTMLDivElement;
+    private distortionIntensity: number = 0;
+    
     // Time tracking
     private time: number = 0;
     
@@ -71,6 +75,19 @@ export class JuiceManager {
         this.chromaticElement.style.opacity = '0';
         this.chromaticElement.style.mixBlendMode = 'screen';
         document.body.appendChild(this.chromaticElement);
+
+        this.distortionElement = document.createElement('div');
+        this.distortionElement.id = 'grav-lens-distortion';
+        this.distortionElement.style.position = 'absolute';
+        this.distortionElement.style.top = '0';
+        this.distortionElement.style.left = '0';
+        this.distortionElement.style.width = '100%';
+        this.distortionElement.style.height = '100%';
+        this.distortionElement.style.pointerEvents = 'none';
+        this.distortionElement.style.zIndex = '390';
+        this.distortionElement.style.opacity = '0';
+        this.distortionElement.style.mixBlendMode = 'overlay';
+        document.body.appendChild(this.distortionElement);
     }
     
     // =========================================================================
@@ -221,6 +238,13 @@ export class JuiceManager {
         };
         
         this.updateChromaticVisuals();
+    }
+
+    /**
+     * Sustained screen warp for grav-lens crush zones (0 = off, 1 = max).
+     */
+    setGravLensDistortion(intensity: number): void {
+        this.distortionIntensity = THREE.MathUtils.clamp(intensity, 0, 1);
     }
     
     /**
@@ -605,6 +629,28 @@ export class JuiceManager {
         text.element.style.transform = `translate(-50%, -50%) scale(${text.scale})`;
     }
     
+    private updateGravLensDistortion(): void {
+        const t = this.time;
+        const wobble = Math.sin(t * 14) * 0.4 + Math.sin(t * 7.3) * 0.3;
+        const intensity = this.distortionIntensity;
+        if (intensity <= 0.01) {
+            this.distortionElement.style.opacity = '0';
+            this.distortionElement.style.transform = '';
+            return;
+        }
+        const px = (2 + wobble * 3) * intensity;
+        this.distortionElement.style.background = `
+            radial-gradient(ellipse at 50% 45%, rgba(120,40,200,0.35) 0%, transparent 55%),
+            repeating-linear-gradient(
+                ${45 + wobble * 20}deg,
+                rgba(255,80,120,${0.08 * intensity}) 0px,
+                rgba(80,200,255,${0.06 * intensity}) ${px}px
+            )`;
+        this.distortionElement.style.opacity = String(0.25 + intensity * 0.55);
+        this.distortionElement.style.transform =
+            `scale(${1 + intensity * 0.02}) skewX(${wobble * intensity * 1.5}deg)`;
+    }
+
     // =========================================================================
     // MAIN UPDATE
     // =========================================================================
@@ -628,6 +674,7 @@ export class JuiceManager {
         
         // Always update these (visual only)
         this.updateChromatic(deltaTime);
+        this.updateGravLensDistortion();
         this.updateFloatingTexts(deltaTime);
         
         return modifiedDelta;
@@ -652,6 +699,8 @@ export class JuiceManager {
         // Clear chromatic
         this.chromaticFlash = null;
         this.chromaticElement.style.opacity = '0';
+        this.distortionIntensity = 0;
+        this.distortionElement.style.opacity = '0';
         
         // Clear white flash
         if (this.whiteFlash) {
@@ -675,6 +724,7 @@ export class JuiceManager {
         this.reset();
         this.textContainer.remove();
         this.chromaticElement.remove();
+        this.distortionElement.remove();
     }
     
     // =========================================================================

--- a/src/level_config.ts
+++ b/src/level_config.ts
@@ -59,6 +59,19 @@ export type BubbleCoralEnvironmentConfig = {
 
 export type MeteorShowerEnvironmentConfig = boolean;
 
+export type GravLensPlacement = {
+    offsetX: number;
+    y: number;
+    z?: number;
+    mass?: number;
+};
+
+/** Chained grav-lens puzzle corridor (levels 2–3). */
+export type GravLensCorridorConfig = {
+    startX: number;
+    lenses: GravLensPlacement[];
+};
+
 export type LevelEnvironments = {
     butterflySwarm?: boolean;
     blackHole?: BlackHoleEnvironmentConfig;
@@ -178,6 +191,8 @@ export type LevelConfig = {
      * Systems not listed (or false) are deactivated.
      */
     environments?: LevelEnvironments;
+    /** Optional chained grav-lens slingshot corridors. */
+    gravLensCorridors?: GravLensCorridorConfig[];
 };
 
 export const LEVEL_CONFIG: { [key: number]: LevelConfig } = {
@@ -282,7 +297,24 @@ export const LEVEL_CONFIG: { [key: number]: LevelConfig } = {
         },
         vignettes: {
             geodeClearings: 0.5
-        }
+        },
+        gravLensCorridors: [
+            {
+                startX: 620,
+                lenses: [
+                    { offsetX: 0, y: 4, z: -5 },
+                    { offsetX: 95, y: -2, z: -6 },
+                    { offsetX: 185, y: 6, z: -4 }
+                ]
+            },
+            {
+                startX: 980,
+                lenses: [
+                    { offsetX: 0, y: 0, z: -5 },
+                    { offsetX: 110, y: 5, z: -7 }
+                ]
+            }
+        ]
     },
     3: {
         name: "Orbital Descent",
@@ -336,7 +368,18 @@ export const LEVEL_CONFIG: { [key: number]: LevelConfig } = {
         },
         vignettes: {
             roseArches: 1.2
-        }
+        },
+        gravLensCorridors: [
+            {
+                startX: 1380,
+                lenses: [
+                    { offsetX: 0, y: 3, z: -5 },
+                    { offsetX: 100, y: -3, z: -6 },
+                    { offsetX: 200, y: 2, z: -4 },
+                    { offsetX: 310, y: 7, z: -5 }
+                ]
+            }
+        ]
     },
     4: {
         name: "The Rusty Gauntlet",

--- a/src/main/grav_lens_update.ts
+++ b/src/main/grav_lens_update.ts
@@ -1,0 +1,130 @@
+/**
+ * Per-frame grav-lens physics, HUD, juice, and sling-combo integration.
+ */
+
+import * as THREE from 'three';
+import { player } from '../player_loader';
+import { playerState } from '../game_config';
+import { game } from '../game_runtime';
+import { gravLensManager, upgradeSystem } from '../game_systems';
+import { GravLensManager } from '../grav_lens';
+import { ShakeType } from '../juice_effects';
+import { DogAnimationState } from '../dog_cockpit';
+import { updateHealthDisplay } from '../ui_controls';
+import { handleGameOver } from './obstacle_setup';
+
+export function updateGravLensSystems(delta: number): void {
+    if (!player || gravLensManager.getLenses().length === 0) return;
+
+    if (playerState.gravLensBoostTimer > 0) {
+        playerState.gravLensBoostTimer = Math.max(0, playerState.gravLensBoostTimer - delta);
+        if (playerState.gravLensBoostTimer <= 0) {
+            playerState.gravLensBoostMultiplier = 1;
+        }
+    }
+
+    const projectiles = game.weaponSystem.getActiveProjectiles();
+    if (projectiles.length > 0) {
+        gravLensManager.handleProjectileHits(projectiles, upgradeSystem.activeUpgrade, (position) => {
+            game.juiceManager.showFloatingText('Detuned!', position, '#00ffff', 20);
+            game.particleSystem.emit(position, 0x00ffff, 10, 3.0, 0.5);
+        });
+    }
+
+    const result = gravLensManager.update(
+        delta,
+        {
+            position: player.position,
+            velocityX: playerState.autoScrollSpeed,
+            velocityY: playerState.currentSpeedY,
+            autoScrollSpeed: playerState.autoScrollSpeed,
+            currentSpeedY: playerState.currentSpeedY,
+            invincible: playerState.invincible,
+            inSafeHarbor: playerState.inSafeHarbor
+        },
+        {
+            onApproachAngle: (angleDeg, inRange) => {
+                game.hudManager.updateGravLensApproach(angleDeg, inRange);
+            },
+            onCrushDamage: (amount, position) => {
+                if (playerState.invincible || playerState.inSafeHarbor) return;
+                playerState.health = Math.max(0, playerState.health - amount);
+                playerState.invincible = true;
+                setTimeout(() => { playerState.invincible = false; }, 800);
+                game.lastPlayerDamageTime = performance.now() * 0.001;
+                game.hudManager.updateHealth(playerState.health, playerState.maxHealth);
+                updateHealthDisplay(playerState);
+                game.dogController.triggerAnimation(DogAnimationState.HIT, 0.8);
+                game.juiceManager.shakeScreen(ShakeType.HEAVY, 0.35);
+                game.juiceManager.setGravLensDistortion(1);
+                game.slingComboManager.resetCombo();
+                game.audioSystem.playImpact(playerState.currentSpeedY);
+                if (playerState.health <= 0) {
+                    handleGameOver();
+                }
+            },
+            onShatter: (position) => {
+                game.juiceManager.flashWhite(0.15);
+                game.juiceManager.shakeScreen(ShakeType.HEAVY, 0.5);
+                game.particleSystem.emit(position, 0xffffff, 30, 5.0, 0.9);
+                game.juiceManager.showFloatingText('Micro Singularity!', position, '#ffccff', 26);
+            }
+        }
+    );
+
+    for (const pos of result.failedExits) {
+        game.hudManager.showGravLensGrade('failed', 0);
+        game.juiceManager.showFloatingText('Crush approach!', pos, '#ff4466', 20);
+    }
+
+    for (const exit of result.slingshotExits) {
+        const { grade, position, chain, boostMult, boostDuration } = exit;
+        game.hudManager.showGravLensGrade(grade, chain);
+        playerState.autoScrollSpeed = Math.min(playerState.autoScrollSpeed * boostMult, 28);
+        playerState.currentSpeedY *= boostMult;
+        playerState.gravLensBoostTimer = boostDuration;
+        playerState.gravLensBoostMultiplier = boostMult;
+
+        const quality = GravLensManager.slingQualityFromGrade(grade);
+        const chainBonus = chain > 1 ? 1 + (chain - 1) * 0.25 : 1;
+        game.slingComboManager.recordSlingAction(quality, position, chainBonus);
+        game.slingObjectiveManager.recordSling(quality);
+        game.reportComboObjectiveProgress();
+        game.audioSystem.playGravitySlingRelease(quality, game.slingComboManager.getCombo());
+        game.particleSystem.emit(position, grade === 'perfect' ? 0x44ffcc : 0xffaa44, 14, 4.0, 0.7);
+        game.juiceManager.showFloatingText(
+            grade === 'perfect' ? 'Grav Sling!' : 'Lens Boost',
+            position,
+            grade === 'perfect' ? '#44ffcc' : '#ffaa44',
+            24
+        );
+        if (grade === 'perfect') {
+            game.juiceManager.shakeScreen(ShakeType.MEDIUM, 0.25);
+            game.dogController.triggerAnimation(DogAnimationState.DELIGHTED, 1.2);
+        }
+    }
+
+    playerState.currentSpeedY += result.forceY;
+    playerState.autoScrollSpeed = Math.min(
+        Math.max(playerState.autoScrollSpeed + result.forceX, playerState.autoScrollSpeed * 0.98),
+        30
+    );
+    player.position.x += result.forceX * 0.15;
+
+    const crushIntensity = result.inCrushZone ? 0.85 : gravLensManager.isInInfluence() ? 0.12 : 0;
+    game.juiceManager.setGravLensDistortion(crushIntensity);
+}
+
+export function spawnGravLensCorridorsForLevel(
+    levelIndex: number,
+    cfg: { gravLensCorridors?: { startX: number; lenses: { offsetX: number; y: number; z?: number }[] }[] }
+): void {
+    gravLensManager.clear();
+    game.hudManager.hideGravLensHud();
+    game.juiceManager.setGravLensDistortion(0);
+
+    if (!cfg.gravLensCorridors?.length) return;
+    for (const corridor of cfg.gravLensCorridors) {
+        gravLensManager.spawnCorridor(corridor);
+    }
+}

--- a/src/main/loop_world.ts
+++ b/src/main/loop_world.ts
@@ -21,6 +21,8 @@ import {
 } from '../environment';
 import { updateCamera } from './camera_system';
 import { updateShadowQuality, updateShadowCulling } from './render_helpers';
+import { updateGravLensSystems } from './grav_lens_update';
+import { gravLensManager } from '../game_systems';
 export function updateLoopWorld(delta: number, time: number): void {
         // "Path to the Moon" gate animates independently of the planet horizon
         game.planetaryHorizonSystem.updateMoonGate(delta);
@@ -81,6 +83,11 @@ export function updateLoopWorld(delta: number, time: number): void {
                 });
             }
         }
+
+        // Grav-lens slingshot corridors (levels 2–3)
+        if (player) {
+            updateGravLensSystems(delta);
+        }
     
         // Update Level Manager (and Clouds)
         if (player) {
@@ -94,6 +101,7 @@ export function updateLoopWorld(delta: number, time: number): void {
                 ...iceNeedleClusters,
                 ...gravityAnchors,
                 ...liquidMetalBlobs,
+                ...gravLensManager.getScannables(),
             ];
             game.discoveryManager.update(player.position, [
                 ...game.levelManager.levelObjects,

--- a/src/main/startup.ts
+++ b/src/main/startup.ts
@@ -24,6 +24,7 @@ import { DiscoveryManager, CreatureCatalogManager } from '../discovery_system';
 import { SlingObjectiveManager } from '../sling_objective';
 import { SlingComboManager } from '../sling_combo';
 import { TetherSystem } from '../tether_system';
+import { spawnGravLensCorridorsForLevel } from './grav_lens_update';
 import { DebugSystem } from '../debug_system';
 import { decorationBudget, registerDefaultDecorationBudgets } from '../decoration_budget';
 import { createGalaxy, createMoon } from '../visuals';
@@ -228,6 +229,7 @@ function createLevelManager(industrialGeometryManager: IndustrialGeometryManager
             game.discoveryManager.reset();
             game.friendsManager.resetLevelLemurCap();
             game.toyRocketSpawnManager.spawnForLevel(game.levelManager.currentLevel, cfg);
+            spawnGravLensCorridorsForLevel(game.levelManager.currentLevel, cfg);
             game.wrenchChargeAvailable = saveManager.hasMemory('mine_robot');
             game.slingObjectiveManager.reset(cfg.objective?.type === 'sling' ? cfg.objective.target : 0);
             if (cfg.objective?.type === 'scan') {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements plan §III **Grav-Lenses** as a CPU-side slingshot puzzle mechanic for levels 2–3.

- **`grav_lens.ts`** — lens mesh (core, orbit ring, crush ring), inverse-square pull with ~15 m stable orbit assist, graded slingshot exits, crush-zone damage, Cryo detune, and shatter → micro black hole
- **Level corridors** — chained lens sequences in `LEVEL_CONFIG` for levels 2 (two corridors) and 3 (one four-lens chain)
- **HUD** — right-side approach-angle meter and brief Perfect / Partial / Failed grade pop
- **Juice** — sustained screen distortion in crush zones via `JuiceManager.setGravLensDistortion()`
- **Combo integration** — perfect/partial lens exits feed `SlingComboManager` with chain bonus multipliers

## Acceptance criteria

- [x] Player can chain 2+ lenses with measurable velocity gain (3× perfect / 1.5× partial + chain bonus)
- [x] Failed approach deals crush damage + visual distortion
- [x] Works in WebGL2 fallback (force logic is CPU-side; standard materials only)

## Testing

- `npm run build` — pass
- `npm run test:smoke` — 2/2 pass (WebGL + SwiftShader path)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e4744b8-dbf3-4fae-b290-f21153808ba8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e4744b8-dbf3-4fae-b290-f21153808ba8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

