### PR TITLE
Fix audio_system TypeScript mixin host typing

### DIFF
--- a/.github/typecheck-baseline.txt
+++ b/.github/typecheck-baseline.txt
@@ -1,6 +1,6 @@
 # TypeScript error baseline — do not edit by hand unless you know what you are doing.
 # Regenerate with: npm run typecheck:baseline:update
-# Count: 142
+# Count: 136
 src/aurora.ts(104,9): TS2739: Type 'OperatorNode' is missing the following properties from type 'MathNode': method, cNode, isMathNode
 src/aurora.ts(86,9): TS2739: Type 'OperatorNode' is missing the following properties from type 'MathNode': method, cNode, isMathNode
 src/biological_background.ts(57,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.
@@ -69,12 +69,6 @@ src/foliage/grass_system.ts(30,35): TS7006: Parameter 'm' implicitly has an 'any
 src/foliage/grass_system.ts(340,5): TS2304: Cannot find name 'registerReactiveMaterial'.
 src/foliage/grass_system.ts(409,5): TS2304: Cannot find name 'registerReactiveMaterial'.
 src/foliage/grass_system.ts(8,5): TS2304: Cannot find name 'grassMeshes'.
-src/game_managers.ts(39,51): TS2345: Argument of type 'unknown' is not assignable to parameter of type 'AudioSystem'.
-src/game_managers.ts(40,56): TS2345: Argument of type 'unknown' is not assignable to parameter of type 'AudioSystem | null | undefined'.
-src/game_managers.ts(41,58): TS2345: Argument of type 'unknown' is not assignable to parameter of type 'ParticleSystem | null | undefined'.
-src/game_managers.ts(42,51): TS2345: Argument of type 'unknown' is not assignable to parameter of type 'AudioSystem'.
-src/game_managers.ts(45,63): TS2345: Argument of type 'unknown' is not assignable to parameter of type 'ParticleSystem | null | undefined'.
-src/game_managers.ts(46,55): TS2345: Argument of type 'unknown' is not assignable to parameter of type 'ParticleSystem | null | undefined'.
 src/geological/geodes.ts(13,5): TS2300: Duplicate identifier 'vec3'.
 src/geological/geodes.ts(24,5): TS2300: Duplicate identifier 'vec3'.
 src/geological/geodes.ts(79,5): TS2740: Type 'OperatorNode' is missing the following properties from type 'ConstNode<number>': isConstNode, generateConst, isInputNode, value, and 3 more.

--- a/src/audio_system/AudioSystem.ts
+++ b/src/audio_system/AudioSystem.ts
@@ -16,79 +16,79 @@ import { hackingSoundsMixin } from './mixins/hacking_sounds';
 import { cleanupMixin } from './mixins/cleanup';
 
 export class AudioSystem {
-    private ctx: AudioContext | null = null;
-    private masterGain: GainNode | null = null;
-    private musicGain: GainNode | null = null;
-    private sfxGain: GainNode | null = null;
-    private engineActive: boolean = false;
+    protected ctx: AudioContext | null = null;
+    protected masterGain: GainNode | null = null;
+    protected musicGain: GainNode | null = null;
+    protected sfxGain: GainNode | null = null;
+    protected engineActive: boolean = false;
     
     // Volume settings (0-1)
-    private musicVolume: number = 0.7;
-    private sfxVolume: number = 0.8;
-    private masterVolume: number = 0.7;
-    private isMuted: boolean = false;
+    protected musicVolume: number = 0.7;
+    protected sfxVolume: number = 0.8;
+    protected masterVolume: number = 0.7;
+    protected isMuted: boolean = false;
     
     // ========== LAYERED MUSIC SYSTEM ==========
-    private musicLayers: Map<string, MusicLayer> = new Map();
-    private currentMusicState: MusicState = 'AMBIENT';
-    private bpm: number = 60; // Base BPM
-    private baseBpm: number = 60;
-    private musicStartTime: number = 0;
-    private musicInterval: number | null = null;
-    private magicMusicTimeout: number | null = null;
+    protected musicLayers: Map<string, MusicLayer> = new Map();
+    protected currentMusicState: MusicState = 'AMBIENT';
+    protected bpm: number = 60; // Base BPM
+    protected baseBpm: number = 60;
+    protected musicStartTime: number = 0;
+    protected musicInterval: number | null = null;
+    protected magicMusicTimeout: number | null = null;
     
     // ========== PROCEDURAL MUSIC ==========
-    private collectChain: number = 0;
-    private lastCollectTime: number = 0;
-    private chainTimeout: number = 1000; // ms between chain collects
-    private melodyQueue: number[] = [];
+    protected collectChain: number = 0;
+    protected lastCollectTime: number = 0;
+    protected chainTimeout: number = 1000; // ms between chain collects
+    protected melodyQueue: number[] = [];
     
     // ========== SPATIAL AUDIO ==========
-    private listenerPosition: { x: number; y: number; z: number } = { x: 0, y: 0, z: 0 };
-    private spatialSounds: Map<string, SpatialSound> = new Map();
-    private pannerNodes: PannerNode[] = [];
+    protected listenerPosition: { x: number; y: number; z: number } = { x: 0, y: 0, z: 0 };
+    protected spatialSounds: Map<string, SpatialSound> = new Map();
+    protected pannerNodes: PannerNode[] = [];
     
     // ========== HOVER SOUND ==========
-    private hoverNode: OscillatorNode | null = null;
-    private hoverGain: GainNode | null = null;
-    private hoverActive: boolean = false;
+    protected hoverNode: OscillatorNode | null = null;
+    protected hoverGain: GainNode | null = null;
+    protected hoverActive: boolean = false;
     
     // ========== VOICE LIMITER ==========
-    private activeVoices: number = 0;
-    private readonly maxVoices: number = 32;
-    private activeVoiceNodes: Array<{ osc?: OscillatorNode, source?: AudioBufferSourceNode, gain: GainNode, priority: number, endTime: number, timeoutId?: any }> = [];
+    protected activeVoices: number = 0;
+    protected readonly maxVoices: number = 32;
+    protected activeVoiceNodes: Array<{ osc?: OscillatorNode, source?: AudioBufferSourceNode, gain: GainNode, priority: number, endTime: number, timeoutId?: any }> = [];
     
     // ========== REVERB ==========
-    private reverbNode: DelayNode | null = null;
-    private reverbFeedback: GainNode | null = null;
-    private reverbFilter: BiquadFilterNode | null = null;
-    private reverbSend: GainNode | null = null;
+    protected reverbNode: DelayNode | null = null;
+    protected reverbFeedback: GainNode | null = null;
+    protected reverbFilter: BiquadFilterNode | null = null;
+    protected reverbSend: GainNode | null = null;
     
     // ========== ENHANCED ENGINE SYSTEM ==========
-    private engineDroneNode: OscillatorNode | null = null;
-    private engineThrustNode: OscillatorNode | null = null;
-    private engineWhooshNode: AudioBufferSourceNode | null = null;
-    private engineWhooshBuffer: AudioBuffer | null = null;
-    private engineBaseGain: GainNode | null = null;
-    private engineThrustGain: GainNode | null = null;
-    private engineWhooshGain: GainNode | null = null;
-    private engineFilter: BiquadFilterNode | null = null;
-    private engineMasterGain: GainNode | null = null;
-    private lastEngineState: { speedY: number; up: boolean; down: boolean } = { speedY: 0, up: false, down: false };
+    protected engineDroneNode: OscillatorNode | null = null;
+    protected engineThrustNode: OscillatorNode | null = null;
+    protected engineWhooshNode: AudioBufferSourceNode | null = null;
+    protected engineWhooshBuffer: AudioBuffer | null = null;
+    protected engineBaseGain: GainNode | null = null;
+    protected engineThrustGain: GainNode | null = null;
+    protected engineWhooshGain: GainNode | null = null;
+    protected engineFilter: BiquadFilterNode | null = null;
+    protected engineMasterGain: GainNode | null = null;
+    protected lastEngineState: { speedY: number; up: boolean; down: boolean } = { speedY: 0, up: false, down: false };
     
     // ========== DUCKING ==========
-    private isDucked: boolean = false;
+    protected isDucked: boolean = false;
     
     // ========== GRAVITY HUM ==========
-    private gravHumOsc: OscillatorNode | null = null;
-    private gravHumNoise: AudioBufferSourceNode | null = null;
-    private gravHumNoiseFilter: BiquadFilterNode | null = null;
-    private gravHumGain: GainNode | null = null;
-    private gravHumActive: boolean = false;
+    protected gravHumOsc: OscillatorNode | null = null;
+    protected gravHumNoise: AudioBufferSourceNode | null = null;
+    protected gravHumNoiseFilter: BiquadFilterNode | null = null;
+    protected gravHumGain: GainNode | null = null;
+    protected gravHumActive: boolean = false;
     
-    private droneNode: OscillatorNode | null = null;
-    private droneGain: GainNode | null = null;
-    private soundConfigs: Record<SoundType, SoundConfig> = SOUND_CONFIGS;
+    protected droneNode: OscillatorNode | null = null;
+    protected droneGain: GainNode | null = null;
+    protected soundConfigs: Record<SoundType, SoundConfig> = SOUND_CONFIGS;
 
     constructor() {
         // Lazy init - create context on first user interaction

--- a/src/audio_system/index.ts
+++ b/src/audio_system/index.ts
@@ -1,3 +1,13 @@
-export type { SoundType, SoundConfig, MusicLayer, SpatialSound, MagicSequence, MusicState, AudioSystemBase } from './types';
+export type {
+    SoundType,
+    SoundConfig,
+    MusicLayer,
+    SpatialSound,
+    MagicSequence,
+    MusicState,
+    AudioSystemHost,
+    /** @deprecated Use AudioSystemHost */
+    AudioSystemBase,
+} from './types';
 export { AudioSystem } from './AudioSystem';
 export { getAudioSystem, initAudioOnInteraction } from './singleton';

--- a/src/audio_system/types.ts
+++ b/src/audio_system/types.ts
@@ -87,8 +87,8 @@ export interface SpatialSound {
     gain: GainNode | null;
 }
 
-/** Shared `this` context for audio mixins merged onto AudioSystem. */
-export interface AudioSystemBase {
+/** Shared `this` context for audio mixins merged onto {@link AudioSystem}. */
+export interface AudioSystemHost {
     ctx: AudioContext | null;
     masterGain: GainNode | null;
     musicGain: GainNode | null;
@@ -174,10 +174,13 @@ export interface AudioSystemBase {
     updateEngineState(currentSpeedY: number, isMovingUp: boolean, isMovingDown: boolean, isBoosting?: boolean): void;
 }
 
-/** @deprecated Use AudioSystemBase */
-export type AudioMixinHost = AudioSystemBase;
+/** @deprecated Use AudioSystemHost */
+export type AudioSystemBase = AudioSystemHost;
 
-export function bindMixin<T extends Record<string, (this: AudioSystemBase, ...args: any[]) => any>>(mixin: T): T {
+/** @deprecated Use AudioSystemHost */
+export type AudioMixinHost = AudioSystemHost;
+
+export function bindMixin<T extends Record<string, (this: AudioSystemHost, ...args: any[]) => any>>(mixin: T): T {
     return mixin;
 }
 

--- a/src/game_managers.ts
+++ b/src/game_managers.ts
@@ -8,6 +8,7 @@ import { ButterflySwarmSystem } from './butterfly_swarm';
 import { SolarSailFernManager } from './solar_sail_ferns';
 import { WindChimeManager } from './wind_chimes';
 import type { ParticleSystem } from './particles';
+import type { AudioSystem } from './audio_system';
 
 export interface GameManagers {
     friendsManager: FriendsManager;
@@ -28,8 +29,8 @@ let createdManagers: GameManagers | null = null;
  */
 export function createGameManagers(
     scene: THREE.Scene,
-    audioSystem: unknown,
-    particleSystem: unknown
+    audioSystem: AudioSystem,
+    particleSystem: ParticleSystem
 ): GameManagers {
     if (createdManagers) {
         throw new Error('createGameManagers() must only be called once per runtime.');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes the audio_system TypeScript foundation work (P0 / #196 follow-up). The mixin composition pattern from #349cc72 already eliminated all `audio_system/**` errors; this PR tightens the host typing and fixes related call-site issues.

### Changes

- **`AudioSystemHost`**: Renamed the shared mixin `this` interface from `AudioSystemBase` to `AudioSystemHost` (with deprecated aliases preserved). `bindMixin()` now types against `AudioSystemHost`.
- **Protected fields**: `AudioSystem` mixin-accessed state is now `protected` instead of `private`, aligning the class with the host interface contract.
- **Call-site typing**: `createGameManagers()` now accepts `AudioSystem` and `ParticleSystem` instead of `unknown`, fixing 6 baseline errors.
- **Baseline ratchet**: Updated `.github/typecheck-baseline.txt` from 142 → 136 known errors.

### Acceptance criteria

- [x] All `audio_system/**` types used across files are properly exported (`SoundConfig`, `MusicLayer`, `SpatialSound`, `AudioSystemHost`, etc.)
- [x] Mixin `this` is fully typed via `bindMixin` + `AudioSystemHost`; no `as any` crutches for audio fields
- [x] Call sites using `audioSystem.play*`, magic sequences, engine updates typecheck cleanly
- [x] Smoke tests pass (WebGL init, HUD, game loop)

### Verification

```bash
npm run typecheck        # 0 errors in audio_system/**
npm run typecheck:ci     # baseline OK (136 known)
npm run build            # OK
npm run test:smoke       # 2 passed
```

### Notes

Kept the existing `Object.assign` mixin composition (rather than refactoring to collaborator classes) since it already typechecks cleanly and avoids runtime regression risk. Mixin methods are surfaced on `AudioSystem` via interface merging (`AudioSystemMixins`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fa5178c-0cf3-4cc7-bcf3-551e7606b1db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fa5178c-0cf3-4cc7-bcf3-551e7606b1db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

