### PR TITLE
feat: Space Base between-run hub shell

### DIFF
--- a/.github/typecheck-baseline.txt
+++ b/.github/typecheck-baseline.txt
@@ -105,7 +105,7 @@ src/magical_effects/stardust_field.ts(21,3): TS2564: Property 'duration' has no 
 src/magical_effects/stardust_field.ts(21,3): TS2612: Property 'duration' will overwrite the base property in 'MagicalEffect'. If this is intentional, add an initializer. Otherwise, add a 'declare' modifier or remove the redundant declaration.
 src/main/grav_lens_update.ts(81,43): TS2345: Argument of type 'SlingshotGrade' is not assignable to parameter of type '"perfect" | "partial" | "failed"'.
 src/main/grav_lens_update.ts(92,50): TS2345: Argument of type 'SlingQuality' is not assignable to parameter of type '"perfect" | "good" | "ok" | undefined'.
-src/main/input_bindings.ts(170,59): TS2345: Argument of type 'InstancedMesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], InstancedMeshEventMap>' is not assignable to parameter of type 'Object3D<Object3DEventMap>[]'.
+src/main/input_bindings.ts(180,59): TS2345: Argument of type 'InstancedMesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], InstancedMeshEventMap>' is not assignable to parameter of type 'Object3D<Object3DEventMap>[]'.
 src/main/loop_geological.ts(340,59): TS2345: Argument of type 'Group<Object3DEventMap>' is not assignable to parameter of type 'Mesh<BufferGeometry<NormalBufferAttributes, BufferGeometryEventMap>, Material | Material[], Object3DEventMap>'.
 src/main/loop_geological.ts(349,78): TS18047: 'player' is possibly 'null'.
 src/main/loop_geological.ts(373,50): TS18047: 'player' is possibly 'null'.

--- a/src/bestiary.ts
+++ b/src/bestiary.ts
@@ -148,10 +148,38 @@ export const BESTIARY_ENTRIES: Record<BestiaryEntryId, BestiaryEntry> = {
     }
 };
 
+/** Renders the bestiary entry grid (cataloged + locked silhouettes). Shared by the modal and the hub. */
+export function createBestiaryGrid(saveManager: SaveManager): HTMLDivElement {
+    const cataloged = new Set(saveManager.getCatalogedCreatures());
+
+    const grid = document.createElement('div');
+    grid.style.cssText = 'display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 14px; max-width: 720px; width: 90%; max-height: 55vh; overflow-y: auto; padding: 4px;';
+
+    for (const entry of Object.values(BESTIARY_ENTRIES)) {
+        const known = cataloged.has(entry.id);
+        const el = document.createElement('div');
+        el.style.cssText = `
+            background: rgba(255,255,255,0.08);
+            padding: 14px;
+            border-radius: 10px;
+            border: 2px solid ${known ? '#44ddaa' : '#444'};
+            opacity: ${known ? 1 : 0.55};
+        `;
+        el.innerHTML = `
+            <div style="font-size: 2em; margin-bottom: 4px;">${known ? entry.icon : '❓'}</div>
+            <div style="font-weight: bold; font-size: 1.05em; margin-bottom: 4px; color: white;">${known ? entry.name : '???'}</div>
+            <div style="font-size: 0.85em; color: #ccc; margin-bottom: 6px;">${known ? entry.flavor : 'Not yet cataloged. ' + entry.howTo}</div>
+            ${known ? `<div style="font-size: 0.8em; color: #88ffcc;">${entry.memoryDesc}</div>` : ''}
+        `;
+        grid.appendChild(el);
+    }
+
+    return grid;
+}
+
 /** Renders the "Weird Life Log" bestiary modal. Caller is responsible for appending/removing it. */
 export function createBestiaryUI(saveManager: SaveManager, onClose: () => void): HTMLDivElement {
     const cataloged = new Set(saveManager.getCatalogedCreatures());
-
     const container = document.createElement('div');
     container.style.cssText = `
         position: fixed;
@@ -177,34 +205,15 @@ export function createBestiaryUI(saveManager: SaveManager, onClose: () => void):
         <p style="font-size: 1.1em; color: #88ccff; margin-bottom: 20px;">
             ${cataloged.size} / ${total} creatures cataloged
         </p>
-        <div id="bestiary-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 14px; max-width: 720px; width: 90%; max-height: 55vh; overflow-y: auto; padding: 4px;"></div>
         <button id="close-bestiary" style="margin-top: 24px; padding: 12px 36px; font-size: 1.1em; background: #444; color: white; border: none; border-radius: 8px; cursor: pointer;">
             Close
         </button>
     `;
 
-    const grid = container.querySelector('#bestiary-grid')!;
+    const closeBtn = container.querySelector('#close-bestiary')!;
+    container.insertBefore(createBestiaryGrid(saveManager), closeBtn);
 
-    for (const entry of Object.values(BESTIARY_ENTRIES)) {
-        const known = cataloged.has(entry.id);
-        const el = document.createElement('div');
-        el.style.cssText = `
-            background: rgba(255,255,255,0.08);
-            padding: 14px;
-            border-radius: 10px;
-            border: 2px solid ${known ? '#44ddaa' : '#444'};
-            opacity: ${known ? 1 : 0.55};
-        `;
-        el.innerHTML = `
-            <div style="font-size: 2em; margin-bottom: 4px;">${known ? entry.icon : '❓'}</div>
-            <div style="font-weight: bold; font-size: 1.05em; margin-bottom: 4px;">${known ? entry.name : '???'}</div>
-            <div style="font-size: 0.85em; color: #ccc; margin-bottom: 6px;">${known ? entry.flavor : 'Not yet cataloged. ' + entry.howTo}</div>
-            ${known ? `<div style="font-size: 0.8em; color: #88ffcc;">${entry.memoryDesc}</div>` : ''}
-        `;
-        grid.appendChild(el);
-    }
-
-    container.querySelector('#close-bestiary')!.addEventListener('click', () => {
+    closeBtn.addEventListener('click', () => {
         container.remove();
         onClose();
     });

--- a/src/discovery_system.ts
+++ b/src/discovery_system.ts
@@ -127,6 +127,10 @@ export class CreatureCatalogManager {
         this.catalogedThisRun.clear();
     }
 
+    getCatalogedCountThisRun(): number {
+        return this.catalogedThisRun.size;
+    }
+
     /** Records a non-lethal encounter with a bestiary creature. */
     catalog(id: BestiaryEntryId): void {
         if (this.catalogedThisRun.has(id)) return;

--- a/src/hub_screen.ts
+++ b/src/hub_screen.ts
@@ -1,0 +1,476 @@
+/**
+ * Space Base — the calm between-run hub shell.
+ *
+ * A DOM overlay (no WebGPU needed) that surfaces meta-progression already
+ * persisted by SaveManager: cores balance, permanent upgrades, the Weird
+ * Life Log bestiary, and chapter select via unlockedLevels. Opened from the
+ * victory, game-over, and pause screens (see src/main/hub_integration.ts).
+ */
+
+import { SaveManager, type PlayerUpgrades } from './save_manager';
+import { createBestiaryGrid, BESTIARY_ENTRIES } from './bestiary';
+import { SPECIES_NAMES } from './discovery_system';
+import { LEVEL_CONFIG } from './level_config';
+
+export type HubMode = 'victory' | 'gameover' | 'pause';
+
+/** Snapshot of the run that just ended (or is paused). */
+export interface HubRunSummary {
+    distance: number;
+    coresEarned: number;
+    speciesDiscovered: number;
+    creaturesCataloged: number;
+}
+
+export interface HubScreenOptions {
+    mode: HubMode;
+    summary?: HubRunSummary;
+    /** Launch (or relaunch) a run starting at this chapter (1-6). */
+    onLaunchChapter: (chapter: number) => void;
+    /** Close the hub and return to whatever screen opened it. */
+    onClose: () => void;
+    playSound?: (name: 'ui_click' | 'twinkle') => void;
+}
+
+const CHAPTER_COUNT = 6;
+
+// Persisted "start at this chapter" request, consumed on the next boot
+// (restarts go through location.reload(), so this must survive it).
+const PENDING_CHAPTER_KEY = 'dog_dash_pending_chapter';
+
+export function setPendingStartChapter(chapter: number): void {
+    try {
+        localStorage.setItem(PENDING_CHAPTER_KEY, String(chapter));
+    } catch (e) {
+        console.warn('Failed to store pending chapter:', e);
+    }
+}
+
+/** Reads and clears the requested start chapter. Null when none was set. */
+export function consumePendingStartChapter(): number | null {
+    try {
+        const raw = localStorage.getItem(PENDING_CHAPTER_KEY);
+        if (raw === null) return null;
+        localStorage.removeItem(PENDING_CHAPTER_KEY);
+        const chapter = parseInt(raw, 10);
+        return Number.isFinite(chapter) ? chapter : null;
+    } catch (e) {
+        return null;
+    }
+}
+
+// Kid-friendly pastel palette (matches hud_system/styles.ts)
+const HUB_COLORS = {
+    pinkLight: '#FFD1DC',
+    lavender: '#E6E6FA',
+    mint: '#98FB98',
+    peach: '#FFDAB9',
+    sky: '#B0E0E6',
+    lemon: '#FFFACD',
+    gold: '#FFD700',
+    white: '#FFFFFF',
+    textDark: '#5D4E6D',
+    textLight: '#8B7B8B',
+    shadow: 'rgba(147, 112, 219, 0.3)'
+};
+
+interface ShopItem {
+    key: keyof PlayerUpgrades;
+    icon: string;
+    name: string;
+    desc: string;
+}
+
+const SHOP_ITEMS: ShopItem[] = [
+    { key: 'maxHealthBonus', icon: '💖', name: 'Tougher Rocket', desc: '+1 heart forever' },
+    { key: 'startingHealth', icon: '🛡️', name: 'Lucky Charm', desc: '+1 spare heart at launch' },
+    { key: 'fireRateBonus', icon: '⭐', name: 'Zippy Blaster', desc: 'Shoot 10% faster' },
+    { key: 'speedBonus', icon: '🚀', name: 'Super Thrusters', desc: 'Fly 10% faster' }
+];
+
+type HubTab = 'home' | 'shop' | 'log' | 'journey';
+
+export function createHubScreen(saveManager: SaveManager, options: HubScreenOptions): HTMLDivElement {
+    const play = options.playSound ?? (() => {});
+    let activeTab: HubTab = 'home';
+
+    const container = document.createElement('div');
+    container.id = 'hub-screen';
+    container.style.cssText = `
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: linear-gradient(160deg, #2a2547 0%, #453a6b 55%, #6b5a8e 100%);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        z-index: 1500;
+        font-family: 'Segoe UI', 'Comic Sans MS', sans-serif;
+        color: ${HUB_COLORS.textDark};
+        overflow: hidden;
+    `;
+
+    // Header: title + cores balance
+    const header = document.createElement('div');
+    header.style.cssText = `
+        width: 100%;
+        max-width: 720px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 16px 20px 8px 20px;
+        box-sizing: border-box;
+    `;
+    const title = document.createElement('div');
+    title.style.cssText = `
+        font-size: clamp(22px, 5vw, 32px);
+        font-weight: bold;
+        color: ${HUB_COLORS.white};
+        text-shadow: 0 2px 8px ${HUB_COLORS.shadow};
+    `;
+    title.textContent = '🐕 Space Base 🌙';
+
+    const coresChip = document.createElement('div');
+    coresChip.id = 'hub-cores-chip';
+    coresChip.style.cssText = `
+        background: linear-gradient(135deg, ${HUB_COLORS.lemon}, ${HUB_COLORS.gold});
+        border: 3px solid ${HUB_COLORS.white};
+        border-radius: 20px;
+        padding: 8px 16px;
+        font-size: clamp(16px, 4vw, 20px);
+        font-weight: bold;
+        white-space: nowrap;
+        box-shadow: 0 4px 12px ${HUB_COLORS.shadow};
+    `;
+    header.appendChild(title);
+    header.appendChild(coresChip);
+
+    // Tab bar
+    const tabBar = document.createElement('div');
+    tabBar.style.cssText = `
+        display: flex;
+        gap: 8px;
+        width: 100%;
+        max-width: 720px;
+        padding: 8px 20px;
+        box-sizing: border-box;
+    `;
+
+    const tabs: { id: HubTab; label: string }[] = [
+        { id: 'home', label: '🏠 Home' },
+        { id: 'shop', label: '⚡ Shop' },
+        { id: 'log', label: '📖 Life Log' },
+        { id: 'journey', label: '🗺️ Chapters' }
+    ];
+    const tabButtons = new Map<HubTab, HTMLButtonElement>();
+
+    // Scrollable content panel
+    const panel = document.createElement('div');
+    panel.style.cssText = `
+        flex: 1;
+        width: 100%;
+        max-width: 720px;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+        padding: 8px 20px;
+        box-sizing: border-box;
+    `;
+
+    // Footer: close button
+    const footer = document.createElement('div');
+    footer.style.cssText = `
+        width: 100%;
+        max-width: 720px;
+        display: flex;
+        gap: 12px;
+        padding: 10px 20px calc(16px + env(safe-area-inset-bottom, 0px)) 20px;
+        box-sizing: border-box;
+    `;
+
+    const closeBtn = bigButton(
+        options.mode === 'pause' ? '▶️ Back to Flight' : '↩️ Back',
+        HUB_COLORS.peach,
+        () => {
+            play('ui_click');
+            container.remove();
+            options.onClose();
+        }
+    );
+    closeBtn.style.flex = '1';
+    footer.appendChild(closeBtn);
+
+    container.appendChild(header);
+    container.appendChild(tabBar);
+    container.appendChild(panel);
+    container.appendChild(footer);
+
+    function bigButton(text: string, color: string, onClick: () => void): HTMLButtonElement {
+        const btn = document.createElement('button');
+        btn.textContent = text;
+        btn.style.cssText = `
+            min-height: 54px;
+            padding: 12px 20px;
+            font-size: clamp(16px, 4vw, 19px);
+            font-weight: bold;
+            font-family: inherit;
+            background: linear-gradient(135deg, ${color}, ${HUB_COLORS.white});
+            border: 3px solid ${HUB_COLORS.white};
+            border-radius: 18px;
+            color: ${HUB_COLORS.textDark};
+            cursor: pointer;
+            box-shadow: 0 4px 12px ${HUB_COLORS.shadow};
+            touch-action: manipulation;
+        `;
+        btn.addEventListener('click', onClick);
+        return btn;
+    }
+
+    function card(): HTMLDivElement {
+        const el = document.createElement('div');
+        el.style.cssText = `
+            background: rgba(255, 255, 255, 0.92);
+            border-radius: 20px;
+            padding: 16px;
+            margin-bottom: 12px;
+            box-shadow: 0 4px 14px ${HUB_COLORS.shadow};
+        `;
+        return el;
+    }
+
+    function refreshCores(): void {
+        coresChip.textContent = `🔷 ${saveManager.getCores()} cores`;
+    }
+
+    function switchTab(tab: HubTab): void {
+        activeTab = tab;
+        tabButtons.forEach((btn, id) => {
+            const active = id === tab;
+            btn.style.background = active
+                ? `linear-gradient(135deg, ${HUB_COLORS.pinkLight}, ${HUB_COLORS.white})`
+                : 'rgba(255,255,255,0.25)';
+            btn.style.color = active ? HUB_COLORS.textDark : HUB_COLORS.white;
+            btn.style.borderColor = active ? HUB_COLORS.white : 'rgba(255,255,255,0.4)';
+        });
+        renderPanel();
+    }
+
+    for (const tab of tabs) {
+        const btn = document.createElement('button');
+        btn.textContent = tab.label;
+        btn.style.cssText = `
+            flex: 1;
+            min-height: 48px;
+            padding: 8px 4px;
+            font-size: clamp(13px, 3.4vw, 16px);
+            font-weight: bold;
+            font-family: inherit;
+            border: 3px solid rgba(255,255,255,0.4);
+            border-radius: 16px;
+            cursor: pointer;
+            touch-action: manipulation;
+            background: rgba(255,255,255,0.25);
+            color: ${HUB_COLORS.white};
+        `;
+        btn.addEventListener('click', () => {
+            play('ui_click');
+            switchTab(tab.id);
+        });
+        tabButtons.set(tab.id, btn);
+        tabBar.appendChild(btn);
+    }
+
+    // ------------------------------------------------------------------
+    // Tab panels
+    // ------------------------------------------------------------------
+
+    function renderPanel(): void {
+        panel.innerHTML = '';
+        panel.scrollTop = 0;
+        switch (activeTab) {
+            case 'home': renderHome(); break;
+            case 'shop': renderShop(); break;
+            case 'log': renderLog(); break;
+            case 'journey': renderJourney(); break;
+        }
+    }
+
+    function statRow(label: string, value: string): string {
+        return `
+            <div style="display:flex; justify-content:space-between; padding:4px 0;">
+                <span style="color:${HUB_COLORS.textLight};">${label}</span>
+                <span style="font-weight:bold;">${value}</span>
+            </div>
+        `;
+    }
+
+    function renderHome(): void {
+        const summary = options.summary;
+        if (summary) {
+            const runCard = card();
+            const heading = options.mode === 'victory'
+                ? '🎉 Amazing flight!'
+                : options.mode === 'gameover'
+                    ? '💫 Good try, space pup!'
+                    : '🚀 Flight so far';
+            runCard.innerHTML = `
+                <div style="font-size:20px; font-weight:bold; margin-bottom:8px;">${heading}</div>
+                ${statRow('🛣️ Distance flown', `${Math.max(0, Math.floor(summary.distance))}m`)}
+                ${statRow('🔷 Cores earned', `${summary.coresEarned}`)}
+                ${statRow('🌿 Plants scanned', `${summary.speciesDiscovered}`)}
+                ${statRow('🐾 Creatures met', `${summary.creaturesCataloged}`)}
+            `;
+            panel.appendChild(runCard);
+        }
+
+        const stats = saveManager.getStats();
+        const lifeCard = card();
+        lifeCard.innerHTML = `
+            <div style="font-size:18px; font-weight:bold; margin-bottom:8px;">🏆 Space Dog Records</div>
+            ${statRow('🥇 Best distance', `${Math.floor(stats.highScore)}m`)}
+            ${statRow('👾 Big bosses beaten', `${stats.bossesDefeated}`)}
+            ${statRow('🌙 Moon trips finished', `${stats.runsCompleted}`)}
+            ${statRow('🔷 Cores found ever', `${stats.totalCoresCollected}`)}
+        `;
+        panel.appendChild(lifeCard);
+
+        const unlocked = saveManager.getUnlockedLevels().filter(l => l >= 1 && l <= CHAPTER_COUNT);
+        const continueChapter = unlocked.length > 0 ? Math.max(...unlocked) : 1;
+        const launchBtn = bigButton(
+            continueChapter > 1 ? `🚀 Blast Off! (Chapter ${continueChapter})` : '🚀 Blast Off!',
+            HUB_COLORS.mint,
+            () => {
+                play('ui_click');
+                options.onLaunchChapter(continueChapter);
+            }
+        );
+        launchBtn.style.width = '100%';
+        launchBtn.style.minHeight = '62px';
+        panel.appendChild(launchBtn);
+    }
+
+    function renderShop(): void {
+        const intro = card();
+        intro.innerHTML = `
+            <div style="font-size:18px; font-weight:bold;">⚡ Rocket Workshop</div>
+            <div style="color:${HUB_COLORS.textLight}; font-size:14px; margin-top:4px;">
+                Trade cores for upgrades that last forever!
+            </div>
+        `;
+        panel.appendChild(intro);
+
+        const upgrades = saveManager.getUpgrades();
+        for (const item of SHOP_ITEMS) {
+            const current = upgrades[item.key];
+            const max = saveManager.getMaxUpgradeLevel(item.key);
+            const cost = saveManager.getUpgradeCost(item.key, current);
+            const maxed = current >= max;
+            const canBuy = saveManager.canUpgrade(item.key);
+
+            const row = card();
+            row.style.display = 'flex';
+            row.style.alignItems = 'center';
+            row.style.gap = '12px';
+
+            const pips = '●'.repeat(current) + '○'.repeat(Math.max(0, max - current));
+            row.innerHTML = `
+                <div style="font-size:34px;">${item.icon}</div>
+                <div style="flex:1; min-width:0;">
+                    <div style="font-size:17px; font-weight:bold;">${item.name}</div>
+                    <div style="font-size:13px; color:${HUB_COLORS.textLight};">${item.desc}</div>
+                    <div style="font-size:14px; color:${maxed ? '#2eaa72' : HUB_COLORS.textLight}; letter-spacing:3px;">${pips}</div>
+                </div>
+            `;
+
+            const buyBtn = bigButton(
+                maxed ? '✅ MAX!' : `${cost} 🔷`,
+                maxed ? HUB_COLORS.mint : canBuy ? HUB_COLORS.lemon : HUB_COLORS.lavender,
+                () => {
+                    if (maxed || !canBuy) return;
+                    if (saveManager.purchaseUpgrade(item.key)) {
+                        play('twinkle');
+                        refreshCores();
+                        renderPanel();
+                    }
+                }
+            );
+            buyBtn.style.minWidth = '110px';
+            if (!maxed && !canBuy) {
+                buyBtn.style.opacity = '0.6';
+                buyBtn.style.cursor = 'not-allowed';
+            }
+            row.appendChild(buyBtn);
+            panel.appendChild(row);
+        }
+    }
+
+    function renderLog(): void {
+        const cataloged = saveManager.getCatalogedCreatures().length;
+        const totalCreatures = Object.keys(BESTIARY_ENTRIES).length;
+        const discovered = saveManager.getDiscoveredSpecies().length;
+        const totalSpecies = Object.keys(SPECIES_NAMES).length;
+
+        const intro = card();
+        intro.innerHTML = `
+            <div style="font-size:18px; font-weight:bold;">📖 Weird Life Log</div>
+            ${statRow('🐾 Creatures cataloged', `${cataloged} / ${totalCreatures}`)}
+            ${statRow('🌿 Plants & rocks scanned', `${discovered} / ${totalSpecies}`)}
+        `;
+        panel.appendChild(intro);
+
+        const grid = createBestiaryGrid(saveManager);
+        grid.style.maxHeight = 'none';
+        grid.style.width = '100%';
+        grid.style.maxWidth = 'none';
+        panel.appendChild(grid);
+    }
+
+    function renderJourney(): void {
+        const intro = card();
+        intro.innerHTML = `
+            <div style="font-size:18px; font-weight:bold;">🗺️ Journey to the Moon</div>
+            <div style="color:${HUB_COLORS.textLight}; font-size:14px; margin-top:4px;">
+                Pick a chapter you've reached and blast off from there!
+            </div>
+        `;
+        panel.appendChild(intro);
+
+        for (let level = 1; level <= CHAPTER_COUNT; level++) {
+            const cfg = LEVEL_CONFIG[level];
+            const isUnlocked = saveManager.isLevelUnlocked(level);
+
+            const row = card();
+            row.style.display = 'flex';
+            row.style.alignItems = 'center';
+            row.style.gap = '12px';
+            if (!isUnlocked) row.style.opacity = '0.55';
+
+            row.innerHTML = `
+                <div style="font-size:30px;">${isUnlocked ? '🌟' : '🔒'}</div>
+                <div style="flex:1; min-width:0;">
+                    <div style="font-size:16px; font-weight:bold;">Chapter ${level}</div>
+                    <div style="font-size:14px; color:${HUB_COLORS.textLight};">
+                        ${isUnlocked ? (cfg?.name ?? '') : 'Keep flying to unlock!'}
+                    </div>
+                </div>
+            `;
+
+            if (isUnlocked) {
+                const goBtn = bigButton('🚀 Go!', HUB_COLORS.sky, () => {
+                    play('ui_click');
+                    options.onLaunchChapter(level);
+                });
+                goBtn.style.minWidth = '96px';
+                row.appendChild(goBtn);
+            }
+            panel.appendChild(row);
+        }
+    }
+
+    refreshCores();
+    switchTab('home');
+
+    return container;
+}

--- a/src/hud_system/hud_manager.ts
+++ b/src/hud_system/hud_manager.ts
@@ -33,6 +33,8 @@ export class HUDManager {
     getJourneyLevel?: () => number;
     getRescuedFriendCount?: () => number;
     getCompletedChapters?: () => number[];
+    /** Opens the between-run Space Base hub. Filled by bootstrap. */
+    openHub?: (mode: 'victory' | 'gameover' | 'pause') => void;
 
     private score: number = 0;
     private distance: number = 0;
@@ -440,7 +442,8 @@ export class HUDManager {
 
     showPauseMenu(onResume: () => void, onRestart: () => void): void {
         this.screens.showPauseMenu(onResume, onRestart, {
-            onOpenJourneyMap: () => this.showJourneyMapOverlay('pause')
+            onOpenJourneyMap: () => this.showJourneyMapOverlay('pause'),
+            onOpenHub: this.openHub ? () => this.openHub!('pause') : undefined
         });
     }
 
@@ -450,7 +453,8 @@ export class HUDManager {
 
     showVictoryScreen(stats: GameStats): void {
         this.screens.showVictoryScreen(stats, {
-            onOpenJourneyMap: () => this.showJourneyMapOverlay('victory')
+            onOpenJourneyMap: () => this.showJourneyMapOverlay('victory'),
+            onOpenHub: this.openHub ? () => this.openHub!('victory') : undefined
         });
         // Acceptance: map visible after victory (2D overlay above the card).
         this.showJourneyMapOverlay('victory');
@@ -487,7 +491,9 @@ export class HUDManager {
     }
 
     showGameOverScreen(stats: GameStats, onRestart: () => void): void {
-        this.screens.showGameOverScreen(stats, onRestart);
+        this.screens.showGameOverScreen(stats, onRestart, {
+            onOpenHub: this.openHub ? () => this.openHub!('gameover') : undefined
+        });
     }
 
     checkAndSaveHighScore(): boolean {

--- a/src/hud_system/hud_screens.ts
+++ b/src/hud_system/hud_screens.ts
@@ -28,7 +28,7 @@ export class HUDScreens {
     showPauseMenu(
         onResume: () => void,
         onRestart: () => void,
-        extras?: { onOpenJourneyMap?: () => void }
+        extras?: { onOpenJourneyMap?: () => void; onOpenHub?: () => void }
     ): void {
         if (this.pauseMenu) return;
 
@@ -137,6 +137,13 @@ export class HUDScreens {
 
         buttons.appendChild(resumeBtn);
         buttons.appendChild(mapBtn);
+        if (extras?.onOpenHub) {
+            const hubBtn = this.createMenuButton('🏠 Space Base', COLORS.lavenderDark, () => {
+                this.hidePauseMenu();
+                extras.onOpenHub!();
+            });
+            buttons.appendChild(hubBtn);
+        }
         buttons.appendChild(restartBtn);
         buttons.appendChild(soundBtn);
 
@@ -197,7 +204,7 @@ export class HUDScreens {
 
     showVictoryScreen(
         stats: GameStats,
-        extras?: { onOpenJourneyMap?: () => void }
+        extras?: { onOpenJourneyMap?: () => void; onOpenHub?: () => void }
     ): void {
         this.celebrateVictory();
 
@@ -263,6 +270,12 @@ export class HUDScreens {
         });
 
         btnRow.appendChild(mapBtn);
+        if (extras?.onOpenHub) {
+            const hubBtn = this.createMenuButton('🏠 Space Base', COLORS.lavenderDark, () => {
+                extras.onOpenHub!();
+            });
+            btnRow.appendChild(hubBtn);
+        }
         btnRow.appendChild(playAgainBtn);
         container.appendChild(btnRow);
         overlay.appendChild(container);
@@ -271,7 +284,11 @@ export class HUDScreens {
         this.victoryScreen = overlay;
     }
 
-    showGameOverScreen(stats: GameStats, onRestart: () => void): void {
+    showGameOverScreen(
+        stats: GameStats,
+        onRestart: () => void,
+        extras?: { onOpenHub?: () => void }
+    ): void {
         const overlay = document.createElement('div');
         overlay.style.cssText = `
             position: fixed;
@@ -324,11 +341,20 @@ export class HUDScreens {
             </div>
         `;
 
-        const tryAgainBtn = this.createMenuButton('🚀 Try Again', COLORS.mint, onRestart);
-        tryAgainBtn.style.margin = '0 auto';
-        tryAgainBtn.style.display = 'block';
+        const btnCol = document.createElement('div');
+        btnCol.style.cssText = 'display:flex; flex-direction:column; gap:12px; align-items:stretch;';
 
-        container.appendChild(tryAgainBtn);
+        const tryAgainBtn = this.createMenuButton('🚀 Try Again', COLORS.mint, onRestart);
+        btnCol.appendChild(tryAgainBtn);
+
+        if (extras?.onOpenHub) {
+            const hubBtn = this.createMenuButton('🏠 Space Base', COLORS.lavenderDark, () => {
+                extras.onOpenHub!();
+            });
+            btnCol.appendChild(hubBtn);
+        }
+
+        container.appendChild(btnCol);
         overlay.appendChild(container);
         document.body.appendChild(overlay);
 

--- a/src/main/hub_integration.ts
+++ b/src/main/hub_integration.ts
@@ -1,0 +1,54 @@
+/**
+ * Glue between the running game and the Space Base hub shell.
+ *
+ * Builds the run summary from live game state and handles chapter launches
+ * (persisted via localStorage, then a reload — the same restart path the
+ * pause/game-over screens already use).
+ */
+
+import { player } from '../player_loader';
+import { playerState, setIsGamePaused } from '../game_config';
+import { game } from '../game_runtime';
+import {
+    createHubScreen,
+    setPendingStartChapter,
+    type HubMode,
+    type HubRunSummary
+} from '../hub_screen';
+
+let hubElement: HTMLDivElement | null = null;
+
+function buildRunSummary(): HubRunSummary {
+    return {
+        distance: player ? Math.floor(player.position.x) : 0,
+        coresEarned: playerState.cores,
+        speciesDiscovered: game.discoveryManager?.getDiscoveredCount() ?? 0,
+        creaturesCataloged: game.creatureCatalogManager?.getCatalogedCountThisRun() ?? 0
+    };
+}
+
+export function isHubOpen(): boolean {
+    return hubElement !== null;
+}
+
+export function openHubScreen(mode: HubMode): void {
+    if (hubElement) return;
+    setIsGamePaused(true);
+
+    hubElement = createHubScreen(game.saveManager, {
+        mode,
+        summary: buildRunSummary(),
+        playSound: (name) => game.audioSystem.play(name, 0.6),
+        onLaunchChapter: (chapter) => {
+            setPendingStartChapter(chapter);
+            location.reload();
+        },
+        onClose: () => {
+            hubElement = null;
+            // Only a pause-opened hub returns to live gameplay; the
+            // victory/game-over screens stay up underneath otherwise.
+            if (mode === 'pause') setIsGamePaused(false);
+        }
+    });
+    document.body.appendChild(hubElement);
+}

--- a/src/main/input_bindings.ts
+++ b/src/main/input_bindings.ts
@@ -13,13 +13,23 @@ import {
 } from './hud_displays';
 import { RESOLUTION_RATIOS } from './render_helpers';
 import { ensureGameplayReady } from '../level_systems_loader';
+import { consumePendingStartChapter } from '../hub_screen';
+import { getLevelSpan } from '../depth_layers';
 import { spawnDeferredPrototypeContent, spawnDeferredVideoStars } from './startup';
 
 async function beginGameplay(): Promise<void> {
     await ensureGameplayReady();
     void spawnDeferredPrototypeContent();
     void spawnDeferredVideoStars();
-    game.levelManager.startLevel(1);
+    // A hub "Go to chapter" request survives the reload via localStorage.
+    const pending = consumePendingStartChapter();
+    const startChapter = pending && game.saveManager.isLevelUnlocked(pending) ? pending : 1;
+    // The journey is one continuous run (player.x 0->5200), so launching a
+    // later chapter means placing the rocket at that chapter's start X.
+    if (startChapter > 1 && player) {
+        player.position.x = getLevelSpan(startChapter).startX;
+    }
+    game.levelManager.startLevel(startChapter);
 }
 
 export let lastSpaceTapTime = 0;

--- a/src/main/startup_callbacks.ts
+++ b/src/main/startup_callbacks.ts
@@ -10,6 +10,7 @@ import { ShakeType } from '../juice_effects';
 import { updateBoostDisplay, updateRollDisplay, updateTetherDisplay, showRollPopup } from './hud_displays';
 import { getMaterialDisplayName, getMaterialColor } from '../resource_inventory';
 import { recordChapterComplete } from '../journey_map';
+import { openHubScreen } from './hub_integration';
 
 export function reportComboObjectiveProgress(): void {
     const objective = game.levelManager.config[game.levelManager.currentLevel]?.objective;
@@ -28,6 +29,7 @@ export function wireStartupCallbacks(): void {
     game.hudManager.getJourneyLevel = () => game.levelManager?.currentLevel ?? 1;
     game.hudManager.getRescuedFriendCount = () => game.friendsManager?.getRescuedCount?.() ?? 0;
     game.hudManager.getCompletedChapters = () => [...(game.completedChaptersThisRun || [])];
+    game.hudManager.openHub = (mode) => openHubScreen(mode);
 
     game.resourceHarvester.onMaterialCollected = (evt) => {
         const name = getMaterialDisplayName(evt.id);


### PR DESCRIPTION
## Summary

Adds a calm, kid-friendly **Space Base** hub that gives the existing meta-progression a cohesive player-facing shell, so cores and catalog progress finally feel meaningful between runs. It's a touch-friendly DOM overlay (no WebGPU needed) opened from the pause, victory, and game-over screens via a new **🏠 Space Base** button.

Implements the "shell" from the issue — issues #204 (crafting) and #206 (journey map) can plug in later as additional tabs.

## What's in the hub (`src/hub_screen.ts`)

Four tabs, all backed by existing `SaveManager` fields:

- **🏠 Home** — this-run summary (distance flown, cores earned, plants scanned, creatures met), lifetime records (best distance, bosses beaten, moon trips, cores ever), and a persistent cores balance chip. A big **Blast Off!** button continues from the furthest unlocked chapter.
- **⚡ Shop** — all four `PlayerUpgrades` (Tougher Rocket, Lucky Charm, Zippy Blaster, Super Thrusters) purchasable with cores, with kid-friendly names/icons and level pips. Purchases go through `SaveManager.purchaseUpgrade` and are applied on the next run (`startup.ts` already reads `applyToHealth`/`applyToSpeed`/etc).
- **📖 Life Log** — the bestiary grid (cataloged creatures + locked `???` silhouettes) plus flora/geology scan totals.
- **🗺️ Chapters** — journey chapter select over `unlockedLevels`, with locked chapters shown but not launchable. Launching a later chapter places the rocket at that chapter's start X (the journey is one continuous run, player.x 0→5200).

## Wiring

- Extracted `createBestiaryGrid` from `createBestiaryUI` so the modal and hub share one renderer.
- Added `CreatureCatalogManager.getCatalogedCountThisRun()` for the run summary.
- `HUDManager.openHub` provider wired from bootstrap (`startup_callbacks.ts`), threaded as `onOpenHub` through the pause / victory / game-over screens — no circular imports.
- `src/main/hub_integration.ts` bridges live game state (player position, cores, discovery/catalog counts) to the hub and handles chapter launches.
- Chapter launches survive the restart `location.reload()` via a `dog_dash_pending_chapter` localStorage key consumed on next boot in `beginGameplay()`.

## Acceptance criteria

- [x] Player can open a hub after a run and see cores + summary
- [x] At least two permanent upgrades purchasable with cores and applied on next run (all four wired)
- [x] Bestiary lists cataloged creatures with locked placeholders for unknowns
- [x] Progress survives refresh (all persistence stays in `SaveManager`/localStorage)
- [x] Touch-friendly buttons (min 48–62px targets, `touch-action: manipulation`, `clamp()` font sizing), readable for younger players
- [x] No regression to in-run HUD or tutorial flow

## Testing

- `npm run typecheck:ci` — passes (no new strict-mode violations; baseline re-anchored for a one-line shift in `input_bindings.ts`).
- `npm run build` — production build succeeds.
- `npm run test:smoke` — both Playwright WebGL smoke tests pass (game boots, renders, gameplay HUD starts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AkbBuGtxPTd5xaycWiznZW

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkbBuGtxPTd5xaycWiznZW)_