### PR TITLE
Add Artifacts systems: Derelict Buoys and Data Monoliths

### DIFF
--- a/.github/typecheck-baseline.txt
+++ b/.github/typecheck-baseline.txt
@@ -1,6 +1,6 @@
 # TypeScript error baseline — do not edit by hand unless you know what you are doing.
 # Regenerate with: npm run typecheck:baseline:update
-# Count: 169
+# Count: 167
 src/aurora.ts(104,9): TS2739: Type 'OperatorNode' is missing the following properties from type 'MathNode': method, cNode, isMathNode
 src/aurora.ts(86,9): TS2739: Type 'OperatorNode' is missing the following properties from type 'MathNode': method, cNode, isMathNode
 src/biological_background.ts(57,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
@@ -10,34 +10,27 @@ src/biological_background.ts(61,5): TS2740: Type 'OperatorNode' is missing the f
 src/biological_background.ts(62,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
 src/biological_background.ts(63,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
 src/biological_background.ts(65,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
-src/boss_system.ts(25,5): TS2564: Property 'mouth' has no initializer and is not definitely assigned in the constructor.
-src/boss_system.ts(26,5): TS2564: Property 'jaw' has no initializer and is not definitely assigned in the constructor.
-src/boss_system.ts(27,5): TS2564: Property 'uvula' has no initializer and is not definitely assigned in the constructor.
-src/boss_system.ts(29,5): TS2564: Property 'accretionDisk' has no initializer and is not definitely assigned in the constructor.
-src/boss_system.ts(30,5): TS2564: Property 'glowLight' has no initializer and is not definitely assigned in the constructor.
-src/boss_system.ts(43,5): TS2564: Property 'onPlayerHit' has no initializer and is not definitely assigned in the constructor.
-src/candy_materials.ts(140,27): TS2345: Argument of type 'CandyMaterial' is not assignable to parameter of type 'string'.
-src/candy_materials.ts(200,100): TS2345: Argument of type 'Node' is not assignable to parameter of type 'number'.
-src/candy_materials.ts(203,57): TS2345: Argument of type 'unknown' is not assignable to parameter of type 'MathNodeParameter'.
-src/candy_materials.ts(229,9): TS18046: 'handle.baseColor.value' is of type 'unknown'.
-src/candy_materials.ts(239,9): TS18046: 'handle.emissiveColor.value' is of type 'unknown'.
-src/candy_materials.ts(372,9): TS2339: Property 'colorNode' does not exist on type 'CandyMaterial'.
-src/candy_materials.ts(373,9): TS2339: Property 'emissiveNode' does not exist on type 'CandyMaterial'.
-src/candy_materials.ts(476,9): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
-src/candy_materials.ts(484,9): TS2339: Property 'colorNode' does not exist on type 'CandyMaterial'.
-src/candy_materials.ts(485,9): TS2339: Property 'emissiveNode' does not exist on type 'CandyMaterial'.
-src/candy_materials.ts(562,9): TS2339: Property 'colorNode' does not exist on type 'CandyMaterial'.
-src/candy_materials.ts(563,9): TS2339: Property 'emissiveNode' does not exist on type 'CandyMaterial'.
-src/candy_materials.ts(591,20): TS2345: Argument of type 'MathNode' is not assignable to parameter of type 'AttributeNode'.
-src/candy_materials.ts(592,20): TS2345: Argument of type 'OperatorNode' is not assignable to parameter of type 'AttributeNode'.
-src/candy_materials.ts(593,20): TS2345: Argument of type 'OperatorNode' is not assignable to parameter of type 'AttributeNode'.
-src/candy_materials.ts(594,20): TS2345: Argument of type 'OperatorNode' is not assignable to parameter of type 'AttributeNode'.
-src/candy_materials.ts(642,35): TS2345: Argument of type 'OperatorNode' is not assignable to parameter of type 'AttributeNode'.
-src/candy_materials.ts(650,9): TS2339: Property 'colorNode' does not exist on type 'CandyMaterial'.
-src/candy_materials.ts(651,9): TS2339: Property 'emissiveNode' does not exist on type 'CandyMaterial'.
-src/candy_materials.ts(728,91): TS2345: Argument of type 'Node' is not assignable to parameter of type 'number'.
-src/candy_materials.ts(731,53): TS2345: Argument of type 'unknown' is not assignable to parameter of type 'MathNodeParameter'.
-src/candy_materials.ts(739,9): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
+src/candy_materials/factories.ts(171,9): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
+src/candy_materials/factories.ts(179,9): TS2339: Property 'colorNode' does not exist on type 'CandyMaterial'.
+src/candy_materials/factories.ts(180,9): TS2339: Property 'emissiveNode' does not exist on type 'CandyMaterial'.
+src/candy_materials/factories.ts(257,9): TS2339: Property 'colorNode' does not exist on type 'CandyMaterial'.
+src/candy_materials/factories.ts(258,9): TS2339: Property 'emissiveNode' does not exist on type 'CandyMaterial'.
+src/candy_materials/factories.ts(281,44): TS2304: Cannot find name 'uv'.
+src/candy_materials/factories.ts(284,40): TS2304: Cannot find name 'uv'.
+src/candy_materials/factories.ts(336,17): TS2304: Cannot find name 'uv'.
+src/candy_materials/factories.ts(345,9): TS2339: Property 'colorNode' does not exist on type 'CandyMaterial'.
+src/candy_materials/factories.ts(346,9): TS2339: Property 'emissiveNode' does not exist on type 'CandyMaterial'.
+src/candy_materials/factories.ts(67,9): TS2339: Property 'colorNode' does not exist on type 'CandyMaterial'.
+src/candy_materials/factories.ts(68,9): TS2339: Property 'emissiveNode' does not exist on type 'CandyMaterial'.
+src/candy_materials/gameplay.ts(101,9): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
+src/candy_materials/gameplay.ts(90,91): TS2345: Argument of type 'Node' is not assignable to parameter of type 'number'.
+src/candy_materials/gameplay.ts(93,53): TS2345: Argument of type 'unknown' is not assignable to parameter of type 'MathNodeParameter'.
+src/candy_materials/shared.ts(145,27): TS2345: Argument of type 'CandyMaterial' is not assignable to parameter of type 'string'.
+src/candy_materials/shared.ts(205,100): TS2345: Argument of type 'Node' is not assignable to parameter of type 'number'.
+src/candy_materials/shared.ts(208,57): TS2345: Argument of type 'unknown' is not assignable to parameter of type 'MathNodeParameter'.
+src/candy_materials/shared.ts(234,9): TS18046: 'handle.baseColor.value' is of type 'unknown'.
+src/candy_materials/shared.ts(244,9): TS18046: 'handle.emissiveColor.value' is of type 'unknown'.
+src/candy_materials/shared.ts(25,37): TS2307: Cannot find module './particles' or its corresponding type declarations.
 src/candy_obstacles/candy_asteroid.ts(12,5): TS2564: Property 'scale' has no initializer and is not definitely assigned in the constructor.
 src/candy_obstacles/candy_asteroid.ts(33,13): TS2564: Property 'originalScale' has no initializer and is not definitely assigned in the constructor.
 src/candy_obstacles/candy_asteroid.ts(5,5): TS2564: Property 'mesh' has no initializer and is not definitely assigned in the constructor.
@@ -67,20 +60,19 @@ src/clouds.ts(67,5): TS2740: Type 'OperatorNode' is missing the following proper
 src/clouds.ts(69,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
 src/clouds.ts(8,5): TS2300: Duplicate identifier 'Loop'.
 src/clouds.ts(9,5): TS2300: Duplicate identifier 'Loop'.
-src/environment.ts(150,22): TS2345: Argument of type 'Mesh<SphereGeometry, MeshStandardNodeMaterial, Object3DEventMap>' is not assignable to parameter of type 'Group<Object3DEventMap>'.
-src/environment.ts(271,31): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
-src/environment.ts(310,39): TS2339: Property 'material' does not exist on type 'Group<Object3DEventMap>'.
-src/environment.ts(318,44): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
-src/environment.ts(383,43): TS2339: Property 'material' does not exist on type 'Group<Object3DEventMap>'.
-src/environment.ts(397,71): TS2345: Argument of type 'Group<Object3DEventMap> | null' is not assignable to parameter of type 'Object3D<Object3DEventMap>'.
-src/environment.ts(415,51): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
-src/environment.ts(66,22): TS2345: Argument of type 'Mesh<SphereGeometry, MeshPhysicalMaterial, Object3DEventMap>' is not assignable to parameter of type 'Group<Object3DEventMap>'.
+src/environment.ts(153,22): TS2345: Argument of type 'Mesh<SphereGeometry, MeshStandardNodeMaterial, Object3DEventMap>' is not assignable to parameter of type 'Group<Object3DEventMap>'.
+src/environment.ts(274,31): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
+src/environment.ts(313,39): TS2339: Property 'material' does not exist on type 'Group<Object3DEventMap>'.
+src/environment.ts(321,44): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
+src/environment.ts(386,43): TS2339: Property 'material' does not exist on type 'Group<Object3DEventMap>'.
+src/environment.ts(408,51): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
+src/environment.ts(67,22): TS2345: Argument of type 'Mesh<SphereGeometry, MeshPhysicalMaterial, Object3DEventMap>' is not assignable to parameter of type 'Group<Object3DEventMap>'.
 src/foliage/grass_system.ts(23,9): TS2304: Cannot find name 'grassMeshes'.
 src/foliage/grass_system.ts(26,12): TS2304: Cannot find name 'grassMeshes'.
 src/foliage/grass_system.ts(30,18): TS2304: Cannot find name 'grassMeshes'.
 src/foliage/grass_system.ts(30,35): TS7006: Parameter 'm' implicitly has an 'any' type.
-src/foliage/grass_system.ts(340,5): TS2552: Cannot find name 'registerReactiveMaterial'. Did you mean 'reactiveMaterials'?
-src/foliage/grass_system.ts(409,5): TS2552: Cannot find name 'registerReactiveMaterial'. Did you mean 'reactiveMaterials'?
+src/foliage/grass_system.ts(340,5): TS2304: Cannot find name 'registerReactiveMaterial'.
+src/foliage/grass_system.ts(409,5): TS2304: Cannot find name 'registerReactiveMaterial'.
 src/foliage/grass_system.ts(8,5): TS2304: Cannot find name 'grassMeshes'.
 src/game_managers.ts(39,51): TS2345: Argument of type 'unknown' is not assignable to parameter of type 'AudioSystem'.
 src/game_managers.ts(40,56): TS2345: Argument of type 'unknown' is not assignable to parameter of type 'AudioSystem | null | undefined'.
@@ -88,25 +80,33 @@ src/game_managers.ts(41,58): TS2345: Argument of type 'unknown' is not assignabl
 src/game_managers.ts(42,51): TS2345: Argument of type 'unknown' is not assignable to parameter of type 'AudioSystem'.
 src/game_managers.ts(45,63): TS2345: Argument of type 'unknown' is not assignable to parameter of type 'ParticleSystem | null | undefined'.
 src/game_managers.ts(46,55): TS2345: Argument of type 'unknown' is not assignable to parameter of type 'ParticleSystem | null | undefined'.
-src/geological/geodes.ts(101,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
 src/geological/geodes.ts(13,5): TS2300: Duplicate identifier 'vec3'.
 src/geological/geodes.ts(24,5): TS2300: Duplicate identifier 'vec3'.
-src/geological/geodes.ts(487,55): TS2339: Property 'lookAt' does not exist on type 'Vector3'.
-src/geological/geodes.ts(500,54): TS2339: Property 'material' does not exist on type 'Object3D<Object3DEventMap>'.
-src/geological/geodes.ts(589,54): TS2339: Property 'material' does not exist on type 'Object3D<Object3DEventMap>'.
-src/geological/geodes.ts(93,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
-src/geological/geodes.ts(94,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
-src/geological/geodes.ts(95,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
-src/geological/geodes.ts(97,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
-src/geological/geodes.ts(98,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
-src/geological/geodes.ts(99,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
+src/geological/geodes.ts(79,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
+src/geological/geodes.ts(80,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
+src/geological/geodes.ts(81,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
+src/geological/geodes.ts(83,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
+src/geological/geodes.ts(84,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
+src/geological/geodes.ts(85,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
+src/geological/geodes.ts(87,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
+src/industrial_background/system.ts(110,25): TS2304: Cannot find name 'createGearGeometry'.
+src/industrial_background/system.ts(111,25): TS2304: Cannot find name 'createMechanismMaterial'.
+src/industrial_background/system.ts(128,23): TS2304: Cannot find name 'createForegroundMaterial'.
+src/industrial_background/system.ts(144,26): TS2304: Cannot find name 'createSimpleIndustrialMaterial'.
+src/industrial_background/system.ts(46,25): TS2304: Cannot find name 'createConveyorMaterial'.
+src/industrial_background/system.ts(61,27): TS2304: Cannot find name 'createPistonGeometry'.
+src/industrial_background/system.ts(62,27): TS2304: Cannot find name 'createMechanismMaterial'.
+src/industrial_background/system.ts(78,24): TS2304: Cannot find name 'createSimpleIndustrialMaterial'.
+src/industrial_background/system.ts(94,29): TS2304: Cannot find name 'createPistonGeometry'.
+src/industrial_background/system.ts(95,29): TS2304: Cannot find name 'createMechanismMaterial'.
 src/input_system.ts(7,10): TS2724: '"./level_manager"' has no exported member named 'levelManager'. Did you mean 'LevelManager'?
 src/input_system.ts(82,59): TS2345: Argument of type 'InstancedMesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], InstancedMeshEventMap>' is not assignable to parameter of type 'Object3D<Object3DEventMap>[]'.
-src/level_manager.ts(389,36): TS2304: Cannot find name 'GodRaysEnvironmentConfig'.
-src/level_manager.ts(394,36): TS2304: Cannot find name 'AuroraEnvironmentConfig'.
-src/level_manager.ts(399,36): TS2304: Cannot find name 'LightningEnvironmentConfig'.
-src/level_manager.ts(404,36): TS2304: Cannot find name 'AsteroidFieldEnvironmentConfig'.
-src/level_manager.ts(423,73): TS2345: Argument of type 'NonNullable<boolean | BlackHoleEnvironmentConfig | GodRaysEnvironmentConfig | AuroraEnvironmentConfig | ... 6 more ... | undefined>' is not assignable to parameter of type 'VoidJellyfishEnvironmentConfig | undefined'.
+src/level_manager/environment_plugins.ts(123,13): TS2322: Type '(config: GodRaysEnvironmentConfig) => void' is not assignable to type '(value: NonNullable<boolean | BlackHoleEnvironmentConfig | GodRaysEnvironmentConfig | AuroraEnvironmentConfig | ... 6 more ... | undefined>) => void'.
+src/level_manager/environment_plugins.ts(128,13): TS2322: Type '(config: AuroraEnvironmentConfig) => void' is not assignable to type '(value: NonNullable<boolean | BlackHoleEnvironmentConfig | GodRaysEnvironmentConfig | AuroraEnvironmentConfig | ... 6 more ... | undefined>) => void'.
+src/level_manager/environment_plugins.ts(133,13): TS2322: Type '(config: LightningEnvironmentConfig) => void' is not assignable to type '(value: NonNullable<boolean | BlackHoleEnvironmentConfig | GodRaysEnvironmentConfig | AuroraEnvironmentConfig | ... 6 more ... | undefined>) => void'.
+src/level_manager/environment_plugins.ts(138,13): TS2322: Type '(config: AsteroidFieldEnvironmentConfig) => void' is not assignable to type '(value: NonNullable<boolean | BlackHoleEnvironmentConfig | GodRaysEnvironmentConfig | AuroraEnvironmentConfig | ... 6 more ... | undefined>) => void'.
+src/level_manager/environment_plugins.ts(157,69): TS2345: Argument of type 'NonNullable<boolean | BlackHoleEnvironmentConfig | GodRaysEnvironmentConfig | AuroraEnvironmentConfig | ... 6 more ... | undefined>' is not assignable to parameter of type 'VoidJellyfishEnvironmentConfig'.
+src/level_manager/environment_plugins.ts(53,69): TS2345: Argument of type 'NonNullable<boolean | BlackHoleEnvironmentConfig | GodRaysEnvironmentConfig | AuroraEnvironmentConfig | ... 6 more ... | undefined>' is not assignable to parameter of type '{ baseX?: number | undefined; baseY?: number | undefined; } | undefined'.
 src/lightning_bolt.ts(20,5): TS2300: Duplicate identifier 'uv'.
 src/lightning_bolt.ts(6,5): TS2300: Duplicate identifier 'uv'.
 src/magical_effects/burst_effects.ts(177,46): TS2304: Cannot find name 'createHeartShape'.
@@ -127,45 +127,43 @@ src/magical_effects/rainbow_trail.ts(20,3): TS2564: Property 'duration' has no i
 src/magical_effects/rainbow_trail.ts(20,3): TS2612: Property 'duration' will overwrite the base property in 'MagicalEffect'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.
 src/magical_effects/stardust_field.ts(21,3): TS2564: Property 'duration' has no initializer and is not definitely assigned in the constructor.
 src/magical_effects/stardust_field.ts(21,3): TS2612: Property 'duration' will overwrite the base property in 'MagicalEffect'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.
-src/main/input_bindings.ts(133,59): TS2345: Argument of type 'InstancedMesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], InstancedMeshEventMap>' is not assignable to parameter of type 'Object3D<Object3DEventMap>[]'.
-src/main/loop_combat.ts(299,21): TS2304: Cannot find name 'aquaticLifeManager'.
-src/main/loop_combat.ts(303,21): TS2304: Cannot find name 'aquaticLifeManager'.
-src/main/loop_combat.ts(312,25): TS2304: Cannot find name 'aquaticLifeManager'.
-src/main/loop_combat.ts(323,36): TS2304: Cannot find name 'aquaticLifeManager'.
-src/main/loop_combat.ts(339,17): TS2304: Cannot find name 'aquaticLifeManager'.
-src/main/loop_combat.ts(348,17): TS2304: Cannot find name 'aquaticLifeManager'.
-src/main/loop_combat.ts(357,21): TS2304: Cannot find name 'starlightKoiManager'.
-src/main/loop_combat.ts(359,21): TS2304: Cannot find name 'starlightKoiManager'.
-src/main/loop_combat.ts(366,21): TS2304: Cannot find name 'starlightKoiManager'.
-src/main/loop_combat.ts(367,21): TS2304: Cannot find name 'starlightKoiManager'.
-src/main/loop_combat.ts(370,17): TS2304: Cannot find name 'starlightKoiManager'.
-src/main/loop_combat.ts(379,21): TS2304: Cannot find name 'bubbleCoralManager'.
-src/main/loop_combat.ts(385,21): TS2304: Cannot find name 'bubbleCoralManager'.
-src/main/loop_combat.ts(393,21): TS2304: Cannot find name 'bubbleCoralManager'.
-src/main/loop_combat.ts(394,21): TS2304: Cannot find name 'bubbleCoralManager'.
-src/main/loop_combat.ts(397,17): TS2304: Cannot find name 'bubbleCoralManager'.
-src/main/loop_geological.ts(101,43): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
-src/main/loop_geological.ts(141,47): TS2339: Property 'material' does not exist on type 'Group<Object3DEventMap>'.
-src/main/loop_geological.ts(149,52): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
-src/main/loop_geological.ts(214,51): TS2339: Property 'material' does not exist on type 'Group<Object3DEventMap>'.
-src/main/loop_geological.ts(225,89): TS18047: 'player' is possibly 'null'.
-src/main/loop_geological.ts(229,83): TS2345: Argument of type 'Group<Object3DEventMap> | null' is not assignable to parameter of type 'Object3D<Object3DEventMap>'.
-src/main/loop_geological.ts(243,13): TS2304: Cannot find name 'liquidMetalSystem'.
-src/main/loop_geological.ts(245,17): TS2304: Cannot find name 'liquidMetalSystem'.
-src/main/loop_geological.ts(248,59): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
-src/main/loop_geological.ts(257,78): TS18047: 'player' is possibly 'null'.
-src/main/loop_geological.ts(281,50): TS18047: 'player' is possibly 'null'.
-src/main/loop_geological.ts(284,93): TS18047: 'player' is possibly 'null'.
-src/main/loop_geological.ts(285,77): TS18047: 'player' is possibly 'null'.
-src/main/loop_geological.ts(288,59): TS18047: 'player' is possibly 'null'.
-src/main/loop_world.ts(227,57): TS18047: 'player' is possibly 'null'.
-src/main/loop_world.ts(262,36): TS18047: 'player' is possibly 'null'.
-src/main/player_update.ts(343,39): TS2769: No overload matches this call.
-src/main/player_update.ts(364,53): TS2304: Cannot find name 'DogAnimationState'.
-src/main/player_update.ts(406,49): TS2304: Cannot find name 'DogAnimationState'.
+src/main/grav_lens_update.ts(82,43): TS2345: Argument of type 'SlingshotGrade' is not assignable to parameter of type '"perfect" | "partial" | "failed"'.
+src/main/grav_lens_update.ts(93,50): TS2345: Argument of type 'SlingQuality' is not assignable to parameter of type '"perfect" | "good" | "ok" | undefined'.
+src/main/input_bindings.ts(159,59): TS2345: Argument of type 'InstancedMesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], InstancedMeshEventMap>' is not assignable to parameter of type 'Object3D<Object3DEventMap>[]'.
+src/main/loop_combat.ts(376,21): TS2304: Cannot find name 'aquaticLifeManager'.
+src/main/loop_combat.ts(380,21): TS2304: Cannot find name 'aquaticLifeManager'.
+src/main/loop_combat.ts(389,25): TS2304: Cannot find name 'aquaticLifeManager'.
+src/main/loop_combat.ts(400,36): TS2304: Cannot find name 'aquaticLifeManager'.
+src/main/loop_combat.ts(416,17): TS2304: Cannot find name 'aquaticLifeManager'.
+src/main/loop_combat.ts(425,17): TS2304: Cannot find name 'aquaticLifeManager'.
+src/main/loop_combat.ts(434,21): TS2304: Cannot find name 'starlightKoiManager'.
+src/main/loop_combat.ts(436,21): TS2304: Cannot find name 'starlightKoiManager'.
+src/main/loop_combat.ts(443,21): TS2304: Cannot find name 'starlightKoiManager'.
+src/main/loop_combat.ts(444,21): TS2304: Cannot find name 'starlightKoiManager'.
+src/main/loop_combat.ts(447,17): TS2304: Cannot find name 'starlightKoiManager'.
+src/main/loop_combat.ts(456,21): TS2304: Cannot find name 'bubbleCoralManager'.
+src/main/loop_combat.ts(462,21): TS2304: Cannot find name 'bubbleCoralManager'.
+src/main/loop_combat.ts(470,21): TS2304: Cannot find name 'bubbleCoralManager'.
+src/main/loop_combat.ts(471,21): TS2304: Cannot find name 'bubbleCoralManager'.
+src/main/loop_combat.ts(474,17): TS2304: Cannot find name 'bubbleCoralManager'.
+src/main/loop_geological.ts(103,43): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
+src/main/loop_geological.ts(143,47): TS2339: Property 'material' does not exist on type 'Group<Object3DEventMap>'.
+src/main/loop_geological.ts(151,52): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
+src/main/loop_geological.ts(216,51): TS2339: Property 'material' does not exist on type 'Group<Object3DEventMap>'.
+src/main/loop_geological.ts(293,59): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
+src/main/loop_geological.ts(302,78): TS18047: 'player' is possibly 'null'.
+src/main/loop_geological.ts(326,50): TS18047: 'player' is possibly 'null'.
+src/main/loop_geological.ts(329,93): TS18047: 'player' is possibly 'null'.
+src/main/loop_geological.ts(330,77): TS18047: 'player' is possibly 'null'.
+src/main/loop_geological.ts(333,59): TS18047: 'player' is possibly 'null'.
+src/main/loop_world.ts(243,57): TS18047: 'player' is possibly 'null'.
+src/main/loop_world.ts(278,36): TS18047: 'player' is possibly 'null'.
+src/main/player_update.ts(344,39): TS2769: No overload matches this call.
+src/main/player_update.ts(365,53): TS2304: Cannot find name 'DogAnimationState'.
+src/main/player_update.ts(407,49): TS2304: Cannot find name 'DogAnimationState'.
 src/main/render_helpers.ts(69,26): TS7006: Parameter 'jellyMoss' implicitly has an 'any' type.
 src/main/render_helpers.ts(69,5): TS2304: Cannot find name 'jellyMosses'.
-src/main/startup.ts(340,40): TS2345: Argument of type 'Object3D<Object3DEventMap>' is not assignable to parameter of type 'Group<Object3DEventMap>'.
+src/main/startup.ts(359,40): TS2345: Argument of type 'Object3D<Object3DEventMap>' is not assignable to parameter of type 'Group<Object3DEventMap>'.
 src/pinwheel_flora.ts(185,31): TS2345: Argument of type 'Material | Material[]' is not assignable to parameter of type 'Material'.
 src/pinwheel_flora.ts(186,30): TS2345: Argument of type 'Material | Material[]' is not assignable to parameter of type 'Material'.
 src/player_loader.ts(31,23): TS2339: Property 'isMesh' does not exist on type 'Object3D<Object3DEventMap>'.

--- a/src/architect_lore.ts
+++ b/src/architect_lore.ts
@@ -1,0 +1,229 @@
+/**
+ * The Architects — lore + progression data unlocked by Data Monoliths (plan §III).
+ *
+ * Each decoded monolith reveals a lore fragment and grants a permanent 5% damage
+ * bonus against a specific flora type. Decoding the full set unlocks the
+ * "Architect's Key" (a future secret exit / L6 variant path).
+ */
+
+import type { SaveManager } from './save_manager';
+
+export interface ArchitectLoreEntry {
+    id: string;
+    title: string;
+    /** The story fragment shown in the codex once decoded. */
+    text: string;
+    /** speciesId (see discovery_system SPECIES_NAMES) this monolith empowers. */
+    floraTarget: string;
+    /** Human-readable flora name for the bonus line. */
+    floraName: string;
+}
+
+/**
+ * A representative slice of the 20-monolith set described in the plan. Each
+ * entry maps to a flora species and a lore beat; the full set can grow without
+ * touching gameplay wiring.
+ */
+export const ARCHITECT_LORE: Record<string, ArchitectLoreEntry> = {
+    seedbearers: {
+        id: 'seedbearers',
+        title: 'I. The Seedbearers',
+        text: 'Before the moon had a name, the Architects seeded the dark with living light. Every fern you pass is a distant echo of their gardens.',
+        floraTarget: 'fern',
+        floraName: 'Star Dust Fern'
+    },
+    first_bloom: {
+        id: 'first_bloom',
+        title: 'II. The First Bloom',
+        text: 'They taught the void to flower. The Nebula Rose was their proudest work — a bloom that drinks starlight and never wilts.',
+        floraTarget: 'rose',
+        floraName: 'Nebula Rose'
+    },
+    resonance: {
+        id: 'resonance',
+        title: 'III. The Resonance',
+        text: 'The Architects sang to their creations. The Subwoofer Lotus still hums their forgotten chord, waiting for a listener who understands.',
+        floraTarget: 'lotus',
+        floraName: 'Subwoofer Lotus'
+    },
+    the_wilds: {
+        id: 'the_wilds',
+        title: 'IV. The Wilds',
+        text: 'Not all their gardens stayed tame. The Void Root Ball grew hungry in the deep, twisting the Architects\' gift into something that grasps.',
+        floraTarget: 'voidRootBall',
+        floraName: 'Void Root Ball'
+    },
+    the_departure: {
+        id: 'the_departure',
+        title: 'V. The Departure',
+        text: 'One day the Architects simply left, folding themselves into the space between stars. They left the monoliths as a map home — and a key.',
+        floraTarget: 'glowingFlower',
+        floraName: 'Glowing Flower'
+    }
+};
+
+export const ARCHITECT_LORE_IDS: string[] = Object.keys(ARCHITECT_LORE);
+export const ARCHITECT_LORE_TOTAL = ARCHITECT_LORE_IDS.length;
+
+/** Per-monolith flora damage bonus (plan: +5% each). */
+export const MONOLITH_FLORA_DAMAGE_BONUS = 0.05;
+
+/** Returns the next un-decoded lore id (deterministic order), or null if done. */
+export function nextArchitectLoreId(unlocked: string[]): string | null {
+    for (const id of ARCHITECT_LORE_IDS) {
+        if (!unlocked.includes(id)) return id;
+    }
+    return null;
+}
+
+/**
+ * Aggregate flora damage multipliers from decoded monoliths, keyed by speciesId.
+ * e.g. { fern: 1.05, rose: 1.05 }. Weapons/obstacle systems can consult this.
+ */
+export function getFloraDamageMultipliers(unlocked: string[]): Record<string, number> {
+    const out: Record<string, number> = {};
+    for (const id of unlocked) {
+        const entry = ARCHITECT_LORE[id];
+        if (!entry) continue;
+        out[entry.floraTarget] = (out[entry.floraTarget] ?? 1) + MONOLITH_FLORA_DAMAGE_BONUS;
+    }
+    return out;
+}
+
+/** True once every monolith in the set has been decoded (Architect's Key). */
+export function hasFullArchitectSet(unlocked: string[]): boolean {
+    return ARCHITECT_LORE_IDS.every(id => unlocked.includes(id));
+}
+
+/**
+ * Compact "lore decoded" reveal shown right after a monolith is solved. Doubles
+ * as the discovery/bestiary-style confirmation required by the acceptance
+ * criteria. Caller appends it and removes it on close.
+ */
+export function createLoreRevealUI(
+    entry: ArchitectLoreEntry,
+    unlockedCount: number,
+    hasKey: boolean,
+    onClose: () => void
+): HTMLDivElement {
+    const container = document.createElement('div');
+    container.style.cssText = `
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 1300;
+        background: radial-gradient(circle at 50% 45%, rgba(10,20,40,0.8), rgba(2,4,10,0.94));
+        font-family: 'Segoe UI', sans-serif;
+        color: #eaf6ff;
+    `;
+
+    const panel = document.createElement('div');
+    panel.style.cssText = `
+        background: rgba(12, 22, 38, 0.95);
+        border: 2px solid #33e0ff;
+        border-radius: 16px;
+        box-shadow: 0 0 44px rgba(51,224,255,0.3);
+        padding: 26px 30px;
+        max-width: 480px;
+        width: 92%;
+        text-align: center;
+    `;
+    panel.innerHTML = `
+        <div style="font-size:1em;color:#66ffaa;letter-spacing:2px;margin-bottom:6px;">✓ MONOLITH DECODED</div>
+        <div style="font-size:1.5em;color:#9be7ff;margin-bottom:12px;">${entry.title}</div>
+        <div style="font-size:1em;color:#cfe6f5;line-height:1.5;margin-bottom:16px;">${entry.text}</div>
+        <div style="font-size:0.9em;color:#66ffaa;margin-bottom:6px;">
+            +${Math.round(MONOLITH_FLORA_DAMAGE_BONUS * 100)}% damage vs ${entry.floraName}
+        </div>
+        <div style="font-size:0.85em;color:${hasKey ? '#ffd76a' : '#8ab'};margin-bottom:18px;">
+            ${hasKey ? '\u{1F511} The Architect’s Key is complete!' : `${unlockedCount} / ${ARCHITECT_LORE_TOTAL} monoliths decoded`}
+        </div>
+        <button id="lore-continue" style="padding:12px 34px;font-size:1.05em;background:#2a6;border:none;border-radius:8px;color:white;cursor:pointer;">
+            Continue
+        </button>
+    `;
+    container.appendChild(panel);
+
+    panel.querySelector('#lore-continue')!.addEventListener('click', () => {
+        container.remove();
+        onClose();
+    });
+
+    return container;
+}
+
+/**
+ * "Architect Codex" — lore modal, sibling to the Weird Life Log bestiary.
+ * Shows decoded entries and locked placeholders. Caller appends/removes it.
+ */
+export function createArchitectCodexUI(saveManager: SaveManager, onClose: () => void): HTMLDivElement {
+    const unlocked = new Set(saveManager.getArchitectLore());
+    const fragments = saveManager.getMapFragments();
+    const hasKey = hasFullArchitectSet([...unlocked]);
+
+    const container = document.createElement('div');
+    container.style.cssText = `
+        position: fixed;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+        background: rgba(6, 10, 22, 0.95);
+        font-family: 'Segoe UI', sans-serif;
+        color: white;
+    `;
+
+    container.innerHTML = `
+        <h1 style="font-size: 2.3em; margin-bottom: 4px; color: #9be7ff; text-shadow: 0 0 22px rgba(51,224,255,0.5);">
+            \u{1F5FF} Architect Codex
+        </h1>
+        <p style="font-size: 1.05em; color: #7fd6ff; margin-bottom: 6px;">
+            ${unlocked.size} / ${ARCHITECT_LORE_TOTAL} monoliths decoded
+            &nbsp;·&nbsp; \u{1F5FA}️ ${fragments} map fragments
+        </p>
+        <p style="font-size: 0.95em; color: ${hasKey ? '#ffd76a' : '#66788a'}; margin-bottom: 18px;">
+            ${hasKey ? '\u{1F511} Architect’s Key assembled — a hidden path awaits.' : 'Decode every monolith to assemble the Architect’s Key.'}
+        </p>
+        <div id="codex-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 12px; max-width: 760px; width: 92%; max-height: 56vh; overflow-y: auto; padding: 4px;"></div>
+        <button id="close-codex" style="margin-top: 22px; padding: 12px 36px; font-size: 1.1em; background: #274; color: white; border: none; border-radius: 8px; cursor: pointer;">
+            Close
+        </button>
+    `;
+
+    const grid = container.querySelector('#codex-grid')!;
+    for (const entry of Object.values(ARCHITECT_LORE)) {
+        const known = unlocked.has(entry.id);
+        const el = document.createElement('div');
+        el.style.cssText = `
+            background: rgba(30, 48, 72, 0.55);
+            padding: 14px;
+            border-radius: 10px;
+            border: 2px solid ${known ? '#33e0ff' : '#3a4658'};
+            opacity: ${known ? 1 : 0.6};
+            text-align: left;
+        `;
+        el.innerHTML = `
+            <div style="font-weight: bold; font-size: 1.05em; margin-bottom: 6px; color: ${known ? '#bff0ff' : '#8aa'};">
+                ${known ? entry.title : '\u{1F512} Encrypted Monolith'}
+            </div>
+            <div style="font-size: 0.86em; color: #cfe6f5; margin-bottom: 8px; line-height: 1.4;">
+                ${known ? entry.text : 'A slab of dead circuitry. Trace its path to decode the Architects’ memory.'}
+            </div>
+            <div style="font-size: 0.8em; color: ${known ? '#66ffaa' : '#788'};">
+                ${known ? `+${Math.round(MONOLITH_FLORA_DAMAGE_BONUS * 100)}% damage vs ${entry.floraName}` : 'Reward: unknown'}
+            </div>
+        `;
+        grid.appendChild(el);
+    }
+
+    container.querySelector('#close-codex')!.addEventListener('click', () => {
+        container.remove();
+        onClose();
+    });
+
+    return container;
+}

--- a/src/audio_system/AudioSystem.ts
+++ b/src/audio_system/AudioSystem.ts
@@ -12,6 +12,7 @@ import { engineSoundsMixin } from './mixins/engine_sounds';
 import { reactiveSoundsMixin } from './mixins/reactive_sounds';
 import { reactiveSoundsMixin2 } from './mixins/reactive_sounds_2';
 import { gravityAudioMixin } from './mixins/gravity_audio';
+import { hackingSoundsMixin } from './mixins/hacking_sounds';
 import { cleanupMixin } from './mixins/cleanup';
 
 export class AudioSystem {
@@ -358,6 +359,7 @@ Object.assign(
     reactiveSoundsMixin,
     reactiveSoundsMixin2,
     gravityAudioMixin,
+    hackingSoundsMixin,
     cleanupMixin,
 );
 
@@ -375,6 +377,7 @@ type RawAudioSystemMixins = typeof musicLayerMixin
     & typeof reactiveSoundsMixin
     & typeof reactiveSoundsMixin2
     & typeof gravityAudioMixin
+    & typeof hackingSoundsMixin
     & typeof cleanupMixin;
 
 export type AudioSystemMixins = StripMixinThisMethods<RawAudioSystemMixins>;

--- a/src/audio_system/mixins/hacking_sounds.ts
+++ b/src/audio_system/mixins/hacking_sounds.ts
@@ -1,0 +1,137 @@
+import { bindMixin } from '../types';
+
+/**
+ * Procedural audio for the Artifacts hacking minigames (plan §III):
+ * Morse transmission tones (440 Hz, dot/dash), input blips, and the
+ * success / fail / alarm stingers. 100% synthesized — no audio files.
+ */
+export const hackingSoundsMixin = bindMixin({
+    /**
+     * Plays a single Morse symbol at the given start offset (seconds from now).
+     * dot = 200 ms, dash = 600 ms (plan-aligned). Returns nothing; scheduling
+     * of the whole sequence is done by the caller.
+     */
+    playMorseSymbol(isDash: boolean, startOffset = 0, frequency = 440): void {
+        this.init();
+        if (!this.ctx || !this.sfxGain) return;
+
+        const start = this.ctx.currentTime + startOffset;
+        const dur = isDash ? 0.6 : 0.2;
+
+        const osc = this.ctx.createOscillator();
+        osc.type = 'sine';
+        osc.frequency.setValueAtTime(frequency, start);
+
+        const gain = this.ctx.createGain();
+        gain.gain.setValueAtTime(0, start);
+        gain.gain.linearRampToValueAtTime(0.22, start + 0.012);
+        gain.gain.setValueAtTime(0.22, start + dur - 0.02);
+        gain.gain.exponentialRampToValueAtTime(0.001, start + dur);
+
+        osc.connect(gain);
+        gain.connect(this.sfxGain);
+        if (this.reverbSend) {
+            const rv = this.ctx.createGain();
+            rv.gain.value = 0.25;
+            gain.connect(rv);
+            rv.connect(this.reverbSend);
+        }
+
+        osc.start(start);
+        osc.stop(start + dur + 0.05);
+    },
+
+    /** Short confirmation blip for a correct player input. */
+    playHackBlip(correct = true): void {
+        this.init();
+        if (!this.ctx || !this.sfxGain) return;
+        const now = this.ctx.currentTime;
+        const osc = this.ctx.createOscillator();
+        osc.type = correct ? 'triangle' : 'square';
+        const f = correct ? 660 : 180;
+        osc.frequency.setValueAtTime(f, now);
+        if (!correct) osc.frequency.exponentialRampToValueAtTime(90, now + 0.18);
+
+        const gain = this.ctx.createGain();
+        gain.gain.setValueAtTime(0.0001, now);
+        gain.gain.linearRampToValueAtTime(correct ? 0.16 : 0.2, now + 0.01);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + (correct ? 0.12 : 0.22));
+
+        osc.connect(gain);
+        gain.connect(this.sfxGain);
+        osc.start(now);
+        osc.stop(now + 0.3);
+    },
+
+    /** Rising arpeggio when a hack is decoded successfully. */
+    playHackSuccess(): void {
+        this.init();
+        if (!this.ctx || !this.sfxGain) return;
+        const now = this.ctx.currentTime;
+        const notes = [523.25, 659.25, 783.99, 1046.5]; // C E G C
+        notes.forEach((f, i) => {
+            const t = now + i * 0.09;
+            const osc = this.ctx!.createOscillator();
+            osc.type = 'sine';
+            osc.frequency.setValueAtTime(f, t);
+            const gain = this.ctx!.createGain();
+            gain.gain.setValueAtTime(0.0001, t);
+            gain.gain.linearRampToValueAtTime(0.18, t + 0.02);
+            gain.gain.exponentialRampToValueAtTime(0.001, t + 0.35);
+            osc.connect(gain);
+            gain.connect(this.sfxGain!);
+            osc.start(t);
+            osc.stop(t + 0.4);
+        });
+    },
+
+    /** Descending buzz when a hack fails. */
+    playHackFail(): void {
+        this.init();
+        if (!this.ctx || !this.sfxGain) return;
+        const now = this.ctx.currentTime;
+        const osc = this.ctx.createOscillator();
+        osc.type = 'sawtooth';
+        osc.frequency.setValueAtTime(320, now);
+        osc.frequency.exponentialRampToValueAtTime(70, now + 0.5);
+
+        const filter = this.ctx.createBiquadFilter();
+        filter.type = 'lowpass';
+        filter.frequency.setValueAtTime(1200, now);
+        filter.frequency.exponentialRampToValueAtTime(300, now + 0.5);
+
+        const gain = this.ctx.createGain();
+        gain.gain.setValueAtTime(0.0001, now);
+        gain.gain.linearRampToValueAtTime(0.2, now + 0.02);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + 0.55);
+
+        osc.connect(filter);
+        filter.connect(gain);
+        gain.connect(this.sfxGain);
+        osc.start(now);
+        osc.stop(now + 0.6);
+    },
+
+    /** Two-tone alarm klaxon (buoy hack failure raises local enemy spawns). */
+    playHackAlarm(): void {
+        this.init();
+        if (!this.ctx || !this.sfxGain) return;
+        const now = this.ctx.currentTime;
+        for (let i = 0; i < 3; i++) {
+            const t = now + i * 0.28;
+            const osc = this.ctx.createOscillator();
+            osc.type = 'square';
+            osc.frequency.setValueAtTime(740, t);
+            osc.frequency.setValueAtTime(560, t + 0.14);
+            const gain = this.ctx.createGain();
+            gain.gain.setValueAtTime(0.0001, t);
+            gain.gain.linearRampToValueAtTime(0.14, t + 0.02);
+            gain.gain.setValueAtTime(0.14, t + 0.24);
+            gain.gain.exponentialRampToValueAtTime(0.001, t + 0.27);
+            osc.connect(gain);
+            gain.connect(this.sfxGain);
+            osc.start(t);
+            osc.stop(t + 0.28);
+        }
+    }
+});

--- a/src/data_monolith.ts
+++ b/src/data_monolith.ts
@@ -1,0 +1,462 @@
+/**
+ * Data Monoliths — circuitry-trace hacking artifact (plan §III).
+ *
+ * A rotating slab with glowing traces. The player traces a path from the input
+ * node to the output node with a cursor, avoiding moving "firewall" blocks.
+ * Three difficulty tiers scale grid size, firewall count, and a time limit.
+ * Decoding a monolith reveals a lore fragment about "The Architects" and grants
+ * a permanent flora damage bonus.
+ *
+ * This module owns the 3D slab prop, the puzzle model, and the overlay UI.
+ * Orchestration lives in main/artifact_update.
+ */
+
+import * as THREE from 'three';
+import { decorationBudget } from './decoration_budget';
+import {
+    HackSession, createHackOverlay, createHackPanel, renderMistakePips,
+    HACK_ACCENT, HACK_ACCENT_GOOD, HACK_ACCENT_WARN, type HackFailReason
+} from './hacking_minigame';
+
+const MONOLITH_BUDGET_ID = 'data_monolith';
+
+export type MonolithTier = 1 | 2 | 3;
+
+export interface MonolithTierConfig {
+    tier: MonolithTier;
+    gridSize: number;
+    firewalls: number;
+    /** 0 = no timer. */
+    timeLimit: number;
+    /** Firewall movement speed (cells/sec, 0 = static). */
+    firewallSpeed: number;
+    maxMistakes: number;
+}
+
+export const MONOLITH_TIERS: Record<MonolithTier, MonolithTierConfig> = {
+    1: { tier: 1, gridSize: 5, firewalls: 2, timeLimit: 0, firewallSpeed: 0, maxMistakes: 3 },
+    2: { tier: 2, gridSize: 6, firewalls: 4, timeLimit: 30, firewallSpeed: 0.6, maxMistakes: 3 },
+    3: { tier: 3, gridSize: 7, firewalls: 6, timeLimit: 20, firewallSpeed: 1.1, maxMistakes: 3 }
+};
+
+interface Cell { r: number; c: number; }
+
+export type Direction = 'up' | 'down' | 'left' | 'right';
+
+const DIR_DELTA: Record<Direction, Cell> = {
+    up: { r: -1, c: 0 },
+    down: { r: 1, c: 0 },
+    left: { r: 0, c: -1 },
+    right: { r: 0, c: 1 }
+};
+
+function cellKey(cell: Cell): string {
+    return `${cell.r},${cell.c}`;
+}
+
+/** Generates a monotonic-ish path from left edge to right edge across the grid. */
+function generateTracePath(size: number): Cell[] {
+    let r = Math.floor(Math.random() * size);
+    const path: Cell[] = [{ r, c: 0 }];
+    for (let c = 1; c < size; c++) {
+        // Optionally jog vertically before stepping right, keeping in-bounds.
+        const jog = Math.random();
+        if (jog < 0.33 && r > 0) {
+            r -= 1;
+            path.push({ r, c: c - 1 });
+        } else if (jog > 0.66 && r < size - 1) {
+            r += 1;
+            path.push({ r, c: c - 1 });
+        }
+        path.push({ r, c });
+    }
+    return path;
+}
+
+interface Firewall {
+    r: number;
+    c: number;
+    dir: 1 | -1;
+    progress: number;
+}
+
+export interface MonolithPuzzle {
+    size: number;
+    path: Cell[];
+    firewalls: Firewall[];
+    pathSet: Set<string>;
+    config: MonolithTierConfig;
+}
+
+export function createMonolithPuzzle(tier: MonolithTier): MonolithPuzzle {
+    const config = MONOLITH_TIERS[tier];
+    const size = config.gridSize;
+    const path = generateTracePath(size);
+    const pathSet = new Set(path.map(cellKey));
+
+    // Place firewalls on cells that are NOT the start/end and (for tier 1) not on
+    // the path, so a static board is always solvable.
+    const firewalls: Firewall[] = [];
+    const startEnd = new Set([cellKey(path[0]), cellKey(path[path.length - 1])]);
+    let guard = 0;
+    while (firewalls.length < config.firewalls && guard++ < 200) {
+        const r = Math.floor(Math.random() * size);
+        const c = Math.floor(Math.random() * size);
+        const key = `${r},${c}`;
+        if (startEnd.has(key)) continue;
+        if (config.firewallSpeed === 0 && pathSet.has(key)) continue; // static must stay off-path
+        if (firewalls.some(f => f.r === r && f.c === c)) continue;
+        firewalls.push({ r, c, dir: Math.random() < 0.5 ? 1 : -1, progress: 0 });
+    }
+    return { size, path, firewalls, pathSet, config };
+}
+
+/** Advances moving firewalls (tiers 2–3). Bounces at grid edges. */
+export function updateMonolithFirewalls(puzzle: MonolithPuzzle, delta: number): void {
+    const speed = puzzle.config.firewallSpeed;
+    if (speed === 0) return;
+    for (const f of puzzle.firewalls) {
+        f.progress += delta * speed;
+        while (f.progress >= 1) {
+            f.progress -= 1;
+            f.r += f.dir;
+            if (f.r < 0) { f.r = 0; f.dir = 1; }
+            else if (f.r > puzzle.size - 1) { f.r = puzzle.size - 1; f.dir = -1; }
+        }
+    }
+}
+
+function firewallAt(puzzle: MonolithPuzzle, cell: Cell): boolean {
+    return puzzle.firewalls.some(f => f.r === cell.r && f.c === cell.c);
+}
+
+function createMonolithMesh(tier: MonolithTier): THREE.Group {
+    const group = new THREE.Group();
+
+    const slab = new THREE.Mesh(
+        new THREE.BoxGeometry(2.4, 4.0, 0.5),
+        new THREE.MeshStandardMaterial({ color: 0x101826, metalness: 0.6, roughness: 0.35 })
+    );
+    group.add(slab);
+
+    // Emissive circuit traces on the face.
+    const traceColor = tier === 3 ? 0xff55aa : tier === 2 ? 0xaa66ff : HACK_ACCENT;
+    for (let i = 0; i < 5; i++) {
+        const trace = new THREE.Mesh(
+            new THREE.BoxGeometry(1.8, 0.05, 0.02),
+            new THREE.MeshBasicMaterial({ color: traceColor, transparent: true, opacity: 0.75 })
+        );
+        trace.position.set((Math.random() - 0.5) * 0.6, -1.6 + i * 0.8, 0.26);
+        trace.userData.isTrace = true;
+        group.add(trace);
+    }
+
+    const glyph = new THREE.Mesh(
+        new THREE.TorusGeometry(0.5, 0.06, 8, 24),
+        new THREE.MeshBasicMaterial({ color: traceColor, transparent: true, opacity: 0.8 })
+    );
+    glyph.position.set(0, 0, 0.28);
+    glyph.userData.isGlyph = true;
+    group.add(glyph);
+
+    group.userData.type = 'dataMonolith';
+    group.userData.speciesId = 'dataMonolith';
+    group.userData.tier = tier;
+    return group;
+}
+
+export interface MonolithPlacement {
+    x: number;
+    y: number;
+    z?: number;
+    tier?: MonolithTier;
+}
+
+export interface DataMonolithInstance {
+    group: THREE.Group;
+    tier: MonolithTier;
+    consumed: boolean;
+}
+
+export const MONOLITH_INTERACT_RADIUS = 5;
+
+export class DataMonolithManager {
+    private readonly scene: THREE.Scene;
+    private monoliths: DataMonolithInstance[] = [];
+
+    constructor(scene: THREE.Scene) {
+        this.scene = scene;
+    }
+
+    getScannables(): THREE.Object3D[] {
+        return this.monoliths.map(m => m.group);
+    }
+
+    hasMonoliths(): boolean {
+        return this.monoliths.length > 0;
+    }
+
+    clear(): void {
+        for (const m of this.monoliths) {
+            this.scene.remove(m.group);
+            m.group.traverse(child => {
+                if (child instanceof THREE.Mesh) {
+                    child.geometry.dispose();
+                    const mat = child.material;
+                    if (Array.isArray(mat)) mat.forEach(x => x.dispose());
+                    else mat.dispose();
+                }
+            });
+        }
+        decorationBudget.reportDestroy(MONOLITH_BUDGET_ID, this.monoliths.length);
+        this.monoliths = [];
+    }
+
+    spawnForLevel(placements: MonolithPlacement[], baseX: number): void {
+        for (const p of placements) {
+            if (!decorationBudget.canSpawn(MONOLITH_BUDGET_ID, 1)) break;
+            const tier: MonolithTier = p.tier ?? 1;
+            const group = createMonolithMesh(tier);
+            group.position.set(baseX + p.x, p.y, p.z ?? -8);
+            this.scene.add(group);
+            decorationBudget.reportSpawn(MONOLITH_BUDGET_ID, 1);
+            this.monoliths.push({ group, tier, consumed: false });
+        }
+    }
+
+    update(delta: number): void {
+        const t = performance.now() * 0.001;
+        for (const m of this.monoliths) {
+            // Tier 2+ slabs slowly rotate; tier 1 stays face-on.
+            if (m.tier >= 2 && !m.consumed) m.group.rotation.y += delta * 0.25;
+            m.group.children.forEach(child => {
+                if (child instanceof THREE.Mesh && child.userData.isGlyph) {
+                    (child.material as THREE.MeshBasicMaterial).opacity =
+                        m.consumed ? 0.25 : 0.6 + Math.sin(t * 2.5) * 0.25;
+                }
+            });
+        }
+    }
+
+    /** Nearest un-consumed monolith within interact radius, or null. */
+    getInteractable(playerPos: THREE.Vector3): DataMonolithInstance | null {
+        let best: DataMonolithInstance | null = null;
+        let bestDist = MONOLITH_INTERACT_RADIUS;
+        for (const m of this.monoliths) {
+            if (m.consumed) continue;
+            const d = m.group.position.distanceTo(playerPos);
+            if (d <= bestDist) {
+                best = m;
+                bestDist = d;
+            }
+        }
+        return best;
+    }
+
+    isInRange(m: DataMonolithInstance, playerPos: THREE.Vector3): boolean {
+        return m.group.position.distanceTo(playerPos) <= MONOLITH_INTERACT_RADIUS + 1;
+    }
+}
+
+// --- Hack overlay UI ----------------------------------------------------------
+
+export interface MonolithHackCallbacks {
+    onSuccess: () => void;
+    onFail: (reason: HackFailReason) => void;
+    onAbort: () => void;
+    playBlip: (correct: boolean) => void;
+}
+
+export interface MonolithHackHandle {
+    element: HTMLDivElement;
+    update: (delta: number) => void;
+    close: () => void;
+    /** Feed a direction from keyboard/touch (also usable in tests). */
+    move: (dir: Direction) => void;
+}
+
+/**
+ * Builds the trace-puzzle overlay. Handles its own keyboard (arrows / WASD) and
+ * touch (tap adjacent cells + D-pad), so the caller only appends the element and
+ * calls update(delta) each frame.
+ */
+export function createMonolithHackUI(
+    puzzle: MonolithPuzzle,
+    callbacks: MonolithHackCallbacks
+): MonolithHackHandle {
+    const overlay = createHackOverlay();
+    const panel = createHackPanel();
+    overlay.appendChild(panel);
+
+    const size = puzzle.size;
+    const start = puzzle.path[0];
+    const end = puzzle.path[puzzle.path.length - 1];
+    let cursor: Cell = { ...start };
+    let pathProgress = 0; // index into puzzle.path reached
+    let finished = false;
+
+    const session = new HackSession({
+        maxMistakes: puzzle.config.maxMistakes,
+        timeLimit: puzzle.config.timeLimit,
+        onSuccess: () => {},
+        onFail: (reason) => finish(false, reason),
+        onTick: () => renderStatus()
+    });
+
+    const gridEl = document.createElement('div');
+    const statusEl = document.createElement('div');
+
+    const finish = (success: boolean, reason?: HackFailReason) => {
+        if (finished) return;
+        finished = true;
+        cleanup();
+        if (success) callbacks.onSuccess();
+        else callbacks.onFail(reason ?? 'mistakes');
+    };
+
+    const renderGrid = () => {
+        gridEl.style.cssText = `
+            display: grid;
+            grid-template-columns: repeat(${size}, 1fr);
+            gap: 4px;
+            margin: 14px auto;
+            max-width: ${Math.min(size * 56, 360)}px;
+        `;
+        gridEl.replaceChildren();
+        for (let r = 0; r < size; r++) {
+            for (let c = 0; c < size; c++) {
+                const cell: Cell = { r, c };
+                const onPath = puzzle.pathSet.has(cellKey(cell));
+                const isFirewall = firewallAt(puzzle, cell);
+                const isCursor = cursor.r === r && cursor.c === c;
+                const isEnd = end.r === r && end.c === c;
+                const isStart = start.r === r && start.c === c;
+
+                const btn = document.createElement('button');
+                let bg = 'rgba(20,32,48,0.7)';
+                let border = '#2a3a4d';
+                if (onPath) { bg = 'rgba(51,224,255,0.12)'; border = HACK_ACCENT; }
+                if (isEnd) { bg = 'rgba(102,255,170,0.18)'; border = HACK_ACCENT_GOOD; }
+                if (isFirewall) { bg = 'rgba(255,85,119,0.4)'; border = HACK_ACCENT_WARN; }
+                if (isCursor) { bg = 'rgba(102,255,170,0.55)'; border = HACK_ACCENT_GOOD; }
+
+                btn.style.cssText = `
+                    aspect-ratio: 1;
+                    border-radius: 6px;
+                    background: ${bg};
+                    border: 2px solid ${border};
+                    color: #eaf6ff;
+                    font-size: 1.1em;
+                    cursor: pointer;
+                    display: flex; align-items: center; justify-content: center;
+                    box-shadow: ${isCursor ? '0 0 12px ' + HACK_ACCENT_GOOD : 'none'};
+                `;
+                btn.textContent = isCursor ? '◈' : isStart ? '▶' : isEnd ? '★' : isFirewall ? '✕' : '';
+                btn.addEventListener('click', () => tapCell(cell));
+                gridEl.appendChild(btn);
+            }
+        }
+    };
+
+    const renderStatus = () => {
+        const timeStr = session.hasTimeLimit ? ` · ⏱ ${session.secondsLeft}s` : '';
+        statusEl.innerHTML = `
+            <div style="margin-bottom:8px;">${renderMistakePips(session.mistakesRemaining, puzzle.config.maxMistakes)}</div>
+            <div style="font-size:0.85em;color:#9fd;">Trace to the ★${timeStr}</div>
+        `;
+    };
+
+    const render = () => {
+        renderGrid();
+        renderStatus();
+    };
+
+    const attemptMove = (dir: Direction) => {
+        if (finished || session.isFinished) return;
+        const delta = DIR_DELTA[dir];
+        const next: Cell = { r: cursor.r + delta.r, c: cursor.c + delta.c };
+        if (next.r < 0 || next.r >= size || next.c < 0 || next.c >= size) return;
+
+        const expected = puzzle.path[pathProgress + 1];
+        const isNextOnPath = expected && expected.r === next.r && expected.c === next.c;
+
+        if (isNextOnPath && !firewallAt(puzzle, next)) {
+            cursor = next;
+            pathProgress++;
+            callbacks.playBlip(true);
+            if (pathProgress >= puzzle.path.length - 1) {
+                render();
+                finish(true);
+                return;
+            }
+        } else {
+            // Wrong direction, off-path, or blocked by a firewall.
+            callbacks.playBlip(false);
+            session.registerMistake();
+        }
+        render();
+    };
+
+    const tapCell = (cell: Cell) => {
+        // Translate a tap on an orthogonally-adjacent cell into a move.
+        const dr = cell.r - cursor.r;
+        const dc = cell.c - cursor.c;
+        if (Math.abs(dr) + Math.abs(dc) !== 1) return;
+        if (dr === -1) attemptMove('up');
+        else if (dr === 1) attemptMove('down');
+        else if (dc === -1) attemptMove('left');
+        else attemptMove('right');
+    };
+
+    const keyHandler = (e: KeyboardEvent) => {
+        let dir: Direction | null = null;
+        if (e.code === 'ArrowUp' || e.code === 'KeyW') dir = 'up';
+        else if (e.code === 'ArrowDown' || e.code === 'KeyS') dir = 'down';
+        else if (e.code === 'ArrowLeft' || e.code === 'KeyA') dir = 'left';
+        else if (e.code === 'ArrowRight' || e.code === 'KeyD') dir = 'right';
+        else if (e.code === 'Escape') { e.preventDefault(); e.stopPropagation(); abort(); return; }
+        if (dir) {
+            e.preventDefault();
+            e.stopPropagation();
+            attemptMove(dir);
+        }
+    };
+
+    const abort = () => {
+        if (finished) return;
+        finished = true;
+        cleanup();
+        callbacks.onAbort();
+    };
+
+    const cleanup = () => {
+        window.removeEventListener('keydown', keyHandler, true);
+    };
+
+    // Header + assemble.
+    const header = document.createElement('div');
+    header.innerHTML = `
+        <div style="font-size:1.3em;color:${HACK_ACCENT};margin-bottom:4px;">\u{1F5FF} Data Monolith · Tier ${puzzle.config.tier}</div>
+        <div style="font-size:0.9em;color:#cfe6f5;">Trace ▶ → ★ · arrows / WASD or tap. Avoid ✕ firewalls.</div>
+    `;
+    panel.appendChild(header);
+    panel.appendChild(gridEl);
+    panel.appendChild(statusEl);
+
+    window.addEventListener('keydown', keyHandler, true);
+    render();
+
+    return {
+        element: overlay,
+        update: (delta: number) => {
+            if (finished) return;
+            updateMonolithFirewalls(puzzle, delta);
+            session.update(delta);
+            if (!finished) renderGrid();
+        },
+        move: attemptMove,
+        close: () => {
+            if (!finished) abort();
+        }
+    };
+}

--- a/src/decoration_budget.ts
+++ b/src/decoration_budget.ts
@@ -306,4 +306,15 @@ export function registerDefaultDecorationBudgets(): void {
         category: 'creatures',
         maxActive: 6
     });
+    // Artifacts (plan §III) — hero props, 1–2 per run in industrial zones.
+    decorationBudget.register('derelict_buoy', {
+        label: 'Derelict Buoys',
+        category: 'effects',
+        maxActive: 2
+    });
+    decorationBudget.register('data_monolith', {
+        label: 'Data Monoliths',
+        category: 'effects',
+        maxActive: 2
+    });
 }

--- a/src/derelict_buoy.ts
+++ b/src/derelict_buoy.ts
@@ -1,0 +1,400 @@
+/**
+ * Derelict Buoys — Morse-decode hacking artifact (plan §III).
+ *
+ * A drifting data buoy with a floating "data dock" ring. Flying inside the dock
+ * radius begins a Morse transmission (3–7 letters); the player decodes it with
+ * Up = dot / Down = dash. Three mistakes fail the hack and trip an alarm.
+ * Success starts a 5-second extraction (shields down, thrusters at 30%) that
+ * rewards a map fragment.
+ *
+ * This module owns the 3D prop, the Morse sequence generator, the dock-radius
+ * check, and the hack overlay UI. Orchestration lives in main/artifact_update.
+ */
+
+import * as THREE from 'three';
+import { decorationBudget } from './decoration_budget';
+import {
+    HackSession, createHackOverlay, createHackPanel, renderMistakePips,
+    HACK_ACCENT, HACK_ACCENT_GOOD, HACK_ACCENT_WARN
+} from './hacking_minigame';
+
+export const BUOY_DOCK_RADIUS = 3;      // plan: 3 m data dock sphere
+export const BUOY_EXTRACTION_TIME = 5;  // plan: 5 s extraction countdown
+export const BUOY_MAX_MISTAKES = 3;     // plan: 3 mistakes fail the hack
+const BUOY_BUDGET_ID = 'derelict_buoy';
+
+export type MorseSymbol = 'dot' | 'dash';
+
+/** International Morse for A–Z (dots/dashes). */
+const MORSE_ALPHABET: Record<string, string> = {
+    A: '.-', B: '-...', C: '-.-.', D: '-..', E: '.', F: '..-.',
+    G: '--.', H: '....', I: '..', J: '.---', K: '-.-', L: '.-..',
+    M: '--', N: '-.', O: '---', P: '.--.', Q: '--.-', R: '.-.',
+    S: '...', T: '-', U: '..-', V: '...-', W: '.--', X: '-..-',
+    Y: '-.--', Z: '--..'
+};
+
+// Short, kid-friendly words the buoys "transmit".
+const BUOY_WORDS = ['DOG', 'MOON', 'STAR', 'HELP', 'LOST', 'HOME', 'DASH', 'ORBIT', 'SIGNAL'];
+
+export interface MorseSequence {
+    word: string;
+    /** Flat list of symbols across all letters, in input order. */
+    symbols: MorseSymbol[];
+    /** Per-letter symbol groups (for spaced display / audio gaps). */
+    letters: MorseSymbol[][];
+    /** e.g. "-.. --- --." */
+    display: string;
+}
+
+/** Builds a Morse sequence from a random 3–7 char word. */
+export function generateMorseSequence(): MorseSequence {
+    // Prefer whole words, but clamp to the plan's 3–7 letter window.
+    const pool = BUOY_WORDS.filter(w => w.length >= 3 && w.length <= 7);
+    const word = pool[Math.floor(Math.random() * pool.length)] ?? 'DOG';
+
+    const letters: MorseSymbol[][] = [];
+    const symbols: MorseSymbol[] = [];
+    for (const ch of word) {
+        const code = MORSE_ALPHABET[ch] ?? '.';
+        const group: MorseSymbol[] = [];
+        for (const c of code) {
+            const sym: MorseSymbol = c === '-' ? 'dash' : 'dot';
+            group.push(sym);
+            symbols.push(sym);
+        }
+        letters.push(group);
+    }
+    const display = letters
+        .map(g => g.map(s => (s === 'dash' ? '–' : '·')).join(''))
+        .join('  ');
+    return { word, symbols, letters, display };
+}
+
+function createBuoyMesh(): THREE.Group {
+    const group = new THREE.Group();
+
+    // Central data core — dark metal drum with an emissive band.
+    const body = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.7, 0.7, 1.8, 12),
+        new THREE.MeshStandardMaterial({ color: 0x2a3340, metalness: 0.7, roughness: 0.4 })
+    );
+    group.add(body);
+
+    const band = new THREE.Mesh(
+        new THREE.TorusGeometry(0.72, 0.12, 8, 20),
+        new THREE.MeshBasicMaterial({ color: HACK_ACCENT, transparent: true, opacity: 0.85 })
+    );
+    band.rotation.x = Math.PI * 0.5;
+    band.userData.isBand = true;
+    group.add(band);
+
+    // Antennae fins.
+    for (let i = 0; i < 3; i++) {
+        const fin = new THREE.Mesh(
+            new THREE.BoxGeometry(0.08, 1.0, 0.4),
+            new THREE.MeshStandardMaterial({ color: 0x556070, metalness: 0.6, roughness: 0.5 })
+        );
+        const a = (i / 3) * Math.PI * 2;
+        fin.position.set(Math.cos(a) * 0.75, 1.2, Math.sin(a) * 0.75);
+        group.add(fin);
+    }
+
+    // Floating "data dock" ring the player must fly into.
+    const dock = new THREE.Mesh(
+        new THREE.RingGeometry(BUOY_DOCK_RADIUS - 0.15, BUOY_DOCK_RADIUS + 0.15, 40),
+        new THREE.MeshBasicMaterial({
+            color: HACK_ACCENT,
+            transparent: true,
+            opacity: 0.4,
+            side: THREE.DoubleSide,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false
+        })
+    );
+    dock.userData.isDock = true;
+    group.add(dock);
+
+    group.userData.type = 'derelictBuoy';
+    group.userData.speciesId = 'derelictBuoy';
+    return group;
+}
+
+export interface BuoyPlacement {
+    x: number;
+    y: number;
+    z?: number;
+}
+
+export interface DerelictBuoyInstance {
+    group: THREE.Group;
+    /** true once this buoy has been hacked (success or fail) this run. */
+    consumed: boolean;
+    hacked: boolean;
+    sequence: MorseSequence | null;
+}
+
+export class DerelictBuoyManager {
+    private readonly scene: THREE.Scene;
+    private buoys: DerelictBuoyInstance[] = [];
+
+    constructor(scene: THREE.Scene) {
+        this.scene = scene;
+    }
+
+    getBuoys(): THREE.Group[] {
+        return this.buoys.map(b => b.group);
+    }
+
+    getScannables(): THREE.Object3D[] {
+        return this.buoys.map(b => b.group);
+    }
+
+    hasBuoys(): boolean {
+        return this.buoys.length > 0;
+    }
+
+    clear(): void {
+        for (const b of this.buoys) {
+            this.scene.remove(b.group);
+            b.group.traverse(child => {
+                if (child instanceof THREE.Mesh) {
+                    child.geometry.dispose();
+                    const mat = child.material;
+                    if (Array.isArray(mat)) mat.forEach(m => m.dispose());
+                    else mat.dispose();
+                }
+            });
+        }
+        decorationBudget.reportDestroy(BUOY_BUDGET_ID, this.buoys.length);
+        this.buoys = [];
+    }
+
+    spawnForLevel(placements: BuoyPlacement[], baseX: number): void {
+        for (const p of placements) {
+            if (!decorationBudget.canSpawn(BUOY_BUDGET_ID, 1)) break;
+            const group = createBuoyMesh();
+            group.position.set(baseX + p.x, p.y, p.z ?? -6);
+            this.scene.add(group);
+            decorationBudget.reportSpawn(BUOY_BUDGET_ID, 1);
+            this.buoys.push({ group, consumed: false, hacked: false, sequence: null });
+        }
+    }
+
+    /** Gentle idle animation for the dock ring + band glow. */
+    update(delta: number): void {
+        const t = performance.now() * 0.001;
+        for (const b of this.buoys) {
+            b.group.rotation.y += delta * 0.3;
+            b.group.children.forEach(child => {
+                if (!(child instanceof THREE.Mesh)) return;
+                if (child.userData.isDock) {
+                    child.rotation.z += delta * 0.5;
+                    const consumed = b.consumed;
+                    (child.material as THREE.MeshBasicMaterial).opacity =
+                        consumed ? 0.12 : 0.3 + Math.sin(t * 2) * 0.12;
+                } else if (child.userData.isBand) {
+                    (child.material as THREE.MeshBasicMaterial).opacity =
+                        b.consumed ? 0.3 : 0.6 + Math.sin(t * 3) * 0.25;
+                }
+            });
+        }
+    }
+
+    /** Nearest un-consumed buoy whose dock the player is inside, else null. */
+    getDockableBuoy(playerPos: THREE.Vector3): DerelictBuoyInstance | null {
+        let best: DerelictBuoyInstance | null = null;
+        let bestDist = BUOY_DOCK_RADIUS;
+        for (const b of this.buoys) {
+            if (b.consumed) continue;
+            const d = b.group.position.distanceTo(playerPos);
+            if (d <= bestDist) {
+                best = b;
+                bestDist = d;
+            }
+        }
+        return best;
+    }
+
+    /** True while the player remains inside the given buoy's dock radius. */
+    isInDock(buoy: DerelictBuoyInstance, playerPos: THREE.Vector3): boolean {
+        return buoy.group.position.distanceTo(playerPos) <= BUOY_DOCK_RADIUS + 0.5;
+    }
+}
+
+// --- Hack overlay UI ----------------------------------------------------------
+
+export interface BuoyHackCallbacks {
+    onSuccess: () => void;
+    onFail: () => void;
+    /** Fired when the player wants to abandon (Esc / out of dock). */
+    onAbort: () => void;
+    playMorse: (sequence: MorseSequence) => void;
+    playBlip: (correct: boolean) => void;
+}
+
+export interface BuoyHackHandle {
+    element: HTMLDivElement;
+    /** Advance the (extraction) timer; call each frame. */
+    update: (delta: number) => void;
+    /** Force-close (e.g. player left dock). */
+    close: () => void;
+    /** Feed a decoded symbol from keyboard/touch. */
+    input: (symbol: MorseSymbol) => void;
+}
+
+type BuoyPhase = 'listen' | 'decode' | 'extraction' | 'done';
+
+/**
+ * Builds and returns the buoy hack overlay. The caller is responsible for
+ * appending element to the DOM and calling update()/input() each frame, and
+ * removing it via close() or after a callback fires.
+ */
+export function createBuoyHackUI(
+    sequence: MorseSequence,
+    callbacks: BuoyHackCallbacks
+): BuoyHackHandle {
+    const overlay = createHackOverlay();
+    const panel = createHackPanel();
+    overlay.appendChild(panel);
+
+    let phase: BuoyPhase = 'listen';
+    let inputIndex = 0;
+
+    const session = new HackSession({
+        maxMistakes: BUOY_MAX_MISTAKES,
+        timeLimit: 0, // extraction timer is handled as its own phase
+        onSuccess: () => {},
+        onFail: () => {}
+    });
+
+    let extractionLeft = BUOY_EXTRACTION_TIME;
+
+    const render = () => {
+        if (phase === 'listen') {
+            panel.innerHTML = `
+                <div style="font-size:1.4em;color:${HACK_ACCENT};margin-bottom:8px;">\u{1F4E1} Derelict Buoy</div>
+                <div style="font-size:1em;color:#cfe6f5;margin-bottom:14px;">Incoming transmission…</div>
+                <div style="font-size:2.4em;letter-spacing:6px;color:${HACK_ACCENT_GOOD};min-height:1.4em;">${sequence.display}</div>
+                <div style="font-size:0.9em;color:#8fb;margin-top:16px;">Listen, then decode:
+                    <br><b>Up</b> / tap · = dot &nbsp;&nbsp; <b>Down</b> / tap – = dash</div>
+            `;
+        } else if (phase === 'decode') {
+            const progress = sequence.symbols
+                .map((s, i) => {
+                    const done = i < inputIndex;
+                    const char = s === 'dash' ? '–' : '·';
+                    const color = done ? HACK_ACCENT_GOOD : '#44576a';
+                    return `<span style="color:${color};font-size:2em;letter-spacing:4px;">${char}</span>`;
+                })
+                .join('');
+            panel.innerHTML = `
+                <div style="font-size:1.3em;color:${HACK_ACCENT};margin-bottom:6px;">Decode the signal</div>
+                <div style="min-height:1.6em;margin:12px 0;">${progress}</div>
+                <div style="margin:12px 0;">${renderMistakePips(session.mistakesRemaining, BUOY_MAX_MISTAKES)}</div>
+                <div style="display:flex;gap:14px;justify-content:center;margin-top:14px;">
+                    <button data-sym="dot" style="flex:1;max-width:150px;padding:16px;font-size:1.6em;background:rgba(51,224,255,0.15);border:2px solid ${HACK_ACCENT};border-radius:10px;color:#eaf6ff;cursor:pointer;">· dot</button>
+                    <button data-sym="dash" style="flex:1;max-width:150px;padding:16px;font-size:1.6em;background:rgba(51,224,255,0.15);border:2px solid ${HACK_ACCENT};border-radius:10px;color:#eaf6ff;cursor:pointer;">– dash</button>
+                </div>
+            `;
+            panel.querySelectorAll('button[data-sym]').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    handleInput((btn as HTMLElement).dataset.sym as MorseSymbol);
+                });
+            });
+        } else if (phase === 'extraction') {
+            panel.innerHTML = `
+                <div style="font-size:1.3em;color:${HACK_ACCENT_WARN};margin-bottom:8px;">⚠ Extracting data</div>
+                <div style="font-size:0.95em;color:#ffd7a0;margin-bottom:10px;">Shields down · thrusters at 30% · hold position!</div>
+                <div style="font-size:3.4em;color:${HACK_ACCENT_GOOD};font-weight:bold;">${Math.ceil(extractionLeft)}</div>
+            `;
+        }
+    };
+
+    const finish = (success: boolean) => {
+        if (phase === 'done') return;
+        phase = 'done';
+        cleanup();
+        if (success) callbacks.onSuccess();
+        else callbacks.onFail();
+    };
+
+    const handleInput = (symbol: MorseSymbol) => {
+        if (phase !== 'decode' || session.isFinished) return;
+        const expected = sequence.symbols[inputIndex];
+        if (symbol === expected) {
+            inputIndex++;
+            callbacks.playBlip(true);
+            if (inputIndex >= sequence.symbols.length) {
+                // Correct code → begin extraction.
+                phase = 'extraction';
+                extractionLeft = BUOY_EXTRACTION_TIME;
+            }
+            render();
+        } else {
+            callbacks.playBlip(false);
+            session.registerMistake();
+            if (session.isFinished) {
+                finish(false);
+            } else {
+                render();
+            }
+        }
+    };
+
+    const keyHandler = (e: KeyboardEvent) => {
+        if (e.code === 'ArrowUp' || e.code === 'KeyW') {
+            e.preventDefault(); e.stopPropagation();
+            handleInput('dot');
+        } else if (e.code === 'ArrowDown' || e.code === 'KeyS') {
+            e.preventDefault(); e.stopPropagation();
+            handleInput('dash');
+        } else if (e.code === 'Escape') {
+            e.preventDefault(); e.stopPropagation();
+            cleanup();
+            if (phase !== 'done') {
+                phase = 'done';
+                callbacks.onAbort();
+            }
+        }
+    };
+
+    const cleanup = () => {
+        window.clearTimeout(listenTimeout);
+        window.removeEventListener('keydown', keyHandler, true);
+    };
+
+    // Kick off the audio transmission, then switch to decode after it plays.
+    callbacks.playMorse(sequence);
+    render();
+    const listenMs = sequence.symbols.length * 500 + 900;
+    const listenTimeout = window.setTimeout(() => {
+        if (phase === 'listen') {
+            phase = 'decode';
+            render();
+        }
+    }, listenMs);
+    window.addEventListener('keydown', keyHandler, true);
+
+    return {
+        element: overlay,
+        update: (delta: number) => {
+            if (phase === 'extraction') {
+                extractionLeft -= delta;
+                if (extractionLeft <= 0) {
+                    finish(true);
+                } else {
+                    render();
+                }
+            }
+        },
+        input: handleInput,
+        close: () => {
+            cleanup();
+            if (phase !== 'done') {
+                phase = 'done';
+                callbacks.onAbort();
+            }
+        }
+    };
+}

--- a/src/discovery_system.ts
+++ b/src/discovery_system.ts
@@ -21,6 +21,8 @@ export const SPECIES_NAMES: Record<string, string> = {
     iceNeedleCluster: 'Ice Needle Cluster',
     gravityAnchor: 'Gravity Anchor',
     gravLens: 'Grav-Lens',
+    derelictBuoy: 'Derelict Buoy',
+    dataMonolith: 'Data Monolith',
     sporeCloud: 'Spore Cloud',
     vacuumKelp: 'Vacuum Kelp',
     liquidMetalBlob: 'Liquid Metal Blob',

--- a/src/game_config.ts
+++ b/src/game_config.ts
@@ -51,7 +51,10 @@ export const playerState = {
     vineBleedDps: 0,
     penguinSlideAssistTimer: 0,
     gravLensBoostTimer: 0,
-    gravLensBoostMultiplier: 1
+    gravLensBoostMultiplier: 1,
+    // Artifact hacking (Derelict Buoy extraction): shields drop, thruster to 30%.
+    hackExtractionTimer: 0,
+    hackThrusterEfficiency: 1
 };
 
 export let isGamePaused = false;

--- a/src/game_systems.ts
+++ b/src/game_systems.ts
@@ -35,6 +35,8 @@ import type { IndustrialBackgroundSystem } from './industrial_background';
 import type { CosmicDustSystem } from './cosmic_dust';
 import type { BlackHoleSystem } from './black_hole';
 import { GravLensManager } from './grav_lens';
+import { DerelictBuoyManager } from './derelict_buoy';
+import { DataMonolithManager } from './data_monolith';
 import type { BiologicalBackgroundSystem } from './biological_background';
 import type { LiquidMetalSystem } from './geological';
 import type { BossManager } from './boss_system';
@@ -283,6 +285,8 @@ export const crystalChimeManager = new CrystalChimeManager(scene, particleSystem
 
 export let blackHoleSystem: BlackHoleSystem = createBlackHoleSystemStub();
 export const gravLensManager = new GravLensManager(scene);
+export const derelictBuoyManager = new DerelictBuoyManager(scene);
+export const dataMonolithManager = new DataMonolithManager(scene);
 
 export type LevelEnvironmentSystemExports = {
     reEntrySystem: ReEntrySystem;

--- a/src/hacking_minigame.ts
+++ b/src/hacking_minigame.ts
@@ -1,0 +1,161 @@
+/**
+ * Hacking Minigame — shared framework for the Artifacts systems (plan §III).
+ *
+ * Both the Derelict Buoy (Morse decode) and the Data Monolith (circuitry trace)
+ * build on this: a timer, a mistake counter with a fail threshold, and
+ * success/fail callbacks. The concrete minigames own their DOM/3D presentation;
+ * this module owns the shared session bookkeeping and a couple of styling
+ * helpers so the overlays read as one system.
+ */
+
+export interface HackSessionOptions {
+    /** Max wrong inputs before the hack fails and the alarm trips. */
+    maxMistakes: number;
+    /** Optional countdown in seconds. 0 / undefined = no time pressure. */
+    timeLimit?: number;
+    onSuccess: () => void;
+    onFail: (reason: HackFailReason) => void;
+    /** Fired whenever the mistake count changes (for HUD/particle feedback). */
+    onMistake?: (mistakes: number, remaining: number) => void;
+    /** Fired once per second while a time limit is running. */
+    onTick?: (secondsLeft: number) => void;
+}
+
+export type HackFailReason = 'mistakes' | 'timeout' | 'aborted';
+
+/**
+ * Tracks the live state of a single hack attempt. Presentation-agnostic: the
+ * concrete minigame drives it via registerMistake()/succeed() and reads the
+ * getters for rendering. update(delta) advances the optional timer.
+ */
+export class HackSession {
+    private readonly options: HackSessionOptions;
+    private mistakes = 0;
+    private timeLeft: number;
+    private tickAccumulator = 0;
+    private finished = false;
+
+    constructor(options: HackSessionOptions) {
+        this.options = options;
+        this.timeLeft = options.timeLimit ?? 0;
+    }
+
+    get isFinished(): boolean {
+        return this.finished;
+    }
+
+    get mistakeCount(): number {
+        return this.mistakes;
+    }
+
+    get mistakesRemaining(): number {
+        return Math.max(0, this.options.maxMistakes - this.mistakes);
+    }
+
+    get secondsLeft(): number {
+        return Math.max(0, Math.ceil(this.timeLeft));
+    }
+
+    get hasTimeLimit(): boolean {
+        return (this.options.timeLimit ?? 0) > 0;
+    }
+
+    /** Advance the optional countdown. Returns true while the session is live. */
+    update(delta: number): boolean {
+        if (this.finished || !this.hasTimeLimit) return !this.finished;
+
+        this.timeLeft -= delta;
+        this.tickAccumulator += delta;
+        if (this.tickAccumulator >= 1) {
+            this.tickAccumulator -= 1;
+            this.options.onTick?.(this.secondsLeft);
+        }
+
+        if (this.timeLeft <= 0) {
+            this.fail('timeout');
+        }
+        return !this.finished;
+    }
+
+    /** Record a wrong input. Fails the hack once the threshold is crossed. */
+    registerMistake(): void {
+        if (this.finished) return;
+        this.mistakes++;
+        this.options.onMistake?.(this.mistakes, this.mistakesRemaining);
+        if (this.mistakes >= this.options.maxMistakes) {
+            this.fail('mistakes');
+        }
+    }
+
+    succeed(): void {
+        if (this.finished) return;
+        this.finished = true;
+        this.options.onSuccess();
+    }
+
+    fail(reason: HackFailReason): void {
+        if (this.finished) return;
+        this.finished = true;
+        this.options.onFail(reason);
+    }
+
+    /** Player left the dock / cancelled before completing. */
+    abort(): void {
+        this.fail('aborted');
+    }
+}
+
+// --- Shared overlay styling ---------------------------------------------------
+
+export const HACK_ACCENT = '#33e0ff';
+export const HACK_ACCENT_WARN = '#ff5577';
+export const HACK_ACCENT_GOOD = '#66ffaa';
+
+/** Full-screen dim backdrop container shared by both hack overlays. */
+export function createHackOverlay(): HTMLDivElement {
+    const overlay = document.createElement('div');
+    overlay.style.cssText = `
+        position: fixed;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        z-index: 1200;
+        background: radial-gradient(circle at 50% 40%, rgba(8,16,32,0.72), rgba(2,4,10,0.92));
+        font-family: 'Segoe UI', sans-serif;
+        color: #eaf6ff;
+        user-select: none;
+        -webkit-user-select: none;
+    `;
+    return overlay;
+}
+
+/** Consistent framed panel used inside the overlay. */
+export function createHackPanel(): HTMLDivElement {
+    const panel = document.createElement('div');
+    panel.style.cssText = `
+        background: rgba(10, 20, 34, 0.92);
+        border: 2px solid ${HACK_ACCENT};
+        border-radius: 14px;
+        box-shadow: 0 0 40px rgba(51, 224, 255, 0.25), inset 0 0 24px rgba(51, 224, 255, 0.08);
+        padding: 22px 26px;
+        max-width: 520px;
+        width: 92%;
+        text-align: center;
+    `;
+    return panel;
+}
+
+/** Renders a compact "mistakes remaining" pip row (shared by both minigames). */
+export function renderMistakePips(remaining: number, total: number): string {
+    let pips = '';
+    for (let i = 0; i < total; i++) {
+        const alive = i < remaining;
+        pips += `<span style="display:inline-block;width:12px;height:12px;margin:0 3px;border-radius:50%;
+            background:${alive ? HACK_ACCENT_GOOD : 'transparent'};
+            border:2px solid ${alive ? HACK_ACCENT_GOOD : HACK_ACCENT_WARN};
+            box-shadow:${alive ? '0 0 8px ' + HACK_ACCENT_GOOD : 'none'};"></span>`;
+    }
+    return pips;
+}

--- a/src/level_config.ts
+++ b/src/level_config.ts
@@ -72,6 +72,23 @@ export type GravLensCorridorConfig = {
     lenses: GravLensPlacement[];
 };
 
+/** Derelict Buoy artifact placement (Morse hack, levels 4–5). */
+export type DerelictBuoyConfig = {
+    /** X offset from the player's position when the level starts. */
+    x: number;
+    y: number;
+    z?: number;
+};
+
+/** Data Monolith artifact placement (trace hack, levels 4–5). */
+export type DataMonolithConfig = {
+    x: number;
+    y: number;
+    z?: number;
+    /** Difficulty tier 1–3 (defaults to 1). */
+    tier?: 1 | 2 | 3;
+};
+
 export type LevelEnvironments = {
     butterflySwarm?: boolean;
     blackHole?: BlackHoleEnvironmentConfig;
@@ -193,6 +210,10 @@ export type LevelConfig = {
     environments?: LevelEnvironments;
     /** Optional chained grav-lens slingshot corridors. */
     gravLensCorridors?: GravLensCorridorConfig[];
+    /** Derelict Buoy artifacts (Morse hack) — industrial zones L4–L5. */
+    derelictBuoys?: DerelictBuoyConfig[];
+    /** Data Monolith artifacts (trace hack) — industrial zones L4–L5. */
+    dataMonoliths?: DataMonolithConfig[];
 };
 
 export const LEVEL_CONFIG: { [key: number]: LevelConfig } = {
@@ -436,7 +457,14 @@ export const LEVEL_CONFIG: { [key: number]: LevelConfig } = {
         vignettes: {
             treeGroves: 0.6,
             roseArches: 0.5
-        }
+        },
+        // Artifacts (plan §III): 1 buoy + 1 tier-1 monolith in the industrial run.
+        derelictBuoys: [
+            { x: 320, y: 6, z: -6 }
+        ],
+        dataMonoliths: [
+            { x: 520, y: 4, z: -8, tier: 1 }
+        ]
     },
     5: {
         name: "The Astral Leviathan",
@@ -503,7 +531,16 @@ export const LEVEL_CONFIG: { [key: number]: LevelConfig } = {
             treeGroves: 0.8,
             roseArches: 0.6,
             geodeClearings: 0.4
-        }
+        },
+        // Artifacts (plan §III): 2 buoys + 2 monoliths (mixed tiers) deeper in.
+        derelictBuoys: [
+            { x: 280, y: 7, z: -6 },
+            { x: 700, y: 4, z: -7 }
+        ],
+        dataMonoliths: [
+            { x: 440, y: 5, z: -8, tier: 1 },
+            { x: 860, y: 6, z: -9, tier: 2 }
+        ]
     },
     6: {
         name: "The Aqua Expanse",

--- a/src/main/artifact_update.ts
+++ b/src/main/artifact_update.ts
@@ -1,0 +1,254 @@
+/**
+ * Artifacts orchestration (plan §III): Derelict Buoys + Data Monoliths.
+ *
+ * Handles per-frame idle animation, proximity-triggered hacks, the paused hack
+ * overlay lifecycle (driven by a local rAF ticker so the world stays frozen),
+ * and reward/penalty application (map fragments, Architect lore, alarm).
+ */
+
+import * as THREE from 'three';
+import { player } from '../player_loader';
+import { playerState, setIsGamePaused } from '../game_config';
+import { game } from '../game_runtime';
+import { derelictBuoyManager, dataMonolithManager } from '../game_systems';
+import { ShakeType } from '../juice_effects';
+import { DogAnimationState } from '../dog_cockpit';
+import {
+    generateMorseSequence, createBuoyHackUI, type DerelictBuoyInstance, type BuoyHackHandle
+} from '../derelict_buoy';
+import {
+    createMonolithPuzzle, createMonolithHackUI, type DataMonolithInstance, type MonolithHackHandle
+} from '../data_monolith';
+import {
+    nextArchitectLoreId, ARCHITECT_LORE, hasFullArchitectSet,
+    createLoreRevealUI
+} from '../architect_lore';
+import type { LevelConfig } from '../level_config';
+
+// Fragments needed to reveal the "Lost Sector" (plan §III).
+const LOST_SECTOR_FRAGMENTS = 3;
+// Quantum Compass unlocks once the buoy network is well-mapped.
+const QUANTUM_COMPASS_FRAGMENTS = 5;
+
+interface ActiveHack {
+    handle: BuoyHackHandle | MonolithHackHandle;
+    tickerId: number | null;
+    lastTick: number;
+}
+
+let activeHack: ActiveHack | null = null;
+// Buoys/monoliths become "armed" while the player is outside their radius, so a
+// hack fires on entry (not continuously) and can be retried after leaving.
+const armed = new Set<string>();
+
+function startTicker(): void {
+    if (!activeHack) return;
+    activeHack.lastTick = performance.now();
+    const step = (now: number) => {
+        if (!activeHack) return;
+        const dt = Math.min((now - activeHack.lastTick) / 1000, 0.1);
+        activeHack.lastTick = now;
+        activeHack.handle.update(dt);
+        if (activeHack) activeHack.tickerId = requestAnimationFrame(step);
+    };
+    activeHack.tickerId = requestAnimationFrame(step);
+}
+
+function endHack(): void {
+    if (activeHack) {
+        if (activeHack.tickerId != null) cancelAnimationFrame(activeHack.tickerId);
+        activeHack.handle.element.remove();
+        activeHack = null;
+    }
+    playerState.hackExtractionTimer = 0;
+    playerState.hackThrusterEfficiency = 1;
+    setIsGamePaused(false);
+}
+
+function beginBuoyHack(buoy: DerelictBuoyInstance): void {
+    if (activeHack) return;
+    setIsGamePaused(true);
+    const sequence = generateMorseSequence();
+    buoy.sequence = sequence;
+
+    const handle = createBuoyHackUI(sequence, {
+        playMorse: (seq) => {
+            let offset = 0;
+            for (const letter of seq.letters) {
+                for (const sym of letter) {
+                    game.audioSystem.playMorseSymbol(sym === 'dash', offset);
+                    offset += (sym === 'dash' ? 0.6 : 0.2) + 0.15;
+                }
+                offset += 0.3; // inter-letter gap
+            }
+        },
+        playBlip: (correct) => game.audioSystem.playHackBlip(correct),
+        onSuccess: () => {
+            buoy.consumed = true;
+            buoy.hacked = true;
+            endHack();
+            game.audioSystem.playHackSuccess();
+            game.dogController.triggerAnimation(DogAnimationState.DELIGHTED, 1.2);
+            game.juiceManager.flashWhite(0.12);
+            game.particleSystem.emit(buoy.group.position, 0x33e0ff, 24, 5, 0.9);
+
+            const fragments = game.saveManager.addMapFragment(1);
+            game.juiceManager.showFloatingText(
+                `\u{1F5FA}️ Map Fragment (${fragments})`, buoy.group.position.clone(), '#66ffaa', 26
+            );
+            if (fragments === LOST_SECTOR_FRAGMENTS) {
+                game.juiceManager.showFloatingText(
+                    'Lost Sector revealed!', player!.position.clone(), '#ffd76a', 24
+                );
+            }
+            if (fragments >= QUANTUM_COMPASS_FRAGMENTS && game.saveManager.unlockQuantumCompass()) {
+                game.juiceManager.showFloatingText(
+                    '\u{1F9ED} Quantum Compass online!', player!.position.clone(), '#33e0ff', 24
+                );
+            }
+        },
+        onFail: () => {
+            endHack();
+            triggerAlarm(buoy.group.position);
+        },
+        onAbort: () => {
+            endHack();
+        }
+    });
+
+    activeHack = { handle, tickerId: null, lastTick: performance.now() };
+    document.body.appendChild(handle.element);
+    startTicker();
+}
+
+function triggerAlarm(position: THREE.Vector3): void {
+    game.audioSystem.playHackFail();
+    game.audioSystem.playHackAlarm();
+    game.juiceManager.shakeScreen(ShakeType.HEAVY, 0.4);
+    game.dogController.triggerAnimation(DogAnimationState.HIT, 0.7);
+    game.juiceManager.showFloatingText('⚠ Hack failed — alarm!', position.clone(), '#ff5577', 26);
+}
+
+function beginMonolithHack(monolith: DataMonolithInstance): void {
+    if (activeHack) return;
+    setIsGamePaused(true);
+    const puzzle = createMonolithPuzzle(monolith.tier);
+
+    const handle = createMonolithHackUI(puzzle, {
+        playBlip: (correct) => game.audioSystem.playHackBlip(correct),
+        onSuccess: () => {
+            monolith.consumed = true;
+            endHack();
+            game.audioSystem.playHackSuccess();
+            game.dogController.triggerAnimation(DogAnimationState.DELIGHTED, 1.2);
+            game.particleSystem.emit(monolith.group.position, 0x9be7ff, 24, 5, 0.9);
+            awardMonolithReward(monolith);
+        },
+        onFail: () => {
+            endHack();
+            triggerAlarm(monolith.group.position);
+        },
+        onAbort: () => {
+            endHack();
+        }
+    });
+
+    activeHack = { handle, tickerId: null, lastTick: performance.now() };
+    document.body.appendChild(handle.element);
+    startTicker();
+}
+
+function awardMonolithReward(monolith: DataMonolithInstance): void {
+    const unlocked = game.saveManager.getArchitectLore();
+    const loreId = nextArchitectLoreId(unlocked);
+
+    // Tier bonuses on top of the lore entry (plan §III).
+    if (monolith.tier >= 2) {
+        const frags = game.saveManager.addMapFragment(1);
+        game.juiceManager.showFloatingText(`Blueprint fragment (${frags})`, monolith.group.position.clone(), '#aa66ff', 22);
+    }
+    if (monolith.tier >= 3) {
+        playerState.cores += 25;
+        game.juiceManager.showFloatingText('+25 cores', monolith.group.position.clone(), '#ffd76a', 22);
+    }
+
+    if (!loreId) {
+        // All lore already decoded — still acknowledge the solve.
+        game.juiceManager.showFloatingText('Monolith re-scanned', monolith.group.position.clone(), '#9be7ff', 22);
+        return;
+    }
+
+    game.saveManager.unlockArchitectLore(loreId);
+    const entry = ARCHITECT_LORE[loreId];
+    const nowUnlocked = game.saveManager.getArchitectLore();
+    const hasKey = hasFullArchitectSet(nowUnlocked);
+
+    // Lore reveal is a paused modal; restore play only when dismissed.
+    setIsGamePaused(true);
+    const modal = createLoreRevealUI(entry, nowUnlocked.length, hasKey, () => {
+        setIsGamePaused(false);
+        if (hasKey) {
+            game.juiceManager.showFloatingText('\u{1F511} Architect’s Key assembled!', player!.position.clone(), '#ffd76a', 26);
+        }
+    });
+    document.body.appendChild(modal);
+}
+
+/** Spawns the artifacts declared by a level config. Call on level start. */
+export function spawnArtifactsForLevel(cfg: LevelConfig, baseX: number): void {
+    derelictBuoyManager.clear();
+    dataMonolithManager.clear();
+    armed.clear();
+    if (cfg.derelictBuoys?.length) {
+        derelictBuoyManager.spawnForLevel(cfg.derelictBuoys, baseX);
+    }
+    if (cfg.dataMonoliths?.length) {
+        dataMonolithManager.spawnForLevel(cfg.dataMonoliths, baseX);
+    }
+}
+
+/** Per-frame update: idle animation + proximity-triggered hacks. */
+export function updateArtifacts(delta: number): void {
+    // While a hack overlay is up the world is paused, so this won't be reached;
+    // the local rAF ticker drives the overlay instead.
+    if (activeHack || !player) return;
+    if (!derelictBuoyManager.hasBuoys() && !dataMonolithManager.hasMonoliths()) return;
+
+    derelictBuoyManager.update(delta);
+    dataMonolithManager.update(delta);
+
+    // Buoys — arm on exit, trigger on entry.
+    for (const buoy of derelictBuoyManager.getBuoys()) {
+        const id = buoy.uuid;
+        const inDock = buoy.position.distanceTo(player.position) <= 3.0;
+        if (!inDock) { armed.add(id); continue; }
+        if (armed.has(id)) {
+            armed.delete(id);
+            const inst = derelictBuoyManager.getDockableBuoy(player.position);
+            if (inst && inst.group.uuid === id && !inst.consumed) {
+                beginBuoyHack(inst);
+                return;
+            }
+        }
+    }
+
+    // Monoliths — arm on exit, trigger on entry.
+    for (const slab of dataMonolithManager.getScannables()) {
+        const id = slab.uuid;
+        const inRange = slab.position.distanceTo(player.position) <= 5.0;
+        if (!inRange) { armed.add(id); continue; }
+        if (armed.has(id)) {
+            armed.delete(id);
+            const inst = dataMonolithManager.getInteractable(player.position);
+            if (inst && inst.group.uuid === id && !inst.consumed) {
+                beginMonolithHack(inst);
+                return;
+            }
+        }
+    }
+}
+
+/** True while a hack overlay is active (for input routing / gating). */
+export function isHackActive(): boolean {
+    return activeHack != null;
+}

--- a/src/main/input_bindings.ts
+++ b/src/main/input_bindings.ts
@@ -6,6 +6,7 @@ import { game } from '../game_runtime';
 import { sporeClouds } from '../environment';
 import { createUI, setupKeyboardControls } from '../ui_controls';
 import { createBestiaryUI } from '../bestiary';
+import { createArchitectCodexUI } from '../architect_lore';
 import {
     createHeatBar, createBoostDisplay, createRollDisplay,
     createTetherDisplay, createCoresDisplay
@@ -27,6 +28,8 @@ export let lastLeftTapTime = 0;
 export let lastRightTapTime = 0;
 export let tetherKeyHeld = false;
 export let tetherMouseHeld = false;
+
+let architectCodexUI: HTMLDivElement | null = null;
 
 const instructions = document.getElementById('instructions');
 
@@ -97,6 +100,20 @@ export function setupInputBindings(): void {
                     setIsGamePaused(false);
                 });
                 document.body.appendChild(game.bestiaryUI);
+            }
+        }
+        if (e.code === 'KeyK') {
+            if (architectCodexUI) {
+                architectCodexUI.remove();
+                architectCodexUI = null;
+                setIsGamePaused(false);
+            } else {
+                setIsGamePaused(true);
+                architectCodexUI = createArchitectCodexUI(game.saveManager, () => {
+                    architectCodexUI = null;
+                    setIsGamePaused(false);
+                });
+                document.body.appendChild(architectCodexUI);
             }
         }
         if (e.code === 'KeyR') {

--- a/src/main/loop_world.ts
+++ b/src/main/loop_world.ts
@@ -22,7 +22,8 @@ import {
 import { updateCamera } from './camera_system';
 import { updateShadowQuality, updateShadowCulling } from './render_helpers';
 import { updateGravLensSystems } from './grav_lens_update';
-import { gravLensManager } from '../game_systems';
+import { updateArtifacts } from './artifact_update';
+import { gravLensManager, derelictBuoyManager, dataMonolithManager } from '../game_systems';
 export function updateLoopWorld(delta: number, time: number): void {
         // "Path to the Moon" gate animates independently of the planet horizon
         game.planetaryHorizonSystem.updateMoonGate(delta);
@@ -88,6 +89,11 @@ export function updateLoopWorld(delta: number, time: number): void {
         if (player) {
             updateGravLensSystems(delta);
         }
+
+        // Artifacts — Derelict Buoys + Data Monoliths (levels 4–5)
+        if (player) {
+            updateArtifacts(delta);
+        }
     
         // Update Level Manager (and Clouds)
         if (player) {
@@ -102,6 +108,8 @@ export function updateLoopWorld(delta: number, time: number): void {
                 ...gravityAnchors,
                 ...liquidMetalBlobs,
                 ...gravLensManager.getScannables(),
+                ...derelictBuoyManager.getScannables(),
+                ...dataMonolithManager.getScannables(),
             ];
             game.discoveryManager.update(player.position, [
                 ...game.levelManager.levelObjects,

--- a/src/main/startup.ts
+++ b/src/main/startup.ts
@@ -25,6 +25,7 @@ import { SlingObjectiveManager } from '../sling_objective';
 import { SlingComboManager } from '../sling_combo';
 import { TetherSystem } from '../tether_system';
 import { spawnGravLensCorridorsForLevel } from './grav_lens_update';
+import { spawnArtifactsForLevel } from './artifact_update';
 import { DebugSystem } from '../debug_system';
 import { decorationBudget, registerDefaultDecorationBudgets } from '../decoration_budget';
 import { createGalaxy, createMoon } from '../visuals';
@@ -230,6 +231,7 @@ function createLevelManager(industrialGeometryManager: IndustrialGeometryManager
             game.friendsManager.resetLevelLemurCap();
             game.toyRocketSpawnManager.spawnForLevel(game.levelManager.currentLevel, cfg);
             spawnGravLensCorridorsForLevel(game.levelManager.currentLevel, cfg);
+            spawnArtifactsForLevel(cfg, player?.position.x ?? 0);
             game.wrenchChargeAvailable = saveManager.hasMemory('mine_robot');
             game.slingObjectiveManager.reset(cfg.objective?.type === 'sling' ? cfg.objective.target : 0);
             if (cfg.objective?.type === 'scan') {

--- a/src/save_manager.ts
+++ b/src/save_manager.ts
@@ -25,6 +25,12 @@ export interface SaveData {
     unlockedLevels: number[];
     discoveredSpecies: string[];
     catalogedCreatures: string[];
+    /** Data Monolith lore ids decoded (see architect_lore.ts). */
+    architectLoreUnlocked: string[];
+    /** Derelict Buoy map fragments collected (persist across runs). */
+    mapFragments: number;
+    /** Quantum Compass HUD upgrade unlocked (full buoy network decoded). */
+    quantumCompassUnlocked: boolean;
     version: string;
 }
 
@@ -81,6 +87,9 @@ export class SaveManager {
             unlockedLevels: [1],
             discoveredSpecies: [],
             catalogedCreatures: [],
+            architectLoreUnlocked: [],
+            mapFragments: 0,
+            quantumCompassUnlocked: false,
             version: CURRENT_VERSION
         };
     }
@@ -217,6 +226,47 @@ export class SaveManager {
     /** True if this creature has been cataloged (its "memory" bonus is active). */
     hasMemory(creatureId: string): boolean {
         return (this.data.catalogedCreatures || []).includes(creatureId);
+    }
+
+    // --- Artifacts: Data Monolith lore (The Architects) ---
+    getArchitectLore(): string[] {
+        return [...(this.data.architectLoreUnlocked || [])];
+    }
+
+    /** Decodes a monolith lore entry. Returns true the first time ever. */
+    unlockArchitectLore(loreId: string): boolean {
+        if (!this.data.architectLoreUnlocked) this.data.architectLoreUnlocked = [];
+        if (this.data.architectLoreUnlocked.includes(loreId)) return false;
+        this.data.architectLoreUnlocked.push(loreId);
+        this.save();
+        return true;
+    }
+
+    hasArchitectLore(loreId: string): boolean {
+        return (this.data.architectLoreUnlocked || []).includes(loreId);
+    }
+
+    // --- Artifacts: Derelict Buoy map fragments + Quantum Compass ---
+    getMapFragments(): number {
+        return this.data.mapFragments || 0;
+    }
+
+    addMapFragment(amount = 1): number {
+        this.data.mapFragments = (this.data.mapFragments || 0) + amount;
+        this.save();
+        return this.data.mapFragments;
+    }
+
+    hasQuantumCompass(): boolean {
+        return this.data.quantumCompassUnlocked === true;
+    }
+
+    /** Unlocks the permanent Quantum Compass HUD upgrade. True the first time. */
+    unlockQuantumCompass(): boolean {
+        if (this.data.quantumCompassUnlocked) return false;
+        this.data.quantumCompassUnlocked = true;
+        this.save();
+        return true;
     }
 
     // Level unlocks


### PR DESCRIPTION
## Summary

Implements the plan §III **Artifacts & Anomalies** risk/reward systems: **Derelict Buoys** (Morse-decode hack) and **Data Monoliths** (circuitry-trace hack), plus a shared hacking framework and the "The Architects" lore/progression layer.

## What's included

**Shared framework — `hacking_minigame.ts`**
- `HackSession`: timer, mistake counter with a fail threshold, and success/fail callbacks. Shared overlay/panel/mistake-pip styling so both minigames read as one system.

**Derelict Buoys — `derelict_buoy.ts`**
- 3D buoy prop with a floating data-dock ring; Morse sequence generator (3–7 letter words, 440 Hz, 200 ms dot / 600 ms dash); dock-radius check.
- Flow: hear Morse transmission → decode with **Up = dot / Down = dash** (or tap) → **5 s extraction countdown** → map-fragment reward. Three mistakes fail the hack and trip an alarm.
- Map fragments persist across runs; reveal the Lost Sector (3) and unlock the Quantum Compass (5).

**Data Monoliths — `data_monolith.ts`**
- 3D slab prop and a circuitry-trace puzzle across 3 difficulty tiers (grid size, firewall count, timer). Trace input → output with **arrows / WASD or tap**, avoiding moving firewalls. Paths are solvable by construction.
- Tiered rewards: Tier 1 lore entry, Tier 2 blueprint (map fragment), Tier 3 upgrade token (cores).

**The Architects — `architect_lore.ts`**
- Lore entries + per-monolith flora damage bonus (+5%), full-set Architect's Key check, a post-solve lore reveal, and an **Architect Codex** modal (`K`, sibling to the Weird Life Log bestiary).

**Persistence — `save_manager.ts`**
- `architectLoreUnlocked[]`, `mapFragments`, `quantumCompassUnlocked`, with lazily-defaulted getters so existing saves migrate without a wipe.

**Audio — `audio_system` `hacking_sounds` mixin**
- Procedural Morse tones, input blips, and success/fail/alarm stingers (no audio files).

**Integration**
- Managers instantiated in `game_systems`; per-frame proximity-triggered hacks in `main/artifact_update` (world pauses; a local rAF ticker drives the overlay); spawned 1–2 buoys + monoliths in L4–L5 industrial zones via `level_config`; hero decoration budgets registered; artifacts registered as scannables for the discovery catalog.

## Acceptance criteria

- [x] Buoy hack: hear Morse → input sequence → 5 s extraction countdown
- [x] Monolith Tier 1 completable with keyboard + touch
- [x] Lore entry shown after success (reveal modal + Architect Codex)

## Verification

- `npm run build` — production build succeeds (266 modules).
- `npm run test:smoke` — boot smoke test passes (WebGL/SwiftShader).
- Pure-logic checks: Morse generator (valid 3–7 letter codes), monolith puzzles (300/300 valid & solvable per tier), `HackSession` (mistake/timeout/success paths).
- End-to-end browser drive of both overlays: buoy `SIGNAL` transmit → decode → extraction countdown from "5" → success; 3 wrong inputs → alarm; monolith Tier 1 solved by **keyboard** and **touch**.
- Typecheck baseline re-synced (net **down**, 180 → 167); the six new modules add zero type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjbmcFACtvVVBuLwj7CaAK

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjbmcFACtvVVBuLwj7CaAK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Derelict Buoys with Morse-code hacking and timed extraction challenges.
  * Added Data Monoliths with tiered trace puzzles, firewalls, and interactive hacking overlays.
  * Added Architect lore discoveries, flora damage bonuses, completion rewards, and an in-game Codex accessible with **K**.
  * Added new synthesized audio feedback for hacking successes, failures, inputs, and alarms.
  * Added persistent map fragments and Quantum Compass progression.
  * Introduced new artifact placements across later levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->