### PR TITLE
Implement Fairy Dog Wings Power-Up

### DIFF
--- a/.github/typecheck-baseline.txt
+++ b/.github/typecheck-baseline.txt
@@ -114,9 +114,9 @@ src/main/loop_geological.ts(377,77): TS18047: 'player' is possibly 'null'.
 src/main/loop_geological.ts(380,59): TS18047: 'player' is possibly 'null'.
 src/main/loop_world.ts(248,57): TS18047: 'player' is possibly 'null'.
 src/main/loop_world.ts(288,36): TS18047: 'player' is possibly 'null'.
-src/main/player_update.ts(344,39): TS2769: No overload matches this call.
-src/main/player_update.ts(365,53): TS2304: Cannot find name 'DogAnimationState'.
-src/main/player_update.ts(407,49): TS2304: Cannot find name 'DogAnimationState'.
+src/main/player_update.ts(353,39): TS2769: No overload matches this call.
+src/main/player_update.ts(374,53): TS2304: Cannot find name 'DogAnimationState'.
+src/main/player_update.ts(416,49): TS2304: Cannot find name 'DogAnimationState'.
 src/main/render_helpers.ts(69,26): TS7006: Parameter 'jellyMoss' implicitly has an 'any' type.
 src/main/render_helpers.ts(69,5): TS2304: Cannot find name 'jellyMosses'.
 src/main/startup.ts(448,45): TS2345: Argument of type 'Object3D<Object3DEventMap>' is not assignable to parameter of type 'Group<Object3DEventMap>'.

--- a/src/main/player_update.ts
+++ b/src/main/player_update.ts
@@ -9,6 +9,8 @@ import { LEVEL_DISTANCE_BOUNDARIES } from '../level_config';
 import { gravityAnchors } from '../environment';
 import { showRollPopup } from './hud_displays';
 import { maybePrefetchNextLevel } from '../level_systems_loader';
+import { PowerUpType } from '../powerup_manager';
+
 export function updatePlayer(delta: number) {
     // Don't update if player hasn't loaded yet
     if (!player) return;
@@ -49,6 +51,9 @@ export function updatePlayer(delta: number) {
         }
     }
     
+    const modifiers = game.powerUpManager.getCombinedModifiers();
+    const hasFairyWings = game.powerUpManager.hasPowerUp(PowerUpType.FAIRY_DOG_WINGS);
+
     if (isMovingUp) {
         targetSpeed = CONFIG.player.maxSpeedY;
     } else if (isMovingDown) {
@@ -58,6 +63,7 @@ export function updatePlayer(delta: number) {
         if (playerState.penguinSlideAssistTimer > 0) {
             targetSpeed *= 0.45;
         }
+        targetSpeed *= (modifiers.gravityMultiplier ?? 1.0);
     }
     
     const accel = (targetSpeed !== -CONFIG.player.gravity && targetSpeed !== 0)
@@ -151,7 +157,10 @@ export function updatePlayer(delta: number) {
     const isBoosting = game.boostSystem.isBoosting();
 
     // Keyboard: Shift hold or double-tap Space
-    if (canActivateBoost) {
+    if (hasFairyWings && keys.run) {
+        // Float instead of boosting
+        targetSpeed = CONFIG.player.gravity * 0.15; // Positive lift
+    } else if (canActivateBoost) {
         if (keys.run) {
             game.boostSystem.activate();
         } else if (game.wantsBoost) {

--- a/src/powerup_manager/manager_visuals.ts
+++ b/src/powerup_manager/manager_visuals.ts
@@ -22,6 +22,7 @@ export interface PowerUpManagerVisualContext {
     butterflies: THREE.Group[];
     cometGlowMesh?: THREE.Mesh;
     cometTrailParticles: THREE.Mesh[];
+    fairyWingsMesh?: THREE.Group;
     shieldBounceTime: number;
     activeEffects: Map<PowerUpType, PowerUpEffect>;
     hasPowerUp: (type: PowerUpType) => boolean;
@@ -48,6 +49,9 @@ export function createEffectVisuals(ctx: PowerUpManagerVisualContext, type: Powe
             break;
         case PowerUpType.STARLIGHT_TIARA:
             createStarlightTiara(ctx, config);
+            break;
+        case PowerUpType.FAIRY_DOG_WINGS:
+            createFairyDogWings(ctx, config);
             break;
     }
 
@@ -158,6 +162,54 @@ export function createButterflyEscort(ctx: PowerUpManagerVisualContext, config: 
     }
 }
 
+// Cache geometry and material for fairy wings to prevent VRAM leaks
+let sharedFairyWingGeometry: THREE.ShapeGeometry | null = null;
+let sharedFairyWingMaterial: THREE.MeshBasicMaterial | null = null;
+
+export function createFairyDogWings(ctx: PowerUpManagerVisualContext, config: PowerUpConfig): void {
+    if (!ctx.rocket) return;
+
+    const wingsGroup = new THREE.Group();
+    wingsGroup.position.set(-0.5, 0.5, 0); // Position slightly behind and above
+
+    if (!sharedFairyWingGeometry) {
+        // Basic procedural butterfly wing shapes
+        const shape = new THREE.Shape();
+        shape.moveTo(0, 0);
+        shape.quadraticCurveTo(1.5, 1.5, 1.5, 0.5);
+        shape.quadraticCurveTo(2.0, -0.5, 1.0, -1.0);
+        shape.quadraticCurveTo(0.2, -1.5, 0, 0);
+        sharedFairyWingGeometry = new THREE.ShapeGeometry(shape);
+    }
+
+    if (!sharedFairyWingMaterial) {
+        sharedFairyWingMaterial = new THREE.MeshBasicMaterial({
+            color: config.color,
+            side: THREE.DoubleSide,
+            transparent: true,
+            opacity: 0.8,
+            depthWrite: false
+        });
+    }
+
+    // Left wing
+    const leftWing = new THREE.Mesh(sharedFairyWingGeometry, sharedFairyWingMaterial);
+    leftWing.position.set(0, 0, 0.5);
+    leftWing.rotation.x = Math.PI / 4;
+    leftWing.scale.set(0.6, 0.6, 0.6);
+    wingsGroup.add(leftWing);
+
+    // Right wing
+    const rightWing = new THREE.Mesh(sharedFairyWingGeometry, sharedFairyWingMaterial);
+    rightWing.position.set(0, 0, -0.5);
+    rightWing.rotation.x = -Math.PI / 4;
+    rightWing.scale.set(0.6, 0.6, 0.6);
+    wingsGroup.add(rightWing);
+
+    ctx.fairyWingsMesh = wingsGroup;
+    ctx.rocket.add(wingsGroup);
+}
+
 export function createStarlightTiara(ctx: PowerUpManagerVisualContext, config: PowerUpConfig): void {
     if (!ctx.rocket) return;
 
@@ -260,6 +312,20 @@ export function updateEffectPosition(ctx: PowerUpManagerVisualContext, type: Pow
                 butterfly.children[0].rotation.y = 0.3 + Math.sin(Date.now() * 0.01 * data.wingSpeed) * 0.3;
                 butterfly.children[1].rotation.y = -0.3 - Math.sin(Date.now() * 0.01 * data.wingSpeed) * 0.3;
             });
+            break;
+        case PowerUpType.FAIRY_DOG_WINGS:
+            if (ctx.fairyWingsMesh) {
+                // Animate wing flapping
+                const now = Date.now() * 0.008;
+                const leftWing = ctx.fairyWingsMesh.children[0];
+                const rightWing = ctx.fairyWingsMesh.children[1];
+
+                if (leftWing && rightWing) {
+                    const flapAngle = Math.sin(now) * 0.6;
+                    leftWing.rotation.x = Math.PI / 4 + flapAngle;
+                    rightWing.rotation.x = -(Math.PI / 4 + flapAngle);
+                }
+            }
             break;
     }
 }
@@ -388,6 +454,12 @@ export function removeEffectVisuals(ctx: PowerUpManagerVisualContext, type: Powe
                 if (b.parent) b.parent.remove(b);
             });
             ctx.butterflies = [];
+            break;
+        case PowerUpType.FAIRY_DOG_WINGS:
+            if (ctx.fairyWingsMesh && ctx.fairyWingsMesh.parent) {
+                ctx.fairyWingsMesh.parent.remove(ctx.fairyWingsMesh);
+            }
+            ctx.fairyWingsMesh = undefined;
             break;
     }
 }

--- a/src/powerup_manager/powerup_effect.ts
+++ b/src/powerup_manager/powerup_effect.ts
@@ -105,6 +105,11 @@ export class PowerUpEffect {
                 return {
                     doubleValue: true
                 };
+            case PowerUpType.FAIRY_DOG_WINGS:
+                return {
+                    gravityMultiplier: 0.35,
+                    speedMultiplier: 1.1
+                };
             case PowerUpType.MOONBEAM_SLIDE:
                 return {
                     speedMultiplier: 1.5,

--- a/src/powerup_manager/types.ts
+++ b/src/powerup_manager/types.ts
@@ -24,6 +24,7 @@ export enum PowerUpType {
     DREAM_CLOUD_CARPET = 'dream_cloud_carpet',
     LULLABY_LANTERN = 'lullaby_lantern',
     PUPPY_HUG_HUG = 'puppy_hug_hug',
+    FAIRY_DOG_WINGS = 'fairy_dog_wings',
     
     // Tier 3 - Wow-Factor Magic (rare/powerful)
     MOONBEAM_SLIDE = 'moonbeam_slide',
@@ -142,6 +143,17 @@ export const POWER_UP_CONFIGS: Record<PowerUpType, PowerUpConfig> = {
         soundEffect: 'powerup_hug',
         tier: 2,
         icon: '🤗'
+    },
+    [PowerUpType.FAIRY_DOG_WINGS]: {
+        type: PowerUpType.FAIRY_DOG_WINGS,
+        name: 'Fairy Dog Wings',
+        description: 'Temporary rainbow butterfly wings! Press SHIFT for a floaty glide.',
+        duration: 10,
+        color: 0xe6e6fa, // soft lilac
+        secondaryColor: 0xffb6c1, // pastel pink
+        soundEffect: 'powerup_fairy',
+        tier: 2,
+        icon: '🪽'
     },
     
     // Tier 3
@@ -383,6 +395,15 @@ export const TRAIL_CONFIGS: Record<PowerUpType, TrailConfig> = {
         particleSize: 0.25,
         lifetime: 1.0,
         rainbow: false,
+        sparkle: true
+    },
+    [PowerUpType.FAIRY_DOG_WINGS]: {
+        color: 0xe6e6fa,
+        secondaryColor: 0xffb6c1,
+        particleCount: 20,
+        particleSize: 0.3,
+        lifetime: 1.0,
+        rainbow: true,
         sparkle: true
     },
     [PowerUpType.MOONBEAM_SLIDE]: {


### PR DESCRIPTION
Implements the "Fairy Dog Wings" power-up from `ideas.md`. It provides the player with temporary procedural wings, a sparkly rainbow particle trail, and allows a floaty glide mechanic when the Shift key is held. Tested to ensure no VRAM leaks and proper input binding interactions via `getCombinedModifiers`.

---
*PR created automatically by Jules for task [274494283516870626](https://jules.google.com/task/274494283516870626) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Fairy Dog Wings power-up.
  - Fairy Dog Wings reduce gravity, increase speed, and allow players to float while running.
  - Added wing visuals with animated flapping effects.
  - Added themed trails, particles, sparkle effects, sound, icon, and display details.

- **Chores**
  - Updated type-checking reference data to reflect current source locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->