### PR TITLE
Fix WaterfallSystem Integration

### DIFF
--- a/src/level_manager/manager.ts
+++ b/src/level_manager/manager.ts
@@ -323,7 +323,7 @@ export class LevelManager {
         const enabled = (name: string) => !dbg || dbg.isEnabled(name);
         const playerPos = this.getPlayer()?.position;
 
-        if (enabled('waterfall')) waterfallSystem.update(cameraX, delta, playerPos);
+        waterfallSystem.update(delta, cameraX, playerPos);
         if (enabled('industrial')) industrialSystem.update(cameraX, delta, playerPos);
         if (enabled('biological')) biologicalSystem.update(delta, cameraX);
         if (enabled('nebula') || enabled('nebulaRibbons') || enabled('cosmicDust')) {

--- a/src/main/loop_combat.ts
+++ b/src/main/loop_combat.ts
@@ -373,11 +373,11 @@ export function updateLoopCombat(_rawDelta: number, delta: number, time: number)
             const isAquaEnv = !!currentLevelCfg?.environments?.aquaticLife;
             if (isAquaEnv) {
                 if (game.aquaticLifeSpawnedLevel !== game.levelManager.currentLevel) {
-                    aquaticLifeManager.clear();
+                    game.aquaticLifeManager.clear();
                     game.aquaticLifeSpawnedLevel = game.levelManager.currentLevel;
                     game.whaleSongTimer = 30;
                     const cfgA = currentLevelCfg;
-                    aquaticLifeManager.spawnForLevel(player.position.x + 80, cfgA.distance - 200);
+                    game.aquaticLifeManager.spawnForLevel(player.position.x + 80, cfgA.distance - 200);
     
                     // Bubble-reef rescue friends feeding the final flotilla parade.
                     const reefFriends = game.friendsManager.spawnTrappedFriendsAlong(
@@ -386,7 +386,7 @@ export function updateLoopCombat(_rawDelta: number, delta: number, time: number)
                         3
                     );
                     for (const reefFriend of reefFriends) {
-                        aquaticLifeManager.spawnBubbleReef(reefFriend.position);
+                        game.aquaticLifeManager.spawnBubbleReef(reefFriend.position);
                     }
     
                     // Scatter seal pups through the aqua expanse
@@ -397,7 +397,7 @@ export function updateLoopCombat(_rawDelta: number, delta: number, time: number)
                     }
                 }
     
-                const aquaEvents = aquaticLifeManager.update(delta, player.position);
+                const aquaEvents = game.aquaticLifeManager.update(delta, player.position);
                 for (const ev of aquaEvents) {
                     if (ev.type === 'jellyfish') {
                         game.hudManager.addScore(15);
@@ -413,7 +413,7 @@ export function updateLoopCombat(_rawDelta: number, delta: number, time: number)
                         game.particleSystem.emit(ev.position.clone(), 0x99ffee, 14, 2.5, 1.2, 0.8);
                     }
                 }
-                aquaticLifeManager.cleanupFarBehind(player.position.x);
+                game.aquaticLifeManager.cleanupFarBehind(player.position.x);
     
                 // "Whale song" ambience - a slow procedural moan from the deep
                 game.whaleSongTimer -= delta;
@@ -422,7 +422,7 @@ export function updateLoopCombat(_rawDelta: number, delta: number, time: number)
                     game.audioSystem.playWhaleSong();
                 }
             } else if (game.aquaticLifeSpawnedLevel !== null) {
-                aquaticLifeManager.clear();
+                game.aquaticLifeManager.clear();
                 game.aquaticLifeSpawnedLevel = null;
             }
     
@@ -431,20 +431,20 @@ export function updateLoopCombat(_rawDelta: number, delta: number, time: number)
             if (shouldSpawnStarlightKoi(koiCfg?.environments, koiCfg?.koiSchoolDensity)) {
                 if (game.koiSpawnedLevel !== game.levelManager.currentLevel) {
                     game.koiSpawnedLevel = game.levelManager.currentLevel;
-                    starlightKoiManager.activate();
+                    game.starlightKoiManager.activate();
                     const koiSpan = getLevelSpan(game.levelManager.currentLevel);
-                    starlightKoiManager.spawnForLevel(
+                    game.starlightKoiManager.spawnForLevel(
                         koiSpan.startX + 60,
                         koiSpan.length - 120,
                         koiCfg!.koiSchoolDensity!
                     );
                 }
                 if (game.debugSystem.isEnabled('starlightKoi')) {
-                    starlightKoiManager.update(delta, camera.position.x, player.position);
-                    starlightKoiManager.cleanupFarBehind(player.position.x);
+                    game.starlightKoiManager.update(delta, camera.position.x, player.position);
+                    game.starlightKoiManager.cleanupFarBehind(player.position.x);
                 }
             } else if (game.koiSpawnedLevel !== null) {
-                starlightKoiManager.deactivate();
+                game.starlightKoiManager.deactivate();
                 game.koiSpawnedLevel = null;
             }
     
@@ -453,13 +453,13 @@ export function updateLoopCombat(_rawDelta: number, delta: number, time: number)
             if (shouldSpawnBubbleCoral(coralCfg?.environments, coralCfg?.bubbleCoralDensity)) {
                 if (game.coralSpawnedLevel !== game.levelManager.currentLevel) {
                     game.coralSpawnedLevel = game.levelManager.currentLevel;
-                    bubbleCoralManager.activate();
+                    game.bubbleCoralManager.activate();
                     const coralSpan = getLevelSpan(game.levelManager.currentLevel);
                     const clusterCount = resolveBubbleCoralClusterCount(
                         coralCfg!.bubbleCoralDensity!,
                         coralCfg!.environments?.bubbleCoral
                     );
-                    bubbleCoralManager.spawnForLevel(
+                    game.bubbleCoralManager.spawnForLevel(
                         coralSpan.startX + 50,
                         coralSpan.length - 100,
                         clusterCount,
@@ -467,11 +467,11 @@ export function updateLoopCombat(_rawDelta: number, delta: number, time: number)
                     );
                 }
                 if (game.debugSystem.isEnabled('bubbleCoral')) {
-                    bubbleCoralManager.update(delta, camera.position.x);
-                    bubbleCoralManager.cleanupFarBehind(player.position.x);
+                    game.bubbleCoralManager.update(delta, camera.position.x);
+                    game.bubbleCoralManager.cleanupFarBehind(player.position.x);
                 }
             } else if (game.coralSpawnedLevel !== null) {
-                bubbleCoralManager.deactivate();
+                game.bubbleCoralManager.deactivate();
                 game.coralSpawnedLevel = null;
             }
     

--- a/src/waterfall.ts
+++ b/src/waterfall.ts
@@ -645,7 +645,7 @@ export class WaterfallSystem {
         this.submersion.setIntensity(0.0);
     }
 
-    update(cameraX: number, delta: number = 0.016, playerPos?: THREE.Vector3) {
+    update(delta: number, cameraX: number, playerPos?: THREE.Vector3) {
         if (playerPos) {
             this.uPlayerPos.value.copy(playerPos);
         }


### PR DESCRIPTION
## 🌌 Architect: WaterfallSystem Integration Fix

### Concept
> "Diving Into Waterfalls and Vertical Water Sections: Combines vertical parallax scrolling with Mode 7-style pseudo-3D effects and particle layers. Water is rendered as multiple transparent layers moving at different speeds, with foreground spray effects that pass in front of the ship."

### Implementation
- Fixed the parameter order in `WaterfallSystem.update` from `(cameraX, delta)` to the standard Cosmic Architect pattern `(delta, cameraX, playerPos)`.
- Replaced the hardcoded external guard `if (enabled('waterfall'))` in `src/level_manager/manager.ts` so that `waterfallSystem.update` is correctly called unconditionally, relying on its internal `this.active` guard as per the architectural guidelines.
- Fixed scoping in `loop_combat.ts` to properly call missing `game.` prefixed systems (like `game.aquaticLifeManager`, `game.starlightKoiManager`, `game.bubbleCoralManager`) to pass the strict typescript verification.

### Visuals
- 3 waterfall parallax layers at distinct Z-depths (Z: -40, -20, +10) and scrolling speeds (0.2, 0.5, 0.8) with curvature to simulate Mode 7 drop-off.
- Multi-colored spray system `SplashSystem` with 300 droplets responsive to player glow and gravity.
- Dynamic SubmersionOverlay effect with varying Y intensity linked to player level progress.

### Integration
- `src/waterfall.ts`: Corrected `update` signature `(delta, cameraX, playerPos)`.
- `src/level_manager/manager.ts`: Line ~326 changed to unconditionally call `waterfallSystem.update(delta, cameraX, playerPos)`.
- `src/main/loop_combat.ts`: Fixed unreferenced manager variables.

### Testing
- [x] `npm run build` passes
- [x] Tested in Level 6 at `npm run dev`
- [x] Mobile/touch controls still work

---
*PR created automatically by Jules for task [11510847130144332704](https://jules.google.com/task/11510847130144332704) started by @ford442*