### PR TITLE
Build hygiene: lockfile, vite config, deploy secrets, script alignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ JS writes object positions directly into the `Float32Array` views, then calls th
 | Environment & backgrounds | `foliage.ts`, `foliage_shared.ts`, `geological.ts`, `stars.ts`, `clouds.ts`, `nebula.ts`, `biological_background.ts`, `industrial_background.ts`, `planetary_horizon.ts`, `sky.ts`, `waterfall.ts`, `reentry.ts`, `asteroid_field.ts`, `environment.ts`, `aurora.ts`, `cosmic_dust.ts`, `meteor_shower.ts`, `ghost_debris.ts` |
 | Gameplay & obstacles | `obstacle_system.ts`, `enemy_patterns.ts`, `weapons.ts`, `boss_system.ts`, `industrial_geometry.ts`, `space_robot_squid.ts`, `slingable_objects.ts`, `sling_combo.ts`, `tether_system.ts` |
 | Visual effects | `particles.ts`, `juice_effects.ts`, `magical_effects.ts`, `lighting.ts`, `flower_constellations.ts`, `cloud_castles.ts`, `candy_obstacles.ts`, `butterfly_swarm.ts`, `lightning_bolt.ts`, `godrays.ts`, `video_tumbling_star.ts` |
-| UI / UX | `ui_controls.ts`, `ui_factory.ts`, `hud_system.ts`, `touch_controls.ts`, `touch_settings.ts`, `touch_integration_example.ts`, `tutorial_system.ts`, `victory_system.ts`, `debug_system.ts` |
+| UI / UX | `ui_controls.ts`, `ui_factory.ts`, `hud_system.ts`, `touch_controls.ts`, `touch_settings.ts`, `docs/touch_integration_example.ts`, `tutorial_system.ts`, `victory_system.ts`, `debug_system.ts` |
 | Performance guardrails | `decoration_budget.ts`, `docs/PERFORMANCE_BUDGETS.md` |
 | Progression & economy | `upgrade_system.ts`, `powerup_manager.ts`, `collectibles.ts`, `save_manager.ts`, `boost_system.ts`, `roll_system.ts` |
 | Characters | `dog_cockpit.ts`, `space_friends.ts`, `player_loader.ts` |
@@ -90,4 +90,4 @@ New 3D props (flowers, creatures, ribbons, background layers) **must** register 
 
 ## Deployment
 
-`deploy.py` uploads `dist/` to `test.1ink.us/dog-dash` via SFTP (Paramiko). It contains hardcoded credentials — do not commit modified versions with credentials in plaintext, and avoid running it without explicit user instruction.
+Optional deploy helpers live in `deploy.py` (Contabo bundle API) and `scripts/deploy.py` (direct SFTP). **Credentials are environment variables only** — see `docs/DEPLOY.md`. Do not commit tokens, passwords, or host-specific secrets.

--- a/README.md
+++ b/README.md
@@ -20,12 +20,16 @@ Dog Dash - A 3D world exploration game.
 
 ### Development
 
-1. Install dependencies:
+1. Install dependencies (use `npm ci` in CI or when you want a lockfile-exact install):
+
    ```bash
-   npm install
+   npm ci          # reproducible install from package-lock.json
+   # or
+   npm install     # local development
    ```
 
-2. Start the development server:
+2. Start the development server (`predev` rebuilds AssemblyScript WASM automatically):
+
    ```bash
    npm run dev
    ```
@@ -34,7 +38,8 @@ Dog Dash - A 3D world exploration game.
 
 ### Production Build
 
-Build the project for production:
+Build the project for production (`prebuild` runs brace check + WASM rebuild, then Vite bundles with `vite.config.ts`):
+
 ```bash
 npm run build
 ```
@@ -145,4 +150,4 @@ Navigate your rocket through 6 massive levels, blasting asteroids and dodging cr
 - **WASM Physics** - AssemblyScript for collision detection
 - **Mathematical Patterns** - Procedural enemy formations using parametric equations
 - Modern WebGPU API for next-generation graphics, with WebGL2 available for debugging and compatibility checks
-- Vite build system for fast development
+- Vite build system for fast development (`vite.config.ts` — ES2022 target, `public/` assets, optional code splitting)

--- a/deploy.py
+++ b/deploy.py
@@ -1,20 +1,11 @@
 #!/usr/bin/env python3
 """
-project_deploy_template.py
-
-Copy this file into your project as `deploy.py` (or deploy_contabo.py).
-Customize the constants at the top for your project.
+Deploy the production build via the Contabo storage manager API.
 
 Usage:
-  1. Build your project:  npm run build   (or python build, etc.)
-  2. python deploy.py
-
-This script contacts https://storage.noahcohn.com (your Contabo storage manager)
-to upload your entire build as a single zip archive.  The server extracts it and
-pushes all files over one persistent SFTP connection — much faster than uploading
-files individually.
-
-Actual FTP/SFTP credentials never leave the VPS.
+  1. Build: npm run build
+  2. export DEPLOY_TOKEN="..."   # required — see docs/DEPLOY.md
+  3. python deploy.py
 
 Requirements:
   pip install requests
@@ -30,16 +21,15 @@ from typing import Optional
 import requests
 
 # ============================================================
-# PER-PROJECT CONFIGURATION - EDIT THESE
+# PER-PROJECT CONFIGURATION (non-secret defaults only)
 # ============================================================
-PROJECT_NAME: str = 'dog-dash'
-BUILD_DIR: str = 'dist'
-CONTABO_BASE_URL: str = "https://storage.noahcohn.com"
-DEPLOY_FOLDER: str = ""  # override remote target folder; empty = use PROJECT_NAME
+PROJECT_NAME: str = os.environ.get('DEPLOY_PROJECT_NAME', 'dog-dash')
+BUILD_DIR: str = os.environ.get('DEPLOY_BUILD_DIR', 'dist')
+CONTABO_BASE_URL: str = os.environ.get('DEPLOY_CONTABO_URL', 'https://storage.noahcohn.com')
+DEPLOY_FOLDER: str = os.environ.get('DEPLOY_FOLDER', '')
 
-# Optional deploy token (recommended for security).
-# Set via environment: export DEPLOY_TOKEN="your_long_token_from_vps_env"
-DEPLOY_TOKEN: Optional[str] = "6de44dca5425348f2e2ef9456fc820bfe56a5ace68bddeb6da4a1c2a9d9cadc0"
+# Required secret — never commit tokens to the repository.
+DEPLOY_TOKEN: Optional[str] = os.environ.get('DEPLOY_TOKEN')
 # ============================================================
 
 
@@ -51,7 +41,6 @@ def build_zip(build_path: Path) -> bytes:
             if file.is_dir():
                 continue
             rel = file.relative_to(build_path)
-            # Skip common junk
             parts = rel.parts
             if any(p in (".git", "node_modules", "__pycache__") for p in parts):
                 continue
@@ -62,11 +51,13 @@ def build_zip(build_path: Path) -> bytes:
 
 def deploy_bundle(build_path: Path) -> bool:
     """Zip the build and upload it as a single bundle."""
+    if not DEPLOY_TOKEN:
+        print("Error: DEPLOY_TOKEN is required. See docs/DEPLOY.md.")
+        return False
+
     target_folder = DEPLOY_FOLDER or PROJECT_NAME
     url = f"{CONTABO_BASE_URL}/api/deploy/{PROJECT_NAME}/bundle"
-    headers = {}
-    if DEPLOY_TOKEN:
-        headers["X-Deploy-Token"] = DEPLOY_TOKEN
+    headers = {"X-Deploy-Token": DEPLOY_TOKEN}
 
     print("Building zip archive...")
     zip_bytes = build_zip(build_path)
@@ -99,7 +90,7 @@ def deploy_bundle(build_path: Path) -> bool:
 
 
 def main():
-    print(f"\n=== Deploying '{PROJECT_NAME}' via Contabo -> storage.1ink.us ===\n")
+    print(f"\n=== Deploying '{PROJECT_NAME}' via Contabo storage API ===\n")
 
     build_path = Path(BUILD_DIR)
     if not build_path.exists() or not build_path.is_dir():
@@ -110,9 +101,9 @@ def main():
     try:
         health = requests.get(f"{CONTABO_BASE_URL}/api/deploy/health", timeout=10)
         if health.status_code == 200:
-            print(f"Contabo deploy service: {health.json().get('status', 'unknown')}")
+            print(f"Deploy service: {health.json().get('status', 'unknown')}")
     except Exception:
-        print("Warning: Could not contact storage.noahcohn.com (continuing anyway).")
+        print(f"Warning: Could not contact {CONTABO_BASE_URL} (continuing anyway).")
 
     print()
     success = deploy_bundle(build_path)

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,46 @@
+# Deployment
+
+Dog Dash has two optional deploy helpers. **Neither stores credentials in the repository.** Set secrets via environment variables (or a local `.env` file that is gitignored).
+
+## Contabo bundle deploy (`deploy.py`)
+
+Uploads `dist/` as a zip to the Contabo storage manager API.
+
+```bash
+npm run build
+export DEPLOY_TOKEN="your-deploy-token"
+python deploy.py
+```
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DEPLOY_TOKEN` | Yes | API token issued by the storage manager |
+| `DEPLOY_PROJECT_NAME` | No | Defaults to `dog-dash` |
+| `DEPLOY_BUILD_DIR` | No | Defaults to `dist` |
+| `DEPLOY_CONTABO_URL` | No | API base URL |
+| `DEPLOY_FOLDER` | No | Remote folder override (defaults to project name) |
+
+## Direct SFTP deploy (`scripts/deploy.py`)
+
+Recursively uploads `dist/` over SFTP. Requires `paramiko` (`pip install paramiko`).
+
+```bash
+npm run build
+export DEPLOY_HOST="example.com"
+export DEPLOY_USER="deploy-user"
+export DEPLOY_REMOTE_DIR="public_html/dog-dash"
+export DEPLOY_PASSWORD="..."          # or DEPLOY_SSH_KEY_PATH=/path/to/key
+python scripts/deploy.py
+```
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DEPLOY_HOST` | Yes | SFTP/SSH hostname |
+| `DEPLOY_USER` | Yes | SSH username |
+| `DEPLOY_REMOTE_DIR` | Yes | Target directory on the server |
+| `DEPLOY_PASSWORD` | One of | SSH password (prompted if omitted in a TTY) |
+| `DEPLOY_SSH_KEY_PATH` | One of | Path to a private key file |
+| `DEPLOY_PORT` | No | Defaults to `22` |
+| `DEPLOY_LOCAL_DIR` | No | Defaults to `dist` |
+
+**Security:** Do not commit tokens, passwords, or host-specific usernames. Rotate any credentials that were previously committed to git history.

--- a/docs/TOUCH_CONTROLS.md
+++ b/docs/TOUCH_CONTROLS.md
@@ -131,7 +131,7 @@ enum ControlMode {
 |------|-------------|
 | `touch_controls.ts` | Main touch controls system |
 | `touch_settings.ts` | Settings UI and persistence |
-| `touch_integration_example.ts` | Integration examples |
+| `docs/touch_integration_example.ts` | Integration examples (documentation only) |
 
 ## Customization
 

--- a/docs/plans/AGENTS.md
+++ b/docs/plans/AGENTS.md
@@ -156,7 +156,7 @@ When you need to find or add functionality, start in the module that matches the
 | **Environment & Backgrounds** | `foliage.ts`, `foliage_shared.ts`, `geological.ts`, `stars.ts`, `clouds.ts`, `nebula.ts`, `biological_background.ts`, `industrial_background.ts`, `planetary_horizon.ts`, `sky.ts`, `waterfall.ts`, `reentry.ts`, `asteroid_field.ts`, `environment.ts` |
 | **Gameplay & Obstacles** | `obstacle_system.ts`, `enemy_patterns.ts`, `weapons.ts`, `boss_system.ts`, `industrial_geometry.ts`, `space_robot_squid.ts` |
 | **Visual Effects** | `particles.ts`, `juice_effects.ts`, `magical_effects.ts`, `lighting.ts`, `flower_constellations.ts`, `cloud_castles.ts`, `candy_obstacles.ts`, `butterfly_swarm.ts` |
-| **UI / UX** | `ui_controls.ts`, `hud_system.ts`, `touch_controls.ts`, `touch_settings.ts`, `touch_integration_example.ts`, `tutorial_system.ts`, `victory_system.ts` |
+| **UI / UX** | `ui_controls.ts`, `hud_system.ts`, `touch_controls.ts`, `touch_settings.ts`, `docs/touch_integration_example.ts`, `tutorial_system.ts`, `victory_system.ts` |
 | **Progression & Economy** | `upgrade_system.ts`, `powerup_manager.ts`, `collectibles.ts`, `save_manager.ts`, `level_config.ts` |
 | **Characters** | `dog_cockpit.ts`, `space_friends.ts` |
 | **Movement & Abilities** | `boost_system.ts`, `roll_system.ts` |

--- a/docs/touch_integration_example.ts
+++ b/docs/touch_integration_example.ts
@@ -1,8 +1,8 @@
 /**
  * Touch Controls Integration Example for Dog Dash
- * 
- * This file shows how to integrate touch controls into main.ts
- * Copy these code snippets into the appropriate locations in main.ts
+ *
+ * Documentation-only: copy snippets into `src/main.ts` as needed.
+ * See also `docs/TOUCH_CONTROLS.md`.
  */
 
 // =============================================================================
@@ -10,15 +10,15 @@
 // =============================================================================
 
 /*
-import { 
-    TouchControlsManager, 
-    ControlMode, 
+import {
+    TouchControlsManager,
+    ControlMode,
     TouchInput,
     detectTouchDevice,
     getRecommendedControlMode,
     isTouchPrimary
 } from './touch_controls';
-import { 
+import {
     createTouchSettingsButton,
     showTouchSettings,
     loadTouchSettings
@@ -70,11 +70,11 @@ let isMovingDown = keys.left;              // A or Left arrow
 if (touchControls) {
     const touchInput = touchControls.getInput();
     touchControls.update(); // Update touch controls each frame
-    
+
     // Combine keyboard and touch input
     if (touchInput.vertical > 0.1) isMovingUp = true;
     if (touchInput.vertical < -0.1) isMovingDown = true;
-    
+
     // Handle boost from touch
     if (touchInput.boost) {
         // Apply boost effect
@@ -83,13 +83,13 @@ if (touchControls) {
             CONFIG.player.maxSpeedY * 2
         );
     }
-    
+
     // Handle fire from touch
     if (touchInput.fire) {
         const fireDirection = new THREE.Vector3(1, 0, 0);
         weaponSystem.fire(player.position, fireDirection);
     }
-    
+
     // Handle pause from touch (long hold)
     if (touchInput.pause && !isGamePaused) {
         togglePause();
@@ -110,7 +110,7 @@ if (touchControls && player) {
     vector.project(camera);
     const screenX = (vector.x * 0.5 + 0.5) * window.innerWidth;
     const screenY = (-vector.y * 0.5 + 0.5) * window.innerHeight;
-    
+
     touchControls.setRocketPosition(
         player.position,
         new THREE.Vector2(screenX, screenY)
@@ -144,7 +144,7 @@ function cleanupTouchControls() {
 /*
 window.addEventListener('resize', () => {
     // Existing resize code...
-    
+
     // Update touch controls
     if (touchControls) {
         touchControls.hide();
@@ -174,11 +174,11 @@ touchControls.setMode(ControlMode.FOLLOW_FINGER);
 // 3. In animate loop, map touch to keyboard keys
 function animate() {
     // ... existing code ...
-    
+
     // Sync touch to keyboard keys
     const touchInput = touchControls.getInput();
     touchControls.update();
-    
+
     // Map touch vertical to keyboard keys
     if (touchInput.vertical > 0.2) {
         uiKeys.jump = true;
@@ -190,13 +190,7 @@ function animate() {
         uiKeys.jump = false;
         uiKeys.left = false;
     }
-    
+
     // ... rest of animate loop ...
 }
 */
-
-// =============================================================================
-// EXPORTS for TypeScript
-// =============================================================================
-
-export {};

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "prebuild": "node tools/check_braces.cjs",
-    "build": "npm run build:wasm && npm run copy:wasm && vite build",
+    "prebuild": "node tools/check_braces.cjs && npm run build:wasm && npm run copy:wasm",
+    "build": "vite build",
     "preview": "vite preview",
     "build:wasm": "asc assembly/index.ts -o build/optimized.wasm -t build/optimized.wat --sourceMap --initialMemory 2 --optimize",
     "copy:wasm": "node -e \"const fs=require('fs'); fs.mkdirSync('public/build', { recursive: true }); ['optimized.wasm','optimized.wasm.map'].forEach(f => { const src = 'build/' + f; const dest = 'public/build/' + f; if (fs.existsSync(src)) fs.copyFileSync(src, dest); });\"",

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -1,19 +1,19 @@
 import os
+import sys
 import paramiko
 import getpass
 
-# --- Server Configuration ---
-# Replace these with your server's details.
-# It's better to use environment variables or a config file for sensitive data.
-HOSTNAME = "1ink.us"
-PORT = 22  # Default SFTP/SSH port
-USERNAME = "ford442"
+# --- Server Configuration (environment variables only) ---
+# Required: DEPLOY_HOST, DEPLOY_USER
+# Auth: DEPLOY_PASSWORD and/or DEPLOY_SSH_KEY_PATH
+HOSTNAME = os.environ.get('DEPLOY_HOST')
+PORT = int(os.environ.get('DEPLOY_PORT', '22'))
+USERNAME = os.environ.get('DEPLOY_USER')
+SSH_KEY_PATH = os.environ.get('DEPLOY_SSH_KEY_PATH')
 
 # --- Project Configuration ---
-# The local directory to upload from.
-LOCAL_DIRECTORY = "dist"
-# The directory on the server where the files should go (e.g., 'public_html/wasm-game').
-REMOTE_DIRECTORY = "test.1ink.us/dog-dash"
+LOCAL_DIRECTORY = os.environ.get('DEPLOY_LOCAL_DIR', 'dist')
+REMOTE_DIRECTORY = os.environ.get('DEPLOY_REMOTE_DIR')
 
 def upload_directory(sftp_client, local_path, remote_path):
     """
@@ -21,10 +21,8 @@ def upload_directory(sftp_client, local_path, remote_path):
     """
     print(f"Creating remote directory: {remote_path}")
     try:
-        # Create the target directory on the server if it doesn't exist.
         sftp_client.mkdir(remote_path)
     except IOError:
-        # Directory already exists, which is fine.
         print(f"Directory {remote_path} already exists.")
 
     for item in os.listdir(local_path):
@@ -35,37 +33,58 @@ def upload_directory(sftp_client, local_path, remote_path):
             print(f"Uploading file: {local_item_path} -> {remote_item_path}")
             sftp_client.put(local_item_path, remote_item_path)
         elif os.path.isdir(local_item_path):
-            # If it's a directory, recurse into it.
             upload_directory(sftp_client, local_item_path, remote_item_path)
+
+def connect_transport():
+    if not HOSTNAME or not USERNAME:
+        print("Error: set DEPLOY_HOST and DEPLOY_USER before running deploy.")
+        print("See docs/DEPLOY.md for required environment variables.")
+        sys.exit(1)
+
+    password = os.environ.get('DEPLOY_PASSWORD')
+    if not password and not SSH_KEY_PATH and sys.stdin.isatty():
+        password = getpass.getpass(f"Enter password for {USERNAME}@{HOSTNAME}: ")
+
+    transport = paramiko.Transport((HOSTNAME, PORT))
+
+    if SSH_KEY_PATH:
+        pkey = paramiko.RSAKey.from_private_key_file(SSH_KEY_PATH)
+        transport.connect(username=USERNAME, pkey=pkey)
+    elif password:
+        transport.connect(username=USERNAME, password=password)
+    else:
+        print("Error: provide DEPLOY_PASSWORD, DEPLOY_SSH_KEY_PATH, or run interactively.")
+        sys.exit(1)
+
+    return transport
 
 def main():
     """
     Main function to connect to the server and start the upload process.
     """
-    password = 'GoogleBez12!' # getpass.getpass(f"Enter password for {USERNAME}@{HOSTNAME}: ")
+    if not REMOTE_DIRECTORY:
+        print("Error: set DEPLOY_REMOTE_DIR to the target path on the server.")
+        print("See docs/DEPLOY.md for required environment variables.")
+        sys.exit(1)
 
     transport = None
     sftp = None
     try:
-        # Establish the SSH connection
-        transport = paramiko.Transport((HOSTNAME, PORT))
         print("Connecting to server...")
-        transport.connect(username=USERNAME, password=password)
+        transport = connect_transport()
         print("Connection successful!")
 
-        # Create an SFTP client from the transport
         sftp = paramiko.SFTPClient.from_transport(transport)
         print(f"Starting upload of '{LOCAL_DIRECTORY}' to '{REMOTE_DIRECTORY}'...")
 
-        # Start the recursive upload
         upload_directory(sftp, LOCAL_DIRECTORY, REMOTE_DIRECTORY)
 
         print("\n✅ Deployment complete!")
 
     except Exception as e:
         print(f"❌ An error occurred: {e}")
+        sys.exit(1)
     finally:
-        # Ensure the connection is closed
         if sftp:
             sftp.close()
         if transport:
@@ -75,5 +94,5 @@ def main():
 if __name__ == "__main__":
     if not os.path.exists(LOCAL_DIRECTORY):
         print(f"Error: Local directory '{LOCAL_DIRECTORY}' not found. Did you run 'npm run build' first?")
-    else:
-        main()
+        sys.exit(1)
+    main()

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,10 @@ function isLevelHeavyModule(id: string): boolean {
 }
 
 export default defineConfig({
+    root: '.',
+    publicDir: 'public',
     build: {
+        target: 'es2022',
         rollupOptions: {
             output: {
                 manualChunks(id) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses several compounding build-hygiene gaps without adding new dependencies.

- **`package-lock.json`**: Already tracked (removed from `.gitignore` in an earlier PR). README now documents `npm ci` for reproducible CI/local installs.
- **`vite.config.ts`**: Adds explicit `root`, `publicDir`, and `build.target: 'es2022'` while keeping existing `manualChunks` splitting (three/audio/level-heavy).
- **Dead / phantom deps**: No direct orphan packages in `package.json`. `@dimforge/rapier3d-compat` is a transitive dev dependency of `@types/three` (types only, not imported in `src/`). Moved documentation-only `touch_integration_example.ts` from `src/` to `docs/`.
- **Deploy scripts**: Removed hardcoded password/token/host defaults from `deploy.py` and `scripts/deploy.py`. Added `docs/DEPLOY.md` listing required environment variables.
- **Script alignment**: `prebuild` now runs brace check + WASM rebuild (matching CLAUDE.md); `build` is `vite build` only.

## Acceptance criteria

- [x] `package-lock.json` tracked; `npm ci` works cleanly
- [x] `vite.config.ts` present and used by dev/build
- [x] No orphan physics/audio packages referenced only via stale `node_modules` (lockfile matches `package.json`; rapier is a legitimate `@types/three` transitive dep)
- [x] Deploy docs warn about secrets; no plaintext credentials required in-repo
- [x] README build section matches actual scripts

## Test plan

- [x] `npm ci`
- [x] `npm run check`
- [x] `npm run build` (WASM prebuild + Vite bundle succeeds; chunks split as expected)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b154bfb-e87b-4cdf-988a-d0817cc355aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b154bfb-e87b-4cdf-988a-d0817cc355aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

