### PR TITLE
feat: Phase A Plasma Caster resource inventory + Resource Pop

### DIFF
--- a/.github/typecheck-baseline.txt
+++ b/.github/typecheck-baseline.txt
@@ -1,6 +1,6 @@
 # TypeScript error baseline — do not edit by hand unless you know what you are doing.
 # Regenerate with: npm run typecheck:baseline:update
-# Count: 151
+# Count: 142
 src/aurora.ts(104,9): TS2739: Type 'OperatorNode' is missing the following properties from type 'MathNode': method, cNode, isMathNode
 src/aurora.ts(86,9): TS2739: Type 'OperatorNode' is missing the following properties from type 'MathNode': method, cNode, isMathNode
 src/biological_background.ts(57,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
@@ -60,13 +60,8 @@ src/clouds.ts(67,5): TS2740: Type 'OperatorNode' is missing the following proper
 src/clouds.ts(69,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
 src/clouds.ts(8,5): TS2300: Duplicate identifier 'Loop'.
 src/clouds.ts(9,5): TS2300: Duplicate identifier 'Loop'.
-src/environment.ts(153,22): TS2345: Argument of type 'Mesh<SphereGeometry, MeshStandardNodeMaterial, Object3DEventMap>' is not assignable to parameter of type 'Group<Object3DEventMap>'.
-src/environment.ts(274,31): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
-src/environment.ts(313,39): TS2339: Property 'material' does not exist on type 'Group<Object3DEventMap>'.
-src/environment.ts(321,44): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
-src/environment.ts(386,43): TS2339: Property 'material' does not exist on type 'Group<Object3DEventMap>'.
-src/environment.ts(408,51): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
-src/environment.ts(67,22): TS2345: Argument of type 'Mesh<SphereGeometry, MeshPhysicalMaterial, Object3DEventMap>' is not assignable to parameter of type 'Group<Object3DEventMap>'.
+src/environment.ts(155,22): TS2345: Argument of type 'Mesh<SphereGeometry, MeshStandardNodeMaterial, Object3DEventMap>' is not assignable to parameter of type 'Group<Object3DEventMap>'.
+src/environment.ts(410,51): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
 src/foliage/grass_system.ts(23,9): TS2304: Cannot find name 'grassMeshes'.
 src/foliage/grass_system.ts(26,12): TS2304: Cannot find name 'grassMeshes'.
 src/foliage/grass_system.ts(30,18): TS2304: Cannot find name 'grassMeshes'.
@@ -130,24 +125,20 @@ src/magical_effects/stardust_field.ts(21,3): TS2612: Property 'duration' will ov
 src/main/grav_lens_update.ts(82,43): TS2345: Argument of type 'SlingshotGrade' is not assignable to parameter of type '"perfect" | "partial" | "failed"'.
 src/main/grav_lens_update.ts(93,50): TS2345: Argument of type 'SlingQuality' is not assignable to parameter of type '"perfect" | "good" | "ok" | undefined'.
 src/main/input_bindings.ts(159,59): TS2345: Argument of type 'InstancedMesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], InstancedMeshEventMap>' is not assignable to parameter of type 'Object3D<Object3DEventMap>[]'.
-src/main/loop_geological.ts(103,43): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
-src/main/loop_geological.ts(143,47): TS2339: Property 'material' does not exist on type 'Group<Object3DEventMap>'.
-src/main/loop_geological.ts(151,52): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
-src/main/loop_geological.ts(216,51): TS2339: Property 'material' does not exist on type 'Group<Object3DEventMap>'.
-src/main/loop_geological.ts(293,59): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
-src/main/loop_geological.ts(302,78): TS18047: 'player' is possibly 'null'.
-src/main/loop_geological.ts(326,50): TS18047: 'player' is possibly 'null'.
-src/main/loop_geological.ts(329,93): TS18047: 'player' is possibly 'null'.
-src/main/loop_geological.ts(330,77): TS18047: 'player' is possibly 'null'.
-src/main/loop_geological.ts(333,59): TS18047: 'player' is possibly 'null'.
-src/main/loop_world.ts(243,57): TS18047: 'player' is possibly 'null'.
-src/main/loop_world.ts(278,36): TS18047: 'player' is possibly 'null'.
+src/main/loop_geological.ts(336,59): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
+src/main/loop_geological.ts(345,78): TS18047: 'player' is possibly 'null'.
+src/main/loop_geological.ts(369,50): TS18047: 'player' is possibly 'null'.
+src/main/loop_geological.ts(372,93): TS18047: 'player' is possibly 'null'.
+src/main/loop_geological.ts(373,77): TS18047: 'player' is possibly 'null'.
+src/main/loop_geological.ts(376,59): TS18047: 'player' is possibly 'null'.
+src/main/loop_world.ts(245,57): TS18047: 'player' is possibly 'null'.
+src/main/loop_world.ts(280,36): TS18047: 'player' is possibly 'null'.
 src/main/player_update.ts(344,39): TS2769: No overload matches this call.
 src/main/player_update.ts(365,53): TS2304: Cannot find name 'DogAnimationState'.
 src/main/player_update.ts(407,49): TS2304: Cannot find name 'DogAnimationState'.
 src/main/render_helpers.ts(69,26): TS7006: Parameter 'jellyMoss' implicitly has an 'any' type.
 src/main/render_helpers.ts(69,5): TS2304: Cannot find name 'jellyMosses'.
-src/main/startup.ts(359,40): TS2345: Argument of type 'Object3D<Object3DEventMap>' is not assignable to parameter of type 'Group<Object3DEventMap>'.
+src/main/startup.ts(361,40): TS2345: Argument of type 'Object3D<Object3DEventMap>' is not assignable to parameter of type 'Group<Object3DEventMap>'.
 src/pinwheel_flora.ts(185,31): TS2345: Argument of type 'Material | Material[]' is not assignable to parameter of type 'Material'.
 src/pinwheel_flora.ts(186,30): TS2345: Argument of type 'Material | Material[]' is not assignable to parameter of type 'Material'.
 src/player_loader.ts(31,23): TS2339: Property 'isMesh' does not exist on type 'Object3D<Object3DEventMap>'.

--- a/src/deferred_system_stubs.ts
+++ b/src/deferred_system_stubs.ts
@@ -182,6 +182,7 @@ export function createBubbleCoralManagerStub(): RainbowBubbleCoralManager {
 export function createSlingableObjectSystemStub(): SlingableObjectSystem {
     return {
         onSpecialEffect: undefined,
+        onDestroyed: undefined,
         objects: [],
         update: noop,
         handleAsteroidCollisions: noop,

--- a/src/discovery_system.ts
+++ b/src/discovery_system.ts
@@ -15,6 +15,8 @@ export const SPECIES_NAMES: Record<string, string> = {
     vine: 'Wisteria Vine',
     mushroom: 'Puffball Mushroom',
     orb: 'Floating Orb',
+    nebulaJellyMoss: 'Nebula Jelly-Moss',
+    fracturedGeode: 'Fractured Geode',
     // Geological species (now scannable for objectives)
     voidRootBall: 'Void Root Ball',
     magmaHeart: 'Magma Heart',

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -49,6 +49,7 @@ export const geodes: THREE.Group[] = [];
 export function createGeodeAtPosition(x: number, y: number, z: number) {
     const geode = createFracturedGeode({ size: 3 + Math.random() * 2 });
     geode.position.set(x, y, z);
+    geode.userData.speciesId = 'fracturedGeode';
     scene.add(geode);
     geodes.push(geode);
     return geode;
@@ -58,11 +59,12 @@ export function createGeodeAtPosition(x: number, y: number, z: number) {
 export const chromaRocks: THREE.Group[] = [];
 
 // Nebula Jelly-Moss - floating gelatinous organisms with fractal moss
-export const jellyMosses: THREE.Group[] = [];
+export const jellyMosses: THREE.Mesh[] = [];
 
 export function createJellyMossAtPosition(x: number, y: number, z: number, size?: number) {
     const jellyMoss = createNebulaJellyMoss({ size: size || 2 + Math.random() * 8 });
     jellyMoss.position.set(x, y, z);
+    jellyMoss.userData.speciesId = 'nebulaJellyMoss';
     scene.add(jellyMoss);
     jellyMosses.push(jellyMoss);
     return jellyMoss;

--- a/src/game_runtime.ts
+++ b/src/game_runtime.ts
@@ -9,6 +9,7 @@ import type { TetherSystem } from './tether_system';
 import type { SlingComboManager } from './sling_combo';
 import type { SlingObjectiveManager } from './sling_objective';
 import type { DiscoveryManager, CreatureCatalogManager } from './discovery_system';
+import type { ResourceHarvester } from './resource_harvester';
 import type { CreatureManager } from './creature_manager';
 import type { AquaticLifeManager } from './aquatic_life';
 import type { StarlightKoiManager } from './starlight_koi';
@@ -127,6 +128,7 @@ export interface GameRuntime {
     slingComboManager: SlingComboManager;
     slingObjectiveManager: SlingObjectiveManager;
     discoveryManager: DiscoveryManager;
+    resourceHarvester: ResourceHarvester;
     creatureCatalogManager: CreatureCatalogManager;
     creatureManager: CreatureManager;
     aquaticLifeManager: AquaticLifeManager;
@@ -179,6 +181,8 @@ export interface GameRuntime {
 
     reportComboObjectiveProgress: () => void;
     handleGameOver: () => void;
+    /** Re-attach slingable callbacks after deferred manager swap. */
+    rewireSlingableCallbacks: () => void;
 
     wantsBoost: boolean;
     wasTouchBoosting: boolean;

--- a/src/geological/geodes.ts
+++ b/src/geological/geodes.ts
@@ -310,11 +310,13 @@ export function createNebulaJellyMoss(config: { size: number }) {
 
     mesh.userData = {
         type: 'nebulaJellyMoss',
+        speciesId: 'nebulaJellyMoss',
         radius: config.size,
         health: 10,
         maxHealth: 10,
         isHiding: false,
-        overloadValue: 0.0 // JS tracker
+        overloadValue: 0.0, // JS tracker
+        hitCount: 0
     };
 
     return mesh;

--- a/src/hud_system/hud_elements.ts
+++ b/src/hud_system/hud_elements.ts
@@ -21,6 +21,8 @@ export interface HUDElementRefs {
     gravLensMeter: HTMLDivElement | null;
     gravLensAngleBar: HTMLDivElement | null;
     gravLensGrade: HTMLDivElement | null;
+    resourcePopDisplay: HTMLDivElement | null;
+    lastMaterialLabel: HTMLDivElement | null;
 }
 
 export function injectHUDStyles(): void {
@@ -119,6 +121,8 @@ export class HUDElementsBuilder {
     gravLensMeter: HTMLDivElement | null = null;
     gravLensAngleBar: HTMLDivElement | null = null;
     gravLensGrade: HTMLDivElement | null = null;
+    resourcePopDisplay: HTMLDivElement | null = null;
+    lastMaterialLabel: HTMLDivElement | null = null;
 
     createAll(callbacks: HUDElementsCallbacks): void {
         this.createScoreDisplay(callbacks.updateHighScoreDisplay);
@@ -130,6 +134,7 @@ export class HUDElementsBuilder {
         this.createGrazeComboDisplay();
         this.createSlingComboDisplay();
         this.createGravLensDisplay();
+        this.createResourcePopDisplay();
         this.createJourneyMapDisplay();
     }
 
@@ -414,6 +419,53 @@ export class HUDElementsBuilder {
             pointer-events: none;
         `;
         document.body.appendChild(this.gravLensGrade);
+    }
+
+    /** Last-collected craft material + floating Resource Pop juice target. */
+    private createResourcePopDisplay(): void {
+        this.lastMaterialLabel = document.createElement('div');
+        this.lastMaterialLabel.id = 'hud-last-material';
+        this.lastMaterialLabel.style.cssText = `
+            position: fixed;
+            top: 20px;
+            left: 50%;
+            transform: translateX(-50%);
+            z-index: 110;
+            min-width: 160px;
+            text-align: center;
+            padding: 8px 18px;
+            border-radius: 18px;
+            font-size: 15px;
+            font-weight: bold;
+            color: ${COLORS.textDark};
+            background: linear-gradient(135deg, ${COLORS.lemon}, ${COLORS.mint});
+            box-shadow: 0 4px 16px ${COLORS.shadow}, inset 0 1px 0 rgba(255,255,255,0.55);
+            border: 3px solid ${COLORS.white};
+            opacity: 0;
+            pointer-events: none;
+            text-shadow: 0 1px 0 rgba(255,255,255,0.5);
+        `;
+        this.lastMaterialLabel.textContent = '';
+        document.body.appendChild(this.lastMaterialLabel);
+
+        this.resourcePopDisplay = document.createElement('div');
+        this.resourcePopDisplay.id = 'hud-resource-pop';
+        this.resourcePopDisplay.style.cssText = `
+            position: fixed;
+            top: 28%;
+            left: 50%;
+            transform: translate(-50%, 0) scale(1);
+            z-index: 120;
+            font-size: 28px;
+            font-weight: bold;
+            color: ${COLORS.gold};
+            text-shadow: 0 0 12px rgba(0,0,0,0.45), 0 2px 0 rgba(255,255,255,0.35);
+            opacity: 0;
+            pointer-events: none;
+            white-space: nowrap;
+        `;
+        this.resourcePopDisplay.textContent = '';
+        document.body.appendChild(this.resourcePopDisplay);
     }
 
     private createPowerUpDisplay(): void {

--- a/src/hud_system/hud_manager.ts
+++ b/src/hud_system/hud_manager.ts
@@ -156,6 +156,34 @@ export class HUDManager {
         if (el) el.style.opacity = '0';
     }
 
+    /**
+     * HUD Resource Pop — shows last collected craft material with juice animation
+     * (float up, scale 1→1.5→0.8, rotate 360° per plan §IV).
+     */
+    showResourcePop(materialName: string, amount: number, color: string = COLORS.gold): void {
+        const amountLabel = amount > 1 ? ` ×${amount}` : '';
+        const labelText = `${materialName}${amountLabel}`;
+
+        const last = this.elements.lastMaterialLabel;
+        if (last) {
+            last.textContent = `✦ ${labelText}`;
+            last.style.background = `linear-gradient(135deg, ${color}aa, ${COLORS.mint})`;
+            last.style.opacity = '1';
+            last.style.animation = 'none';
+            void last.offsetWidth;
+            last.style.animation = 'resource-pop-hud 1.6s ease-out forwards';
+        }
+
+        const pop = this.elements.resourcePopDisplay;
+        if (pop) {
+            pop.textContent = `+ ${labelText}`;
+            pop.style.color = color;
+            pop.style.animation = 'none';
+            void pop.offsetWidth;
+            pop.style.animation = 'resource-pop 1.35s ease-out forwards';
+        }
+    }
+
     setObjectiveLabel(text: string): void {
         const label = document.getElementById('hud-scan-label');
         if (label) label.textContent = text;

--- a/src/hud_system/styles.ts
+++ b/src/hud_system/styles.ts
@@ -107,6 +107,34 @@ export const HUD_STYLES = `
     50% { transform: scale(1.1); box-shadow: 0 0 32px rgba(200,68,255,1.0), inset 0 1px 0 rgba(255,255,255,0.4); }
 }
 
+/* Resource Pop — craft material pickup juice (plan §IV Action Feedback) */
+@keyframes resource-pop {
+    0% {
+        opacity: 0;
+        transform: translate(-50%, 0) scale(1) rotate(0deg);
+    }
+    20% {
+        opacity: 1;
+        transform: translate(-50%, -12px) scale(1.5) rotate(72deg);
+    }
+    55% {
+        opacity: 1;
+        transform: translate(-50%, -36px) scale(1.15) rotate(220deg);
+    }
+    100% {
+        opacity: 0;
+        transform: translate(-50%, -72px) scale(0.8) rotate(360deg);
+    }
+}
+
+@keyframes resource-pop-hud {
+    0% { opacity: 0; transform: translateX(-50%) scale(0.85) rotate(-8deg); }
+    18% { opacity: 1; transform: translateX(-50%) scale(1.5) rotate(12deg); }
+    45% { opacity: 1; transform: translateX(-50%) scale(1.1) rotate(-4deg); }
+    70% { opacity: 1; transform: translateX(-50%) scale(1) rotate(360deg); }
+    100% { opacity: 0; transform: translateX(-50%) scale(0.8) rotate(360deg); }
+}
+
 
 
 .hud-element {

--- a/src/juice_effects/juice_manager.ts
+++ b/src/juice_effects/juice_manager.ts
@@ -570,7 +570,58 @@ export class JuiceManager {
         const color = amount > 0 ? 'pink' : 'red';
         this.showFloatingText(text, position, color, 28);
     }
-    
+
+    /**
+     * Resource Pop juice — material name floats upward, scales 1→1.5→0.8,
+     * and rotates a full 360° (plan §IV Action Feedback Suite).
+     */
+    showResourcePop(
+        materialName: string,
+        amount: number,
+        position: THREE.Vector3,
+        color: string = 'gold'
+    ): void {
+        if (!this.enableFloatingText) return;
+
+        const label = amount > 1 ? `+${amount} ${materialName}` : materialName;
+
+        if (this.floatingTexts.length >= this.maxFloatingTexts) {
+            const oldest = this.floatingTexts.shift();
+            if (oldest) oldest.element.remove();
+        }
+
+        const element = document.createElement('div');
+        element.textContent = label;
+        element.style.position = 'absolute';
+        element.style.fontFamily = "'Segoe UI', Tahoma, Geneva, Verdana, sans-serif";
+        element.style.fontSize = '26px';
+        element.style.fontWeight = 'bold';
+        element.style.pointerEvents = 'none';
+        element.style.textShadow = '0 0 12px rgba(0,0,0,0.55)';
+        element.style.whiteSpace = 'nowrap';
+        element.style.userSelect = 'none';
+
+        const colorValue = TEXT_COLORS[color as keyof typeof TEXT_COLORS] ?? color;
+        element.style.color = colorValue;
+
+        this.textContainer.appendChild(element);
+
+        const floatingText: FloatingText = {
+            element,
+            position: position.clone(),
+            velocity: new THREE.Vector3(0, 4.5, 0),
+            life: 1.4,
+            maxLife: 1.4,
+            scale: 1,
+            bounces: 99, // disable bounce — Resource Pop floats straight up
+            baseY: position.y - 100,
+            resourcePop: true
+        };
+
+        this.floatingTexts.push(floatingText);
+        this.updateFloatingTextPosition(floatingText);
+    }
+
     /**
      * Update floating text positions
      */
@@ -578,17 +629,37 @@ export class JuiceManager {
         for (let i = this.floatingTexts.length - 1; i >= 0; i--) {
             const text = this.floatingTexts[i];
             text.life -= dt;
-            
+
             if (text.life <= 0) {
                 text.element.remove();
                 this.floatingTexts.splice(i, 1);
                 continue;
             }
-            
+
+            const lifeRatio = text.life / text.maxLife;
+            const elapsed = 1 - lifeRatio;
+
+            if (text.resourcePop) {
+                // Straight float up; scale 1 → 1.5 → 0.8; rotate 360°
+                text.velocity.y = 4.5;
+                text.position.add(text.velocity.clone().multiplyScalar(dt));
+                if (elapsed < 0.25) {
+                    text.scale = 1 + (elapsed / 0.25) * 0.5; // 1 → 1.5
+                } else {
+                    const t = (elapsed - 0.25) / 0.75;
+                    text.scale = 1.5 - t * 0.7; // 1.5 → 0.8
+                }
+                const rotation = elapsed * 360;
+                text.element.style.opacity = String(Math.min(1, lifeRatio * 2.2));
+                text.element.style.transform = `translate(-50%, -50%) scale(${text.scale}) rotate(${rotation}deg)`;
+                this.updateFloatingTextPosition(text, true);
+                continue;
+            }
+
             // Update physics
             text.velocity.y -= 4.0 * dt; // Gravity
             text.position.add(text.velocity.clone().multiplyScalar(dt));
-            
+
             // Bounce off "ground" for fun effect
             if (text.position.y < text.baseY && text.bounces < 2) {
                 text.position.y = text.baseY;
@@ -596,37 +667,38 @@ export class JuiceManager {
                 text.velocity.x *= 0.8;
                 text.bounces++;
             }
-            
+
             // Scale animation (pop in, then shrink)
-            const lifeRatio = text.life / text.maxLife;
             if (lifeRatio > 0.8) {
                 text.scale = 1 + (1 - lifeRatio) * 2; // Pop in
             } else {
                 text.scale = 0.8 + lifeRatio * 0.2; // Shrink out
             }
-            
+
             // Update visual
             text.element.style.opacity = String(Math.min(1, lifeRatio * 2));
             text.element.style.transform = `scale(${text.scale})`;
-            
+
             this.updateFloatingTextPosition(text);
         }
     }
-    
+
     /**
      * Update the screen position of a floating text element
      */
-    private updateFloatingTextPosition(text: FloatingText): void {
+    private updateFloatingTextPosition(text: FloatingText, skipTransform = false): void {
         // Project world position to screen space
         const screenPos = text.position.clone().project(this.camera);
-        
+
         // Convert to CSS coordinates
         const x = (screenPos.x * 0.5 + 0.5) * 100;
         const y = (-screenPos.y * 0.5 + 0.5) * 100;
-        
+
         text.element.style.left = `${x}%`;
         text.element.style.top = `${y}%`;
-        text.element.style.transform = `translate(-50%, -50%) scale(${text.scale})`;
+        if (!skipTransform) {
+            text.element.style.transform = `translate(-50%, -50%) scale(${text.scale})`;
+        }
     }
     
     private updateGravLensDistortion(): void {

--- a/src/juice_effects/shared.ts
+++ b/src/juice_effects/shared.ts
@@ -137,6 +137,8 @@ export interface FloatingText {
     scale: number;
     bounces: number;
     baseY: number;
+    /** When set, uses Resource Pop motion (float + scale + 360° spin). */
+    resourcePop?: boolean;
 }
 
 /** Predefined text styles */

--- a/src/level_systems_loader.ts
+++ b/src/level_systems_loader.ts
@@ -38,6 +38,10 @@ function loadDeferredManagers(): Promise<DeferredManagers> {
             game.bubbleCoralManager = managers.bubbleCoralManager;
             game.slingableObjectSystem = managers.slingableObjectSystem;
             game.toyRocketSpawnManager = managers.toyRocketSpawnManager;
+            // Re-bind callbacks that were attached to the startup stub
+            if (typeof game.rewireSlingableCallbacks === 'function') {
+                game.rewireSlingableCallbacks();
+            }
             if (game.levelManager) {
                 game.levelManager.ghostDebrisSystem = managers.ghostDebrisSystem;
                 game.levelManager.voidJellyfishSystem = managers.voidJellyfishSystem;

--- a/src/main/loop_geological.ts
+++ b/src/main/loop_geological.ts
@@ -74,6 +74,9 @@ export function updateLoopGeological(delta: number, time: number): void {
                             const justDepleted = damageGeode(geode, 20); // 5 hits to deplete
                             if (justDepleted) {
                                 game.audioSystem.playCollect(); // Or a breaking sound
+                                // Craft materials from geode shatter (Void Gems)
+                                const geodeTag = (geode.userData.speciesId as string) || 'fracturedGeode';
+                                game.resourceHarvester.harvest(geodeTag, 'destroy', geode.position.clone());
                                 // Release gems (Void Gems) based on quality
                                 const gemCount = Math.floor(3 + Math.random() * 3 * geode.userData.quality);
                                 for (let i = 0; i < gemCount; i++) {
@@ -102,17 +105,49 @@ export function updateLoopGeological(delta: number, time: number): void {
                 if (!isFar || farUpdateFrame) {
                     updateNebulaJellyMoss(jellyMoss, delta, time);
                 }
-    
+
+                // Projectile hits — precision core shot can destroy for Pure Extract
+                if (jellyMoss.visible && jellyMoss.userData.radius) {
+                    const projectiles = game.weaponSystem.getActiveProjectiles();
+                    const hitRadius = jellyMoss.userData.radius * 0.55;
+                    for (const proj of projectiles) {
+                        if (!proj.active) continue;
+                        if (proj.mesh.position.distanceTo(jellyMoss.position) < hitRadius) {
+                            proj.deactivate();
+                            game.particleSystem.emit(proj.mesh.position.clone(), 0x00ff88, 8, 4.0, 0.4, 0.6);
+                            jellyMoss.userData.health = (jellyMoss.userData.health || 10) - 5;
+                            jellyMoss.userData.hitCount = (jellyMoss.userData.hitCount || 0) + 1;
+                            if (jellyMoss.userData.health <= 0) {
+                                const precision = jellyMoss.userData.hitCount <= 2;
+                                const pos = jellyMoss.position.clone();
+                                destroyNebulaJellyMoss(jellyMoss, scene, game.particleSystem);
+                                jellyMosses.splice(i, 1);
+                                game.resourceHarvester.harvest(
+                                    'nebulaJellyMoss',
+                                    'destroy',
+                                    pos,
+                                    { precision }
+                                );
+                                game.audioSystem.playCollect();
+                                break;
+                            }
+                        }
+                    }
+                    if (!jellyMosses[i] || jellyMosses[i] !== jellyMoss) {
+                        continue; // destroyed this frame
+                    }
+                }
+
                 // --- NEW: Jelly Moss Interaction (Stealth, Shield & Overload) ---
                 if (player && jellyMoss.visible && jellyMoss.userData.radius) {
                     const dist = player.position.distanceTo(jellyMoss.position);
                     const radius = jellyMoss.userData.radius;
-    
+
                     // Player inside membrane?
                     if (dist < radius) {
                         // 1. Viscosity
                         playerState.velocity.multiplyScalar(Math.pow(0.05, delta));
-    
+
                         // 2. Stealth Effect
                         if (!jellyMoss.userData.isHiding) {
                             jellyMoss.userData.isHiding = true;
@@ -130,28 +165,36 @@ export function updateLoopGeological(delta: number, time: number): void {
                                  });
                             }
                         }
-    
+
                         // 3. Shield Leech & Overload
                         const normDist = dist / radius;
                         const leechIntensity = THREE.MathUtils.lerp(1.0, 0.0, normDist);
-    
+
                         // Build Overload! (Destruction Mechanic)
                         // Rate: 0.5 per second (takes ~2 seconds to explode)
                         jellyMoss.userData.overloadValue = (jellyMoss.userData.overloadValue || 0) + delta * 0.5;
-    
+
                         // Update Shader Uniform
                         const mat = jellyMoss.material as any;
                         if (mat.userData && mat.userData.uOverload) {
                             mat.userData.uOverload.value = Math.min(1.0, jellyMoss.userData.overloadValue);
                         }
-    
+
                         // Check for Explosion
                         if (jellyMoss.userData.overloadValue >= 1.0) {
-                            // BOOM
+                            // BOOM — sustained overload yields Tainted Extract
+                            const pos = jellyMoss.position.clone();
                             destroyNebulaJellyMoss(jellyMoss, scene, game.particleSystem);
-    
+
                             // Remove from list
                             jellyMosses.splice(i, 1);
+
+                            game.resourceHarvester.harvest(
+                                'nebulaJellyMoss',
+                                'destroy',
+                                pos,
+                                { precision: false }
+                            );
     
                             // Restore player state immediately (exit stealth)
                             const rocket = player.children[0];

--- a/src/main/loop_world.ts
+++ b/src/main/loop_world.ts
@@ -101,12 +101,14 @@ export function updateLoopWorld(delta: number, time: number): void {
             game.levelManager.update(delta, camera.position.x, playerState.autoScrollSpeed, isFiringProxy, new THREE.Vector3(1, 0, 0));
             const geoScannables = [
                 ...sporeClouds.map(cloud => cloud.spores),
+                ...jellyMosses,
                 ...vacuumKelps,
                 ...voidRootBalls,
                 ...magmaHearts,
                 ...iceNeedleClusters,
                 ...gravityAnchors,
                 ...liquidMetalBlobs,
+                ...geodes,
                 ...gravLensManager.getScannables(),
                 ...derelictBuoyManager.getScannables(),
                 ...dataMonolithManager.getScannables(),

--- a/src/main/startup.ts
+++ b/src/main/startup.ts
@@ -21,6 +21,7 @@ import { playerState, showError } from '../game_config';
 import { LevelManager } from '../level_manager';
 import { CreatureManager } from '../creature_manager';
 import { DiscoveryManager, CreatureCatalogManager } from '../discovery_system';
+import { ResourceHarvester } from '../resource_harvester';
 import { SlingObjectiveManager } from '../sling_objective';
 import { SlingComboManager } from '../sling_combo';
 import { TetherSystem } from '../tether_system';
@@ -337,6 +338,7 @@ export function initializeStartup(): void {
     game.bubbleCoralManager = createBubbleCoralManagerStub();
     game.creatureManager = new CreatureManager({ scene, particleSystem, debrisSystem, audioSystem });
     game.discoveryManager = new DiscoveryManager(saveManager);
+    game.resourceHarvester = new ResourceHarvester(saveManager);
     game.creatureCatalogManager = new CreatureCatalogManager(saveManager);
     game.slingObjectiveManager = new SlingObjectiveManager();
     game.slingComboManager = new SlingComboManager({

--- a/src/main/startup_callbacks.ts
+++ b/src/main/startup_callbacks.ts
@@ -9,6 +9,7 @@ import { DogAnimationState } from '../dog_cockpit';
 import { ShakeType } from '../juice_effects';
 import { CONFIG } from '../game_config';
 import { updateBoostDisplay, updateRollDisplay, updateTetherDisplay, showRollPopup } from './hud_displays';
+import { getMaterialDisplayName, getMaterialColor } from '../resource_inventory';
 
 export function reportComboObjectiveProgress(): void {
     const objective = game.levelManager.config[game.levelManager.currentLevel]?.objective;
@@ -19,6 +20,18 @@ export function reportComboObjectiveProgress(): void {
 
 export function wireStartupCallbacks(): void {
     game.reportComboObjectiveProgress = reportComboObjectiveProgress;
+    game.rewireSlingableCallbacks = wireSlingableCallbacks;
+
+    game.resourceHarvester.onMaterialCollected = (evt) => {
+        const name = getMaterialDisplayName(evt.id);
+        const color = getMaterialColor(evt.id);
+        game.hudManager.showResourcePop(name, evt.amount, color);
+        const pos = evt.position ?? player?.position?.clone();
+        if (pos) {
+            game.juiceManager.showResourcePop(name, evt.amount, pos, color);
+        }
+        game.audioSystem.playCollect();
+    };
 
     game.orbManager.onPowerUpReady = () => {
         const triggered = game.powerUpManager.collectOrb();
@@ -68,10 +81,12 @@ export function wireStartupCallbacks(): void {
         originalAddScore(Math.round(points * mult));
     };
 
-    game.discoveryManager.onSpeciesDiscovered = (_speciesId, name, totalThisRun, _isNewEver) => {
+    game.discoveryManager.onSpeciesDiscovered = (speciesId, name, totalThisRun, _isNewEver) => {
         if (player) {
             game.juiceManager.showFloatingText(`Scanned: ${name}!`, player.position.clone(), '#00ffcc', 22);
             game.juiceManager.burstMagic(player.position.clone());
+            // Scan-event craft material drops (Phase A drop tables)
+            game.resourceHarvester.harvest(speciesId, 'scan', player.position.clone());
         }
         game.dogController.triggerAnimation(DogAnimationState.DELIGHTED, 1.2);
         game.audioSystem.playMagicSequence('star_collect');
@@ -239,6 +254,11 @@ function wireObjectiveComplete(): void {
 }
 
 function wireSlingableCallbacks(): void {
+    game.slingableObjectSystem.onDestroyed = (kind, position, speciesId) => {
+        const tag = speciesId || kind;
+        game.resourceHarvester.harvest(tag, 'sling', position);
+    };
+
     game.slingableObjectSystem.onSpecialEffect = (effect) => {
         if (effect.type === 'puffballPop') {
             if (player) {

--- a/src/resource_harvester.ts
+++ b/src/resource_harvester.ts
@@ -1,0 +1,86 @@
+/**
+ * Resource Harvester — rolls drop tables, writes to SaveManager inventory,
+ * and notifies HUD / juice listeners for Resource Pop feedback.
+ */
+
+import * as THREE from 'three';
+import { SaveManager } from './save_manager';
+import {
+    type HarvestEvent,
+    type HarvestOptions,
+    type MaterialGrant,
+    type MaterialId,
+    rollMaterialDrops
+} from './resource_inventory';
+
+export interface MaterialCollectedEvent {
+    id: MaterialId;
+    amount: number;
+    total: number;
+    /** World position for floating Resource Pop juice (optional). */
+    position?: THREE.Vector3;
+    event: HarvestEvent;
+}
+
+/**
+ * Central harvest pipeline for scan / destroy / sling material grants.
+ */
+export class ResourceHarvester {
+    private saveManager: SaveManager;
+
+    /** Fired once per material grant (after inventory write). */
+    onMaterialCollected?: (evt: MaterialCollectedEvent) => void;
+
+    constructor(saveManager: SaveManager) {
+        this.saveManager = saveManager;
+    }
+
+    /**
+     * Roll drops for a tagged species/kind and persist them.
+     * Returns the grants that were actually added.
+     */
+    harvest(
+        tag: string,
+        event: HarvestEvent,
+        position?: THREE.Vector3,
+        options: HarvestOptions = {}
+    ): MaterialGrant[] {
+        if (!tag) return [];
+
+        const grants = rollMaterialDrops(tag, event, options);
+        if (grants.length === 0) return [];
+
+        const applied: MaterialGrant[] = [];
+        for (const grant of grants) {
+            const total = this.saveManager.addMaterial(grant.id, grant.amount);
+            applied.push(grant);
+            this.onMaterialCollected?.({
+                id: grant.id,
+                amount: grant.amount,
+                total,
+                position: position?.clone(),
+                event
+            });
+        }
+        return applied;
+    }
+
+    /** Direct grant (quests, debug, boss rewards) without a drop table. */
+    grant(
+        id: MaterialId,
+        amount: number,
+        event: HarvestEvent = 'destroy',
+        position?: THREE.Vector3
+    ): number {
+        if (amount <= 0) return this.saveManager.getMaterialCount(id);
+        const total = this.saveManager.addMaterial(id, amount);
+        this.onMaterialCollected?.({
+            id,
+            amount,
+            total,
+            position: position?.clone(),
+            event
+        });
+        return total;
+    }
+}

--- a/src/resource_inventory.ts
+++ b/src/resource_inventory.ts
@@ -1,0 +1,259 @@
+/**
+ * Resource Inventory — Plasma Caster crafting materials (Phase A foundation).
+ *
+ * Materials drop from scan / destroy / sling events on tagged flora & geology,
+ * persist via SaveManager, and surface on the HUD as a "Resource Pop".
+ */
+
+/** Crafting material ids matching docs/plans/plan.md §VI economy. */
+export type MaterialId =
+    | 'luminousDust'
+    | 'pureExtract'
+    | 'taintedExtract'
+    | 'pyroclastOre'
+    | 'voidGem'
+    | 'quantumSeed'
+    | 'frostHeart'
+    | 'magmaCore'
+    | 'architectKey';
+
+/** How a resource was obtained — drives drop-table selection. */
+export type HarvestEvent = 'destroy' | 'scan' | 'sling';
+
+export type MaterialRarity = 'common' | 'uncommon' | 'rare' | 'legendary';
+
+export interface MaterialMeta {
+    id: MaterialId;
+    name: string;
+    /** CSS / juice color for Resource Pop. */
+    color: string;
+    rarity: MaterialRarity;
+}
+
+/** Bag of craft materials persisted in save data. */
+export type ResourceInventory = Record<MaterialId, number>;
+
+export interface MaterialGrant {
+    id: MaterialId;
+    amount: number;
+}
+
+export interface HarvestOptions {
+    /** Precision core shot → Pure Extract; sustained/overload → Tainted. */
+    precision?: boolean;
+}
+
+interface DropEntry {
+    id: MaterialId;
+    /** Inclusive min/max grant amount when the roll succeeds. */
+    min: number;
+    max: number;
+    /** 0–1 chance this entry drops (default 1). */
+    chance?: number;
+}
+
+type EventDropTable = DropEntry[];
+
+/** Per-species drop tables keyed by harvest event. */
+const DROP_TABLES: Record<string, Partial<Record<HarvestEvent, EventDropTable>>> = {
+    nebulaJellyMoss: {
+        destroy: [
+            { id: 'taintedExtract', min: 1, max: 2 },
+            { id: 'luminousDust', min: 1, max: 3, chance: 0.6 }
+        ],
+        scan: [
+            { id: 'luminousDust', min: 1, max: 1, chance: 0.35 }
+        ]
+    },
+    fern: {
+        destroy: [{ id: 'luminousDust', min: 1, max: 2 }],
+        scan: [{ id: 'luminousDust', min: 1, max: 1, chance: 0.25 }]
+    },
+    rose: {
+        destroy: [{ id: 'luminousDust', min: 1, max: 2 }],
+        scan: [{ id: 'luminousDust', min: 1, max: 1, chance: 0.25 }]
+    },
+    lotus: {
+        destroy: [{ id: 'luminousDust', min: 1, max: 3 }],
+        scan: [{ id: 'luminousDust', min: 1, max: 1, chance: 0.3 }]
+    },
+    glowingFlower: {
+        destroy: [{ id: 'luminousDust', min: 1, max: 2 }],
+        scan: [{ id: 'luminousDust', min: 1, max: 1, chance: 0.3 }]
+    },
+    tree: {
+        destroy: [{ id: 'luminousDust', min: 1, max: 2 }],
+        scan: [{ id: 'luminousDust', min: 1, max: 1, chance: 0.15 }]
+    },
+    floweringTree: {
+        destroy: [{ id: 'luminousDust', min: 2, max: 3 }],
+        scan: [{ id: 'luminousDust', min: 1, max: 1, chance: 0.2 }]
+    },
+    shrub: {
+        destroy: [{ id: 'luminousDust', min: 1, max: 1 }],
+        scan: [{ id: 'luminousDust', min: 1, max: 1, chance: 0.15 }]
+    },
+    vine: {
+        destroy: [{ id: 'luminousDust', min: 1, max: 2 }],
+        scan: [{ id: 'luminousDust', min: 1, max: 1, chance: 0.2 }]
+    },
+    mushroom: {
+        destroy: [{ id: 'luminousDust', min: 1, max: 2 }],
+        scan: [{ id: 'luminousDust', min: 1, max: 1, chance: 0.25 }]
+    },
+    orb: {
+        destroy: [{ id: 'luminousDust', min: 1, max: 1 }],
+        scan: [{ id: 'luminousDust', min: 1, max: 1, chance: 0.2 }]
+    },
+    pinwheelFlower: {
+        destroy: [{ id: 'luminousDust', min: 1, max: 2 }],
+        scan: [{ id: 'luminousDust', min: 1, max: 1, chance: 0.25 }],
+        sling: [{ id: 'luminousDust', min: 1, max: 2 }]
+    },
+    sporeCloud: {
+        destroy: [{ id: 'luminousDust', min: 2, max: 4 }],
+        scan: [{ id: 'luminousDust', min: 1, max: 2, chance: 0.5 }]
+    },
+    vacuumKelp: {
+        destroy: [
+            { id: 'luminousDust', min: 1, max: 2 },
+            { id: 'quantumSeed', min: 1, max: 1, chance: 0.15 }
+        ],
+        scan: [{ id: 'luminousDust', min: 1, max: 1, chance: 0.2 }]
+    },
+    voidRootBall: {
+        destroy: [{ id: 'voidGem', min: 1, max: 2 }],
+        scan: [{ id: 'voidGem', min: 1, max: 1, chance: 0.2 }]
+    },
+    magmaHeart: {
+        destroy: [
+            { id: 'pyroclastOre', min: 1, max: 3 },
+            { id: 'magmaCore', min: 1, max: 1, chance: 0.08 }
+        ],
+        scan: [{ id: 'pyroclastOre', min: 1, max: 1, chance: 0.25 }]
+    },
+    iceNeedleCluster: {
+        destroy: [{ id: 'frostHeart', min: 1, max: 2 }],
+        scan: [{ id: 'frostHeart', min: 1, max: 1, chance: 0.2 }]
+    },
+    gravityAnchor: {
+        scan: [{ id: 'luminousDust', min: 1, max: 1, chance: 0.15 }]
+    },
+    liquidMetalBlob: {
+        destroy: [{ id: 'pyroclastOre', min: 1, max: 1 }],
+        scan: [{ id: 'luminousDust', min: 1, max: 1, chance: 0.15 }]
+    },
+    // Fractured geodes (not always species-tagged — also keyed by type)
+    fracturedGeode: {
+        destroy: [{ id: 'voidGem', min: 2, max: 4 }]
+    },
+    // Slingable kinds used as fallback when speciesId is absent
+    puffball: {
+        sling: [{ id: 'luminousDust', min: 1, max: 2 }]
+    },
+    chromaRock: {
+        sling: [{ id: 'pyroclastOre', min: 1, max: 1, chance: 0.5 }]
+    },
+    wreckingBall: {
+        sling: [{ id: 'pyroclastOre', min: 1, max: 2, chance: 0.4 }]
+    },
+    toyRocketWreck: {
+        destroy: [{ id: 'luminousDust', min: 1, max: 2 }],
+        scan: [{ id: 'luminousDust', min: 1, max: 1, chance: 0.3 }],
+        sling: [{ id: 'luminousDust', min: 1, max: 2 }]
+    }
+};
+
+export const MATERIAL_META: Record<MaterialId, MaterialMeta> = {
+    luminousDust: { id: 'luminousDust', name: 'Luminous Dust', color: '#FFE066', rarity: 'common' },
+    pureExtract: { id: 'pureExtract', name: 'Pure Extract', color: '#66FFCC', rarity: 'uncommon' },
+    taintedExtract: { id: 'taintedExtract', name: 'Tainted Extract', color: '#AA66FF', rarity: 'uncommon' },
+    pyroclastOre: { id: 'pyroclastOre', name: 'Pyroclast Ore', color: '#FF8844', rarity: 'common' },
+    voidGem: { id: 'voidGem', name: 'Void Gem', color: '#8866FF', rarity: 'uncommon' },
+    quantumSeed: { id: 'quantumSeed', name: 'Quantum Seed', color: '#44FFAA', rarity: 'rare' },
+    frostHeart: { id: 'frostHeart', name: 'Frost Heart', color: '#88DDFF', rarity: 'rare' },
+    magmaCore: { id: 'magmaCore', name: 'Magma Core', color: '#FF4422', rarity: 'legendary' },
+    architectKey: { id: 'architectKey', name: "Architect's Key", color: '#FFD700', rarity: 'legendary' }
+};
+
+export const ALL_MATERIAL_IDS: MaterialId[] = Object.keys(MATERIAL_META) as MaterialId[];
+
+export function createEmptyInventory(): ResourceInventory {
+    const bag = {} as ResourceInventory;
+    for (const id of ALL_MATERIAL_IDS) {
+        bag[id] = 0;
+    }
+    return bag;
+}
+
+/** Coerce unknown save payload into a full ResourceInventory. */
+export function normalizeInventory(raw: unknown): ResourceInventory {
+    const bag = createEmptyInventory();
+    if (!raw || typeof raw !== 'object') return bag;
+    const src = raw as Record<string, unknown>;
+    for (const id of ALL_MATERIAL_IDS) {
+        const n = src[id];
+        if (typeof n === 'number' && Number.isFinite(n) && n >= 0) {
+            bag[id] = Math.floor(n);
+        }
+    }
+    return bag;
+}
+
+function rollAmount(min: number, max: number): number {
+    if (max <= min) return min;
+    return min + Math.floor(Math.random() * (max - min + 1));
+}
+
+/**
+ * Roll drop table for a tagged species / kind.
+ * Jelly-Moss destroy uses precision flag to swap Pure vs Tainted Extract.
+ */
+export function rollMaterialDrops(
+    tag: string,
+    event: HarvestEvent,
+    options: HarvestOptions = {}
+): MaterialGrant[] {
+    const table = DROP_TABLES[tag]?.[event];
+    if (!table || table.length === 0) return [];
+
+    const grants: MaterialGrant[] = [];
+
+    for (const entry of table) {
+        const chance = entry.chance ?? 1;
+        if (Math.random() > chance) continue;
+
+        let id = entry.id;
+        // Jelly-Moss quality: precision core shot → Pure; sustained/overload → Tainted
+        if (tag === 'nebulaJellyMoss' && event === 'destroy') {
+            if (id === 'taintedExtract' || id === 'pureExtract') {
+                id = options.precision ? 'pureExtract' : 'taintedExtract';
+            }
+        }
+
+        const amount = rollAmount(entry.min, entry.max);
+        if (amount > 0) {
+            grants.push({ id, amount });
+        }
+    }
+
+    // Guaranteed at least one material on destroy of a known flora/geo tag
+    if (event === 'destroy' && grants.length === 0 && table.length > 0) {
+        const fallback = table[0];
+        let id = fallback.id;
+        if (tag === 'nebulaJellyMoss') {
+            id = options.precision ? 'pureExtract' : 'taintedExtract';
+        }
+        grants.push({ id, amount: Math.max(1, fallback.min) });
+    }
+
+    return grants;
+}
+
+export function getMaterialDisplayName(id: MaterialId): string {
+    return MATERIAL_META[id]?.name ?? id;
+}
+
+export function getMaterialColor(id: MaterialId): string {
+    return MATERIAL_META[id]?.color ?? '#FFFFFF';
+}

--- a/src/save_manager.ts
+++ b/src/save_manager.ts
@@ -2,6 +2,13 @@
  * Save Manager - LocalStorage persistence for meta-progression
  */
 
+import {
+    type MaterialId,
+    type ResourceInventory,
+    createEmptyInventory,
+    normalizeInventory
+} from './resource_inventory';
+
 export interface PlayerUpgrades {
     maxHealthBonus: number;      // +0 to +2 (max 5 total health)
     fireRateBonus: number;       // 0 to 0.3 (+30%)
@@ -31,6 +38,8 @@ export interface SaveData {
     mapFragments: number;
     /** Quantum Compass HUD upgrade unlocked (full buoy network decoded). */
     quantumCompassUnlocked: boolean;
+    /** Crafting material bag (Plasma Caster economy Phase A). */
+    resources: ResourceInventory;
     version: string;
 }
 
@@ -70,7 +79,7 @@ export class SaveManager {
                 if (parsed.version !== CURRENT_VERSION) {
                     return this.migrateSave(parsed);
                 }
-                return parsed;
+                return this.normalizeSave(parsed);
             }
         } catch (e) {
             console.warn('Failed to load save:', e);
@@ -90,13 +99,33 @@ export class SaveManager {
             architectLoreUnlocked: [],
             mapFragments: 0,
             quantumCompassUnlocked: false,
+            resources: createEmptyInventory(),
+            version: CURRENT_VERSION
+        };
+    }
+
+    /** Fill missing fields on older localStorage payloads without wiping progress. */
+    private normalizeSave(raw: any): SaveData {
+        const base = this.createNewSave();
+        return {
+            ...base,
+            ...raw,
+            upgrades: { ...base.upgrades, ...(raw?.upgrades || {}) },
+            stats: { ...base.stats, ...(raw?.stats || {}) },
+            unlockedLevels: Array.isArray(raw?.unlockedLevels) ? raw.unlockedLevels : base.unlockedLevels,
+            discoveredSpecies: Array.isArray(raw?.discoveredSpecies) ? raw.discoveredSpecies : [],
+            catalogedCreatures: Array.isArray(raw?.catalogedCreatures) ? raw.catalogedCreatures : [],
+            architectLoreUnlocked: Array.isArray(raw?.architectLoreUnlocked) ? raw.architectLoreUnlocked : [],
+            mapFragments: typeof raw?.mapFragments === 'number' ? raw.mapFragments : 0,
+            quantumCompassUnlocked: raw?.quantumCompassUnlocked === true,
+            resources: normalizeInventory(raw?.resources),
             version: CURRENT_VERSION
         };
     }
 
     private migrateSave(oldData: any): SaveData {
-        // Handle version migrations here if needed
-        return this.createNewSave();
+        // Preserve known fields across version bumps; fill gaps via normalize.
+        return this.normalizeSave(oldData);
     }
 
     save(): boolean {
@@ -265,6 +294,45 @@ export class SaveManager {
     unlockQuantumCompass(): boolean {
         if (this.data.quantumCompassUnlocked) return false;
         this.data.quantumCompassUnlocked = true;
+        this.save();
+        return true;
+    }
+
+    // --- Crafting materials (Plasma Caster economy) ---
+    getResources(): ResourceInventory {
+        if (!this.data.resources) {
+            this.data.resources = createEmptyInventory();
+        }
+        return { ...this.data.resources };
+    }
+
+    getMaterialCount(id: MaterialId): number {
+        if (!this.data.resources) this.data.resources = createEmptyInventory();
+        return this.data.resources[id] || 0;
+    }
+
+    /**
+     * Adds crafting materials to the persistent bag.
+     * @returns new total for that material
+     */
+    addMaterial(id: MaterialId, amount: number): number {
+        if (!this.data.resources) this.data.resources = createEmptyInventory();
+        if (!Number.isFinite(amount) || amount === 0) {
+            return this.data.resources[id] || 0;
+        }
+        const next = Math.max(0, (this.data.resources[id] || 0) + Math.floor(amount));
+        this.data.resources[id] = next;
+        this.save();
+        return next;
+    }
+
+    /** Spends materials if the bag has enough. Returns false when short. */
+    spendMaterial(id: MaterialId, amount: number): boolean {
+        if (!this.data.resources) this.data.resources = createEmptyInventory();
+        const need = Math.floor(amount);
+        if (need <= 0) return true;
+        if ((this.data.resources[id] || 0) < need) return false;
+        this.data.resources[id] -= need;
         this.save();
         return true;
     }

--- a/src/slingable_objects.ts
+++ b/src/slingable_objects.ts
@@ -79,6 +79,9 @@ export class SlingableObjectSystem {
     /** Fired for kind-specific moments (puffball pops, chroma slipstreams). */
     onSpecialEffect?: (effect: SlingableSpecialEffect) => void;
 
+    /** Fired when a slingable is destroyed (asteroid smash / health depleted). */
+    onDestroyed?: (kind: SlingableKind, position: THREE.Vector3, speciesId?: string) => void;
+
     constructor(
         private readonly scene: THREE.Scene,
         private readonly particleSystem: ParticleSystem,
@@ -614,12 +617,15 @@ export class SlingableObjectSystem {
 
     private destroyObjectAtIndex(index: number): void {
         const obj = this.objects[index];
+        const pos = obj.group.position.clone();
+        const speciesId = obj.group.userData?.speciesId as string | undefined;
         if (obj.kind === 'toyRocket') {
             this._resolveToyRocket(obj, false);
         } else {
             this.debrisSystem.emit(obj.group.position.clone(), 8, 5.5, obj.radius * 0.8);
             this.particleSystem.emit(obj.group.position.clone(), 0xffffff, 14, 6.0, 1.0, obj.radius);
         }
+        this.onDestroyed?.(obj.kind, pos, speciesId);
         this.removeObjectAtIndex(index);
     }
 

--- a/tools/smoke_resource_pop.mjs
+++ b/tools/smoke_resource_pop.mjs
@@ -1,0 +1,113 @@
+/**
+ * Playwright smoke: Phase A resource inventory + Resource Pop HUD.
+ */
+import { chromium } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ARTIFACTS = '/opt/cursor/artifacts/screenshots';
+fs.mkdirSync(ARTIFACTS, { recursive: true });
+
+async function main() {
+    const browser = await chromium.launch({
+        executablePath: '/usr/local/bin/google-chrome',
+        headless: true,
+        args: [
+            '--use-gl=angle',
+            '--use-angle=swiftshader',
+            '--enable-unsafe-swiftshader',
+            '--ignore-gpu-blocklist',
+            '--no-sandbox'
+        ]
+    });
+
+    const context = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+    const page = await context.newPage();
+    page.on('pageerror', (err) => console.warn('PAGE ERROR', err.message));
+
+    await page.goto('http://127.0.0.1:5173/?renderer=webgl', { waitUntil: 'networkidle', timeout: 60000 });
+    await page.waitForTimeout(2000);
+    await page.mouse.click(640, 400);
+    await page.waitForTimeout(800);
+    await page.keyboard.press('Space');
+    await page.waitForTimeout(1500);
+
+    // Wait until game runtime + harvester are wired
+    await page.waitForFunction(async () => {
+        try {
+            const { game } = await import('/src/game_runtime.ts');
+            return !!(game && game.resourceHarvester && game.hudManager);
+        } catch {
+            return false;
+        }
+    }, { timeout: 30000 });
+
+    const result = await page.evaluate(async () => {
+        const { game } = await import('/src/game_runtime.ts');
+        const { getMaterialDisplayName } = await import('/src/resource_inventory.ts');
+
+        const before = game.saveManager.getMaterialCount('taintedExtract');
+        const dustBefore = game.saveManager.getMaterialCount('luminousDust');
+
+        const grants = game.resourceHarvester.harvest(
+            'nebulaJellyMoss',
+            'destroy',
+            undefined,
+            { precision: false }
+        );
+
+        // Allow HUD animation to start
+        await new Promise((r) => setTimeout(r, 100));
+
+        const after = game.saveManager.getMaterialCount('taintedExtract');
+        const dustAfter = game.saveManager.getMaterialCount('luminousDust');
+        const raw = localStorage.getItem('dog_dash_save_v1');
+        const parsed = raw ? JSON.parse(raw) : null;
+
+        const last = document.getElementById('hud-last-material');
+        const pop = document.getElementById('hud-resource-pop');
+
+        return {
+            usingWebGL: window.usingWebGL === true,
+            grants,
+            before,
+            after,
+            dustBefore,
+            dustAfter,
+            persistedTainted: parsed?.resources?.taintedExtract ?? null,
+            persistedDust: parsed?.resources?.luminousDust ?? null,
+            hasLast: !!last,
+            hasPop: !!pop,
+            lastText: last?.textContent ?? '',
+            popText: pop?.textContent ?? '',
+            lastOpacity: last ? getComputedStyle(last).opacity : null,
+            grantNames: grants.map((g) => getMaterialDisplayName(g.id))
+        };
+    });
+
+    console.log(JSON.stringify(result, null, 2));
+
+    await page.waitForTimeout(500);
+    const shot = path.join(ARTIFACTS, 'resource-pop-phase-a.png');
+    await page.screenshot({ path: shot, fullPage: false });
+    console.log('screenshot', shot);
+
+    if (!result.grants?.length) throw new Error('Expected destroy to grant materials');
+    if (result.after + result.dustAfter <= result.before + result.dustBefore) {
+        throw new Error('Inventory totals did not increase');
+    }
+    if (result.persistedTainted !== result.after) {
+        throw new Error(`taintedExtract persist mismatch ${result.persistedTainted} vs ${result.after}`);
+    }
+    if (!result.hasLast || !result.hasPop) throw new Error('HUD Resource Pop elements missing');
+    if (!result.lastText || result.lastText === '') throw new Error('Last material label empty');
+    if (!result.popText || result.popText === '') throw new Error('Resource Pop text empty');
+
+    console.log('ACCEPTANCE OK');
+    await browser.close();
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase A** of the Plasma Caster economy (`docs/plans/plan.md` §V / §VI):

- Persistent `ResourceInventory` in `save_manager` (luminous dust, pure/tainted extract, pyroclast ore, void gems, etc.)
- Drop tables for **destroy / scan / sling** events keyed by species / kind tags
- HUD **Resource Pop** juice (float up, scale 1→1.5→0.8, rotate 360°) plus last-collected material banner

## Acceptance criteria

- [x] Destroying tagged flora (Nebula Jelly-Moss) grants at least one material type
- [x] Materials persist across sessions via `save_manager` / localStorage
- [x] HUD shows last collected material with juice animation

## Key files

- `src/resource_inventory.ts` — material ids, drop tables, normalize helpers
- `src/resource_harvester.ts` — harvest pipeline → save + HUD/juice callbacks
- `src/save_manager.ts` — `resources` bag + migrate/normalize on load
- `src/main/loop_geological.ts` — jelly-moss projectile/overload destroy grants
- `src/hud_system/*` + `src/juice_effects/*` — Resource Pop UI/animation
- `tools/smoke_resource_pop.mjs` — Playwright acceptance smoke

## Notes

- Overload destroy → Tainted Extract; ≤2-hit precision kill → Pure Extract
- Scan and sling hooks are wired for foundation; crafting UI is Phase B
- Typecheck baseline ratcheted down (151 → 142) after fixing jelly-moss `Mesh` typing

## Verification

- `npm run typecheck:ci` — OK
- `node tools/check_braces.cjs` — OK
- `node tools/smoke_resource_pop.mjs` against `?renderer=webgl` + SwiftShader — grants + persist + HUD pop OK

![Resource Pop HUD](https://cursor.com/artifacts/c/art-f4ffc98c-64c2-4b91-bb11-dcb954a2efae)
<a href="https://cursor.com/agents/bc-bfb3326f-44b1-4a64-a2ae-dd3c972e337e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fresource-pop-demo.webm"><img src="https://cursor.com/artifacts/c/art-326bbccb-af7a-46a2-a95c-eb11bcb69ca3" alt="resource-pop-demo.webm" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfb3326f-44b1-4a64-a2ae-dd3c972e337e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfb3326f-44b1-4a64-a2ae-dd3c972e337e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

