### PR TITLE
Complete typecheck gate: npm run check + AGENTS.md docs (#224)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,20 @@ Useful URL flags:
 
 See `docs/RENDERER_FALLBACK.md` for the implementation details.
 
+## Typecheck gate
+
+Strict TypeScript is gated with a **baseline ratchet** (not zero-error yet):
+
+- `npm run typecheck` — raw `tsc --noEmit` (reports all current errors)
+- `npm run typecheck:ci` — fail only on errors newer than `.github/typecheck-baseline.txt`
+- `npm run typecheck:baseline:update` — after fixing errors, ratchet the baseline down
+- `npm run check` — local pre-PR gate: brace balance + typecheck ratchet
+
+CI (`.github/workflows/ci.yml`) runs `npm run typecheck:ci` then `npm run build` on PRs/pushes to `main`. Prefer `npm run check` locally before opening a PR.
+
 ## Cursor Cloud specific instructions
 
-Standard commands live in `README.md` / `package.json` / `CLAUDE.md` (`npm run dev` on :5173, `npm run build`, brace-check gate `node tools/check_braces.cjs`). `predev`/`prebuild` rebuild the AssemblyScript WASM automatically, so no separate WASM step is needed for normal dev. There is no lint or test suite.
+Standard commands live in `README.md` / `package.json` / `CLAUDE.md` (`npm run dev` on :5173, `npm run build`, `npm run check` for braces + typecheck ratchet). `predev`/`prebuild` rebuild the AssemblyScript WASM automatically, so no separate WASM step is needed for normal dev. There is no ESLint or unit-test suite; quality gates are brace check, typecheck baseline, production build, and Playwright smoke.
 
 Non-obvious caveats for headless/cloud verification:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,13 +33,15 @@ npm run copy:cpp-wasm             # copy build/game_cpp.wasm into public/build/
 npm run typecheck                 # strict TypeScript check (see baseline ratchet below)
 npm run typecheck:ci              # CI gate: fail only on new errors vs .github/typecheck-baseline.txt
 npm run typecheck:baseline:update # refresh baseline after fixing errors (ratchet down)
+npm run check                     # local gate: brace balance + typecheck:ci
 npm run test:smoke                # Playwright smoke test (WebGL path, SwiftShader in CI)
 ```
 
 There is no ESLint or unit-test suite. The automated quality gates are:
 
 - `tools/check_braces.cjs` — runs on `prebuild`, verifies brace balance in `.ts`/`.js`/`.cjs` files
-- `npm run typecheck:ci` — compares `tsc --noEmit` against a tracked baseline (currently ~180 known strict-mode violations); CI fails only when **new** errors appear. After fixing errors locally, run `npm run typecheck:baseline:update` to ratchet the baseline down.
+- `npm run typecheck:ci` — compares `tsc --noEmit` against a tracked baseline (currently ~142 known strict-mode violations); CI fails only when **new** errors appear. After fixing errors locally, run `npm run typecheck:baseline:update` to ratchet the baseline down.
+- `npm run check` — local workflow helper: brace check + typecheck ratchet (use before PRs)
 - GitHub Actions (`.github/workflows/ci.yml`) — `npm ci`, typecheck ratchet, production build, and Playwright smoke test on PRs to `main`.
 
 WebGPU is unavailable headlessly, so runtime verification requires a browser with WebGPU enabled (Chrome/Edge 113+).

--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ Run the TypeScript compiler in strict mode (no emit):
 npm run typecheck
 ```
 
-CI uses a **baseline ratchet** so existing known errors do not block PRs, but new strict-mode violations do:
+CI uses a **baseline ratchet** so existing known errors do not block PRs, but new strict-mode violations do. For a local pre-PR gate (brace balance + typecheck ratchet):
 
 ```bash
+npm run check                         # braces + typecheck:ci
 npm run typecheck:ci                  # compare against .github/typecheck-baseline.txt
 npm run typecheck:baseline:update     # after fixing errors, ratchet the baseline down
 ```

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "typecheck": "tsc --noEmit",
     "typecheck:ci": "node tools/typecheck_baseline.cjs",
     "typecheck:baseline:update": "node tools/typecheck_baseline.cjs --update",
+    "check": "node tools/check_braces.cjs && npm run typecheck:ci",
     "test:smoke": "playwright test"
   },
   "keywords": [],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes **#224**. The TypeScript CI gate and baseline ratchet already landed in #211; this PR finishes the remaining acceptance criteria.

## Already on `main` (from #211)

- `npm run typecheck` / `typecheck:ci` / `typecheck:baseline:update`
- `.github/workflows/ci.yml` — `npm ci` → typecheck ratchet → build on PRs to `main`
- Tracked baseline at `.github/typecheck-baseline.txt` (**142** known errors; new errors blocked)

## This PR

- Adds `npm run check` — local pre-PR gate: brace balance + typecheck ratchet
- Documents the typecheck gate in `AGENTS.md` (was missing)
- Updates `README.md` / `CLAUDE.md` with `check` and the current ~142 baseline count

## Acceptance criteria

- [x] `npm run typecheck` exists and is documented
- [x] CI runs on PRs to `main`
- [x] Tracked baseline with ratchet (no new errors allowed)
- [x] Dedicated `check` script surfaces typecheck in local workflows

## Verification

- `npm run check` → braces OK, 142/142 baseline OK
- Injected a deliberate new `tsc` error → `typecheck:ci` exited 1; restored → OK

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a14b38db-9fe1-439f-9855-5a1c810f6e6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a14b38db-9fe1-439f-9855-5a1c810f6e6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

