### PR TITLE
Wire Tier 2–3 power-up visuals, modifiers, and composition hooks

### DIFF
--- a/docs/POWER_UP_STATUS.md
+++ b/docs/POWER_UP_STATUS.md
@@ -1,0 +1,48 @@
+# Power-Up Integration Status Matrix
+
+Audit of all 16 `PowerUpType` entries after Tier 2–3 polish (July 2026).
+
+Legend: **✅** wired end-to-end · **⚠️** partial / generic · **❌** missing
+
+| # | Power-Up | Tier | Modifiers | Visuals | Composition hook | Audio cue | Dog reaction |
+|---|----------|------|-----------|---------|------------------|-----------|--------------|
+| 1 | Rainbow Comet Tail | 1 | ✅ candy + auto-collect | ✅ comet glow | ✅ RAINBOW_TRAIL | ✅ `powerup_rainbow` | ⚠️ POWER_UP |
+| 2 | Flower Crown Boost | 1 | ✅ gravity + obstacle slow | ✅ flower crown | ✅ STARDUST_FIELD | ✅ `powerup_flower` | ⚠️ POWER_UP |
+| 3 | Bubblegum Shield | 1 | ✅ shield bounce | ✅ heart bubble | ✅ HEART_BUBBLE | ✅ `powerup_shield` | ⚠️ POWER_UP |
+| 4 | Twinkle Star Magnet | 1 | ✅ magnet pull | ⚠️ star lines | ✅ STARDUST_FIELD | ✅ `powerup_magnet` | ⚠️ POWER_UP |
+| 5 | Unicorn Horn Blast | 2 | ✅ asteroids→butterflies | ⚠️ trail + beam | ✅ GLITTER_BEAM | ✅ `powerup_unicorn` | ⚠️ POWER_UP |
+| 6 | Dream Cloud Carpet | 2 | ✅ zero-g + speed | ✅ cloud carpet | ✅ STARDUST_FIELD | ✅ `powerup_cloud` | ⚠️ POWER_UP |
+| 7 | Lullaby Lantern | 2 | ✅ obstacle slow + sway | ✅ lantern glow | — | ✅ `powerup_lantern` | ✅ CURIOUS |
+| 8 | Puppy Hug Hug | 2 | ✅ double value + extra life | ✅ golden heart aura | ✅ HEART_RAIN | ✅ `powerup_hug` | ✅ DELIGHTED |
+| 9 | Fairy Dog Wings | 2 | ✅ glide + gravity | ✅ rainbow wings | — | ✅ `powerup_fairy` | ⚠️ POWER_UP |
+| 10 | Moonbeam Slide | 3 | ✅ speed + auto-collect | ✅ silver slide beam | — | ✅ `powerup_moonbeam` | ⚠️ POWER_UP |
+| 11 | Fairy Godmother Sparkle | 3 | ✅ random grant | ✅ fairy sparkle orb | ✅ RAINBOW_SPIRAL | ✅ `powerup_fairy` | ✅ DELIGHTED |
+| 12 | Candy Cane Vortex | 3 | ✅ vortex pull + candy | ✅ spinning vortex | ✅ CONFETTI_BURST | ✅ `powerup_vortex` | ⚠️ POWER_UP |
+| 13 | Starlight Tiara | 3 | ✅ invincible + double value | ✅ tiara mesh | ✅ STAR_CASCADE | ✅ `powerup_tiara` | ⚠️ POWER_UP |
+| 14 | Butterfly Escort | 3 | ✅ 3 hit charges | ✅ orbiting butterflies | ✅ BUTTERFLY_SWARM | ✅ `powerup_butterfly` | ⚠️ POWER_UP |
+| 15 | Magic Paintbrush | 3 | ✅ rainbow bridge paint | ✅ brush mesh | — | ✅ `powerup_paint` | ✅ CURIOUS |
+| 16 | Best Friend Forever Aura | 3 | ✅ time slow + double + sparkle | ✅ heart aura ring | ✅ SPARKLE_FIELD | ✅ `powerup_bff` | ✅ DELIGHTED |
+
+## Modifier consumption (runtime)
+
+| Modifier | Consumed in |
+|----------|-------------|
+| `gravityMultiplier` | `player_update.ts` |
+| `speedMultiplier` | `player_update.ts` |
+| `autoCollectRadius` | `loop_combat/powerups.ts` |
+| `magnetRadius` | `loop_combat/powerups.ts` |
+| `shieldActive` / `shieldBouncesAsteroids` | `obstacle_system/` |
+| `invincible` | `loop_combat/powerups.ts` + collision |
+| `butterflyCharges` | `obstacle_setup.ts` |
+| `doubleValue` | `startup_callbacks.ts` (score wrapper) |
+| `obstaclesSlowed` / `obstacleSlowFactor` | `obstacle_system/manager.ts` |
+| `asteroidsToCandy` | `loop_combat/powerups.ts` |
+| `asteroidsToButterflies` | `loop_combat/weapons.ts` |
+| `timeScale` | `loop_combat/index.ts` |
+| `sparkle` | `powerup_manager/manager.ts` |
+| Fairy Godmother grant | `powerup_hooks.ts` on activate |
+| Magic Paintbrush bridge | `magic_paintbrush.ts` + `input_bindings.ts` |
+
+## Central hook
+
+All activation/deactivation side effects route through `src/powerup_manager/powerup_hooks.ts`, called from `create_game_systems.ts` and `startup_callbacks.ts`.

--- a/src/audio_system/mixins/reactive_sounds.ts
+++ b/src/audio_system/mixins/reactive_sounds.ts
@@ -522,5 +522,60 @@ playRoll() {
     rumbleGain.connect(this.sfxGain);
     rumble.start(now);
     rumble.stop(now + 0.35);
+},
+
+/**
+ * Procedural stub for per-power-up activation cues referenced in POWER_UP_CONFIGS.
+ */
+playPowerUpCue(cueId: string) {
+    this.init();
+    if (!this.ctx || !this.sfxGain) return;
+
+    const now = this.ctx.currentTime;
+    const cueProfiles: Record<string, { freq: number; slide: number; wave: OscillatorType; dur: number }> = {
+        powerup_rainbow: { freq: 523, slide: 1046, wave: 'sine', dur: 0.5 },
+        powerup_flower: { freq: 440, slide: 554, wave: 'triangle', dur: 0.4 },
+        powerup_shield: { freq: 350, slide: 700, wave: 'sine', dur: 0.35 },
+        powerup_magnet: { freq: 880, slide: 1320, wave: 'sine', dur: 0.3 },
+        powerup_unicorn: { freq: 659, slide: 988, wave: 'triangle', dur: 0.45 },
+        powerup_cloud: { freq: 220, slide: 330, wave: 'sine', dur: 0.6 },
+        powerup_lantern: { freq: 392, slide: 494, wave: 'sine', dur: 0.55 },
+        powerup_hug: { freq: 523, slide: 659, wave: 'sine', dur: 0.4 },
+        powerup_fairy: { freq: 1046, slide: 1318, wave: 'sine', dur: 0.35 },
+        powerup_moonbeam: { freq: 784, slide: 1175, wave: 'triangle', dur: 0.4 },
+        powerup_vortex: { freq: 330, slide: 660, wave: 'sawtooth', dur: 0.5 },
+        powerup_tiara: { freq: 880, slide: 1108, wave: 'sine', dur: 0.45 },
+        powerup_butterfly: { freq: 698, slide: 932, wave: 'triangle', dur: 0.35 },
+        powerup_paint: { freq: 494, slide: 740, wave: 'square', dur: 0.3 },
+        powerup_bff: { freq: 440, slide: 554, wave: 'sine', dur: 0.6 },
+    };
+
+    const profile = cueProfiles[cueId];
+    if (!profile) {
+        this.play('powerup', 0.7);
+        return;
+    }
+
+    const osc = this.ctx.createOscillator();
+    osc.type = profile.wave;
+    osc.frequency.setValueAtTime(profile.freq, now);
+    osc.frequency.exponentialRampToValueAtTime(profile.slide, now + profile.dur * 0.6);
+
+    const gain = this.ctx.createGain();
+    gain.gain.setValueAtTime(0, now);
+    gain.gain.linearRampToValueAtTime(0.2, now + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.001, now + profile.dur);
+
+    osc.connect(gain);
+    gain.connect(this.sfxGain);
+    osc.start(now);
+    osc.stop(now + profile.dur + 0.05);
+
+    if (cueId === 'powerup_bff' || cueId === 'powerup_hug') {
+        this.play('giggle', 0.25, 3);
+    }
+    if (cueId === 'powerup_vortex' || cueId === 'powerup_paint') {
+        this.play('whoosh', 0.2, 3);
+    }
 }
 });

--- a/src/create_game_systems.ts
+++ b/src/create_game_systems.ts
@@ -52,11 +52,12 @@ import { UpgradeSystem, PickupManager, HeatSystem, UPGRADE_CONFIGS } from './upg
 import { getSaveManager, type SaveManager } from './save_manager';
 import { StarfieldSystem } from './stars';
 import { OrbManager } from './collectibles';
-import { PowerUpManager, PowerUpType } from './powerup_manager';
+import { PowerUpManager, PowerUpType, handlePowerUpStart, handlePowerUpEnd, syncMagicalEffectsFromActive } from './powerup_manager';
 import { DogCockpitController, DogAnimationState } from './dog_cockpit';
 import { HUDManager } from './hud_system';
 import { JuiceManager, ShakeType } from './juice_effects';
-import { EffectManager, MagicalEffectType } from './magical_effects';
+import { EffectManager } from './magical_effects';
+import { MagicPaintbrushSystem } from './magic_paintbrush';
 import { VictorySystem } from './victory_system';
 import { TutorialSystem, shouldShowTutorial } from './tutorial_system';
 import { BoostSystem } from './boost_system';
@@ -106,6 +107,7 @@ export type GameSystems = {
     boostSystem: BoostSystem;
     rollSystem: RollSystem;
     effectManager: EffectManager;
+    magicPaintbrushSystem: MagicPaintbrushSystem;
     victorySystem: VictorySystem;
     tutorialSystem: TutorialSystem;
     lightningBoltSystem: LightningBoltSystem;
@@ -214,6 +216,19 @@ export function createGameSystems(deps: CreateGameSystemsDeps): GameSystems {
 
     const tempTarget = new THREE.Group();
     const effectManager = new EffectManager(scene, audioSystem, tempTarget);
+    const magicPaintbrushSystem = new MagicPaintbrushSystem(scene);
+
+    const powerUpHookCtx = {
+        effectManager,
+        audioSystem,
+        dogController,
+        juiceManager,
+        powerUpManager: null as unknown as PowerUpManager,
+        getPlayerPosition: () => player?.position,
+        onHudHealthUpdate: () => {
+            hudManager.updateHealth(playerState.health, playerState.maxHealth);
+        },
+    };
 
     const powerUpManager = new PowerUpManager({
         scene,
@@ -222,75 +237,24 @@ export function createGameSystems(deps: CreateGameSystemsDeps): GameSystems {
         rocket: undefined,
         onPowerUpStart: (type, config) => {
             console.log(`Power-up started: ${config.name}`);
-            switch (type) {
-                case PowerUpType.RAINBOW_COMET_TAIL:
-                    effectManager.activateEffect(MagicalEffectType.RAINBOW_TRAIL, config.duration);
-                    audioSystem.playCometActivate();
-                    dogController.triggerAnimation(DogAnimationState.POWER_UP, 2.0);
-                    juiceManager.flashRainbow(0.8);
-                    break;
-                case PowerUpType.FLOWER_CROWN_BOOST:
-                    effectManager.activateEffect(MagicalEffectType.STARDUST_FIELD, config.duration);
-                    audioSystem.playBoost();
-                    break;
-                case PowerUpType.TWINKLE_STAR_MAGNET:
-                    effectManager.activateEffect(MagicalEffectType.STARDUST_FIELD, config.duration);
-                    audioSystem.playCollect();
-                    break;
-                case PowerUpType.BUBBLEGUM_SHIELD:
-                    effectManager.activateEffect(MagicalEffectType.HEART_BUBBLE, config.duration);
-                    audioSystem.playShieldActivate();
-                    break;
-                case PowerUpType.BUTTERFLY_ESCORT:
-                    effectManager.activateEffect(MagicalEffectType.BUTTERFLY_SWARM, config.duration);
-                    audioSystem.playCollect();
-                    break;
-                case PowerUpType.UNICORN_HORN_BLAST:
-                    effectManager.activateEffect(MagicalEffectType.GLITTER_BEAM, config.duration);
-                    audioSystem.playBoost();
-                    break;
-            }
+            handlePowerUpStart(powerUpHookCtx, type, config);
         },
         onPowerUpEnd: (type, config) => {
             console.log(`Power-up ended: ${config.name}`);
-            if (type === PowerUpType.BUBBLEGUM_SHIELD && player) {
-                audioSystem.playShieldBreak();
-                juiceManager.showFloatingText('Pop!', player.position, '#ff69b4', 24);
-                juiceManager.burstMagic(player.position.clone());
+            handlePowerUpEnd(powerUpHookCtx, type, config);
+            if (type === PowerUpType.MAGIC_PAINTBRUSH) {
+                magicPaintbrushSystem.clear();
             }
         }
     });
+    powerUpHookCtx.powerUpManager = powerUpManager;
 
     orbManager.onPowerUpReady = () => {
         const triggered = powerUpManager.collectOrb();
         if (triggered && player) {
-            dogController.triggerAnimation(DogAnimationState.POWER_UP, 2.0);
             juiceManager.flashRainbow(0.5);
             juiceManager.burstMagic(player.position.clone());
-
-            const activeEffects = powerUpManager.getActiveEffects();
-            activeEffects.forEach((effect) => {
-                switch (effect.type) {
-                    case PowerUpType.RAINBOW_COMET_TAIL:
-                        effectManager.activateEffect(MagicalEffectType.RAINBOW_TRAIL, effect.duration);
-                        break;
-                    case PowerUpType.FLOWER_CROWN_BOOST:
-                        effectManager.activateEffect(MagicalEffectType.STARDUST_FIELD, effect.duration);
-                        break;
-                    case PowerUpType.BUBBLEGUM_SHIELD:
-                        effectManager.activateEffect(MagicalEffectType.HEART_BUBBLE, effect.duration);
-                        break;
-                    case PowerUpType.TWINKLE_STAR_MAGNET:
-                        effectManager.activateEffect(MagicalEffectType.STARDUST_FIELD, effect.duration);
-                        break;
-                    case PowerUpType.BUTTERFLY_ESCORT:
-                        effectManager.activateEffect(MagicalEffectType.BUTTERFLY_SWARM, effect.duration);
-                        break;
-                    case PowerUpType.UNICORN_HORN_BLAST:
-                        effectManager.activateEffect(MagicalEffectType.GLITTER_BEAM, effect.duration);
-                        break;
-                }
-            });
+            syncMagicalEffectsFromActive(powerUpHookCtx);
         }
     };
 
@@ -388,6 +352,7 @@ export function createGameSystems(deps: CreateGameSystemsDeps): GameSystems {
         boostSystem,
         rollSystem,
         effectManager,
+        magicPaintbrushSystem,
         victorySystem,
         tutorialSystem,
         lightningBoltSystem,

--- a/src/decoration_budget.ts
+++ b/src/decoration_budget.ts
@@ -291,6 +291,11 @@ export function registerDefaultDecorationBudgets(): void {
         category: 'background3d',
         maxActive: 24
     });
+    decorationBudget.register('magic_paintbrush_path', {
+        label: 'Rainbow paint path',
+        category: 'effects',
+        maxActive: 36
+    });
     decorationBudget.register('star_eater_boss', {
         label: 'Star-Eater Pitcher (boss)',
         category: 'creatures',

--- a/src/magic_paintbrush.ts
+++ b/src/magic_paintbrush.ts
@@ -1,0 +1,152 @@
+import * as THREE from 'three';
+import { decorationBudget } from './decoration_budget';
+import { getRainbowColor } from './magical_effects/shared';
+
+const BUDGET_ID = 'magic_paintbrush_path';
+const MAX_SEGMENTS = 36;
+const SEGMENT_LIFETIME = 10;
+const MIN_PAINT_SPACING = 1.8;
+const GUIDE_RADIUS_X = 4;
+const GUIDE_RADIUS_Y = 2.5;
+const GUIDE_STRENGTH = 12;
+
+interface PaintSegment {
+    mesh: THREE.Mesh;
+    position: THREE.Vector3;
+    lifetime: number;
+}
+
+let sharedSegmentGeo: THREE.TorusGeometry | null = null;
+
+function getSegmentGeometry(): THREE.TorusGeometry {
+    if (!sharedSegmentGeo) {
+        sharedSegmentGeo = new THREE.TorusGeometry(0.55, 0.12, 6, 12);
+    }
+    return sharedSegmentGeo;
+}
+
+export class MagicPaintbrushSystem {
+    private scene: THREE.Scene;
+    private segments: PaintSegment[] = [];
+    private isPainting = false;
+    private lastPaintPos?: THREE.Vector3;
+    private registered = false;
+
+    constructor(scene: THREE.Scene) {
+        this.scene = scene;
+    }
+
+    private ensureBudget(): void {
+        if (this.registered) return;
+        decorationBudget.register(BUDGET_ID, {
+            label: 'Rainbow paint path',
+            category: 'effects',
+            maxActive: MAX_SEGMENTS,
+        });
+        this.registered = true;
+    }
+
+    setPainting(active: boolean): void {
+        this.isPainting = active;
+        if (!active) this.lastPaintPos = undefined;
+    }
+
+    isActivePainting(): boolean {
+        return this.isPainting;
+    }
+
+    paintAt(worldPos: THREE.Vector3): void {
+        if (!this.isPainting) return;
+
+        this.ensureBudget();
+
+        if (this.lastPaintPos && worldPos.distanceTo(this.lastPaintPos) < MIN_PAINT_SPACING) {
+            return;
+        }
+        if (!decorationBudget.canSpawn(BUDGET_ID)) return;
+
+        const hue = (this.segments.length * 0.07) % 1;
+        const material = new THREE.MeshBasicMaterial({
+            color: getRainbowColor(hue),
+            transparent: true,
+            opacity: 0.85,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false,
+        });
+
+        const mesh = new THREE.Mesh(getSegmentGeometry(), material);
+        mesh.position.copy(worldPos);
+        mesh.rotation.z = Math.PI / 2;
+        mesh.rotation.y = Math.random() * Math.PI;
+        this.scene.add(mesh);
+
+        if (!decorationBudget.reportSpawn(BUDGET_ID)) {
+            this.scene.remove(mesh);
+            material.dispose();
+            return;
+        }
+
+        this.segments.push({
+            mesh,
+            position: worldPos.clone(),
+            lifetime: SEGMENT_LIFETIME,
+        });
+        this.lastPaintPos = worldPos.clone();
+    }
+
+    /**
+     * Gently guide the rocket toward the nearest painted segment on the path.
+     */
+    applyGuideForce(playerPos: THREE.Vector3, currentSpeedY: number, delta: number): number {
+        let bestDist = Infinity;
+        let bestSegment: PaintSegment | undefined;
+
+        for (const seg of this.segments) {
+            const dx = Math.abs(seg.position.x - playerPos.x);
+            const dy = Math.abs(seg.position.y - playerPos.y);
+            if (dx > GUIDE_RADIUS_X || dy > GUIDE_RADIUS_Y) continue;
+            const dist = dx + dy * 0.5;
+            if (dist < bestDist) {
+                bestDist = dist;
+                bestSegment = seg;
+            }
+        }
+
+        if (!bestSegment) return currentSpeedY;
+
+        const targetY = bestSegment.position.y;
+        const diff = targetY - playerPos.y;
+        return currentSpeedY + diff * GUIDE_STRENGTH * delta;
+    }
+
+    update(dt: number, _playerPos?: THREE.Vector3): void {
+        this.ensureBudget();
+        decorationBudget.syncCount(BUDGET_ID, this.segments.length);
+
+        for (let i = this.segments.length - 1; i >= 0; i--) {
+            const seg = this.segments[i];
+            seg.lifetime -= dt;
+            const mat = seg.mesh.material as THREE.MeshBasicMaterial;
+            mat.opacity = Math.max(0, (seg.lifetime / SEGMENT_LIFETIME) * 0.85);
+
+            if (seg.lifetime <= 0) {
+                this.scene.remove(seg.mesh);
+                mat.dispose();
+                decorationBudget.reportDestroy(BUDGET_ID);
+                this.segments.splice(i, 1);
+            }
+        }
+    }
+
+    clear(): void {
+        for (const seg of this.segments) {
+            this.scene.remove(seg.mesh);
+            (seg.mesh.material as THREE.Material).dispose();
+            decorationBudget.reportDestroy(BUDGET_ID);
+        }
+        this.segments = [];
+        this.isPainting = false;
+        this.lastPaintPos = undefined;
+        decorationBudget.syncCount(BUDGET_ID, 0);
+    }
+}

--- a/src/main/input_bindings.ts
+++ b/src/main/input_bindings.ts
@@ -4,6 +4,7 @@ import { player } from '../player_loader';
 import { playerState, gameStarted, setGameStarted, setIsGamePaused, isGamePaused } from '../game_config';
 import { game } from '../game_runtime';
 import { sporeClouds } from '../environment';
+import { PowerUpType } from '../powerup_manager';
 import { createUI, setupKeyboardControls } from '../ui_controls';
 import { createBestiaryUI } from '../bestiary';
 import { createArchitectCodexUI } from '../architect_lore';
@@ -39,6 +40,22 @@ export let lastLeftTapTime = 0;
 export let lastRightTapTime = 0;
 export let tetherKeyHeld = false;
 export let tetherMouseHeld = false;
+let paintbrushMouseDown = false;
+
+function screenToWorldXY(clientX: number, clientY: number): THREE.Vector3 | null {
+    if (!player) return null;
+    const rect = canvas.getBoundingClientRect();
+    const mouse = new THREE.Vector2();
+    mouse.x = ((clientX - rect.left) / rect.width) * 2 - 1;
+    mouse.y = -((clientY - rect.top) / rect.height) * 2 + 1;
+    const raycaster = new THREE.Raycaster();
+    raycaster.setFromCamera(mouse, camera);
+    const plane = new THREE.Plane(new THREE.Vector3(0, 0, 1), 0);
+    const target = new THREE.Vector3();
+    if (!raycaster.ray.intersectPlane(plane, target)) return null;
+    target.z = player.position.z;
+    return target;
+}
 
 let architectCodexUI: HTMLDivElement | null = null;
 
@@ -220,16 +237,32 @@ export function setupInputBindings(): void {
     });
 
     canvas.addEventListener('mousedown', (e) => {
+        if (e.button === 0 && gameStarted && game.powerUpManager.hasPowerUp(PowerUpType.MAGIC_PAINTBRUSH)) {
+            paintbrushMouseDown = true;
+            game.magicPaintbrushSystem.setPainting(true);
+            const pos = screenToWorldXY(e.clientX, e.clientY);
+            if (pos) game.magicPaintbrushSystem.paintAt(pos);
+            return;
+        }
         if (e.button === 2 && gameStarted) {
             tetherMouseHeld = true;
             game.wantsTether = true;
         }
     });
     canvas.addEventListener('mouseup', (e) => {
+        if (e.button === 0 && paintbrushMouseDown) {
+            paintbrushMouseDown = false;
+            game.magicPaintbrushSystem.setPainting(false);
+        }
         if (e.button === 2) {
             tetherMouseHeld = false;
             if (game.tetherSystem.isLatched()) game.wantsReleaseTether = true;
         }
+    });
+    window.addEventListener('mousemove', (e) => {
+        if (!paintbrushMouseDown || !gameStarted) return;
+        const pos = screenToWorldXY(e.clientX, e.clientY);
+        if (pos) game.magicPaintbrushSystem.paintAt(pos);
     });
     canvas.addEventListener('contextmenu', (e) => e.preventDefault());
 }

--- a/src/main/loop_combat/index.ts
+++ b/src/main/loop_combat/index.ts
@@ -14,31 +14,34 @@ import { updateCombatWeapons } from './weapons';
 export function updateLoopCombat(_rawDelta: number, delta: number, time: number): boolean {
     if (updateCombatBoss(delta)) return true;
 
-    if (player) {
-        updateCombatPickups(delta, time);
-        updateCombatPowerups(delta);
+    const timeScale = game.powerUpManager.getCombinedModifiers().timeScale;
+    const scaledDelta = delta * timeScale;
 
-        game.victorySystem.update(delta);
-        game.tutorialSystem.update(delta);
+    if (player) {
+        updateCombatPickups(scaledDelta, time);
+        updateCombatPowerups(scaledDelta);
+
+        game.victorySystem.update(scaledDelta);
+        game.tutorialSystem.update(scaledDelta);
 
         maybeSpawnRandomOrb();
-        updateCombatFriends(delta);
+        updateCombatFriends(scaledDelta);
 
-        game.dogController.update(delta, playerState);
+        game.dogController.update(scaledDelta, playerState);
     }
 
-    updateMoonGateSequence(delta);
+    updateMoonGateSequence(scaledDelta);
 
-    game.hudManager.update(delta);
+    game.hudManager.update(scaledDelta);
 
     if (game.debugSystem.isEnabled('particles')) {
-        game.particleSystem.update(delta);
+        game.particleSystem.update(scaledDelta);
     }
     if (game.debugSystem.isEnabled('debris')) {
-        game.debrisSystem.update(delta);
+        game.debrisSystem.update(scaledDelta);
     }
 
-    updateCombatWeapons(delta);
+    updateCombatWeapons(scaledDelta);
 
     return false;
 }

--- a/src/main/loop_combat/powerups.ts
+++ b/src/main/loop_combat/powerups.ts
@@ -1,80 +1,143 @@
 import * as THREE from 'three';
 import { player } from '../../player_loader';
+import { playerState } from '../../game_config';
 import { game } from '../../game_runtime';
 import { PowerUpType } from '../../powerup_manager';
 import { MagicalEffectType } from '../../magical_effects';
 
-/** Power-ups, rainbow comet gameplay, magical effects → nebula. */
+function applyAsteroidsToCandy(playerPos: THREE.Vector3, radius: number): void {
+    const obstacles = game.obstacleSystem.getObstacles();
+    for (let i = obstacles.length - 1; i >= 0; i--) {
+        const obs = obstacles[i];
+        const obsRadius = obs.userData.radius || 1.0;
+        if (obsRadius >= 1.2 || playerPos.distanceTo(obs.position) >= radius) continue;
+
+        const pastelColors = [0xffb6c1, 0xffc0cb, 0xe6e6fa, 0xb0e0e6, 0x98fb98];
+        const candyColor = pastelColors[Math.floor(Math.random() * pastelColors.length)];
+        (obs.material as THREE.MeshStandardMaterial).color.setHex(candyColor);
+        (obs.material as THREE.MeshStandardMaterial).emissive.setHex(candyColor);
+        (obs.material as THREE.MeshStandardMaterial).emissiveIntensity = 0.3;
+        obs.userData.isCandy = true;
+
+        game.particleSystem.emit(obs.position.clone(), candyColor, 5, 3.0, 0.4, 0.6);
+        game.particleSystem.emit(obs.position.clone(), 0xffffff, 3, 2.0, 0.3, 0.4);
+
+        if (obsRadius < 0.6 && Math.random() < 0.05) {
+            game.particleSystem.emit(obs.position.clone(), candyColor, 10, 4.0, 0.6, 1.0);
+            game.obstacleSystem.splitAsteroid(obs);
+            game.audioSystem.playMagicSound('happy');
+        }
+    }
+}
+
+function applyAutoCollect(playerPos: THREE.Vector3, radius: number): void {
+    const orbCollectibles = game.orbManager.getActiveOrbs();
+    for (const orb of orbCollectibles) {
+        if (orb.collected) continue;
+        const dist = playerPos.distanceTo(orb.position);
+        if (dist >= radius) continue;
+
+        const pullDir = playerPos.clone().sub(orb.position).normalize();
+        const pullStrength = radius >= 20 ? 0.05 : 0.08;
+        orb.position.addScaledVector(pullDir, dist * pullStrength);
+        orb.mesh.position.copy(orb.position);
+
+        if (dist < 2) {
+            orb.collected = true;
+            orb.mesh.visible = false;
+            game.boostSystem.addCharge(1);
+            game.audioSystem.playCollect();
+            game.juiceManager.burstCollect(orb.position.clone());
+            const scoreMult = game.powerUpManager.getCombinedModifiers().doubleValue ? 2 : 1;
+            game.hudManager.addScore(Math.floor(orb.points * 1.15 * scoreMult));
+        }
+    }
+}
+
+function applyMagnetPull(playerPos: THREE.Vector3, radius: number): void {
+    const orbCollectibles = game.orbManager.getActiveOrbs();
+    for (const orb of orbCollectibles) {
+        if (orb.collected) continue;
+        const dist = playerPos.distanceTo(orb.position);
+        if (dist >= radius) continue;
+
+        const pullDir = playerPos.clone().sub(orb.position).normalize();
+        orb.position.addScaledVector(pullDir, Math.min(dist * 0.12, 2.5));
+        orb.mesh.position.copy(orb.position);
+    }
+}
+
+function applyCandyVortex(playerPos: THREE.Vector3, delta: number): void {
+    const obstacles = game.obstacleSystem.getObstacles();
+    for (const obs of obstacles) {
+        const dist = playerPos.distanceTo(obs.position);
+        if (dist > 18) continue;
+
+        const pullDir = playerPos.clone().sub(obs.position).normalize();
+        obs.position.addScaledVector(pullDir, (18 - dist) * 0.04 * delta * 60);
+
+        if (dist < 6) {
+            const pastelColors = [0xff6b6b, 0xffffff, 0x00ff00];
+            const color = pastelColors[Math.floor(Math.random() * pastelColors.length)];
+            game.particleSystem.emit(obs.position.clone(), color, 6, 4.0, 0.5, 0.5);
+            if (dist < 3 && (obs.userData.radius || 1) < 1.0) {
+                game.obstacleSystem.splitAsteroid(obs);
+                game.audioSystem.play('boing', 0.5);
+            }
+        }
+    }
+}
+
+/** Power-ups, modifier gameplay, magical effects. */
 export function updateCombatPowerups(delta: number): void {
     if (!player) return;
 
-    game.powerUpManager.update(delta);
+    game.powerUpManager.update(delta, player.position);
 
-    const hasRainbowComet = game.powerUpManager.hasPowerUp(PowerUpType.RAINBOW_COMET_TAIL);
+    const modifiers = game.powerUpManager.getCombinedModifiers();
+    const playerPos = player.position;
+
+    if (modifiers.invincible) {
+        playerState.invincible = true;
+    }
+
+    if (modifiers.autoCollectRadius > 0) {
+        applyAutoCollect(playerPos, modifiers.autoCollectRadius);
+    }
+
+    if (modifiers.magnetRadius > 0) {
+        applyMagnetPull(playerPos, modifiers.magnetRadius);
+    }
+
+    if (modifiers.asteroidsToCandy) {
+        const candyRadius = game.powerUpManager.hasPowerUp(PowerUpType.CANDY_CANE_VORTEX) ? 30 : 25;
+        applyAsteroidsToCandy(playerPos, candyRadius);
+    }
+
+    if (game.powerUpManager.hasPowerUp(PowerUpType.CANDY_CANE_VORTEX)) {
+        applyCandyVortex(playerPos, delta);
+    }
+
+    if (game.powerUpManager.hasPowerUp(PowerUpType.MAGIC_PAINTBRUSH)) {
+        game.magicPaintbrushSystem.update(delta, playerPos);
+    }
+
     const rainbowEffect = game.powerUpManager.activeEffects.get(PowerUpType.RAINBOW_COMET_TAIL);
-    const rainbowTimeRemaining = rainbowEffect ? rainbowEffect.timeRemaining : 0;
-
-    if (hasRainbowComet && player) {
-        const orbCollectibles = game.orbManager.getActiveOrbs();
-        for (const orb of orbCollectibles) {
-            if (orb.collected) continue;
-            const dist = player.position.distanceTo(orb.position);
-            if (dist < 45) {
-                const pullDir = player.position.clone().sub(orb.position).normalize();
-                orb.position.addScaledVector(pullDir, dist * 0.05);
-                orb.mesh.position.copy(orb.position);
-                if (dist < 2) {
-                    orb.collected = true;
-                    orb.mesh.visible = false;
-                    game.boostSystem.addCharge(1);
-                    game.audioSystem.playCollect();
-                    game.juiceManager.burstCollect(orb.position.clone());
-                    game.hudManager.addScore(Math.floor(orb.points * 1.15));
-                }
-            }
-        }
-
-        const obstacles = game.obstacleSystem.getObstacles();
-        for (let i = obstacles.length - 1; i >= 0; i--) {
-            const obs = obstacles[i];
-            const radius = obs.userData.radius || 1.0;
-            if (radius < 1.2 && player.position.distanceTo(obs.position) < 25) {
-                const pastelColors = [0xffb6c1, 0xffc0cb, 0xe6e6fa, 0xb0e0e6, 0x98fb98];
-                const candyColor = pastelColors[Math.floor(Math.random() * pastelColors.length)];
-                (obs.material as THREE.MeshStandardMaterial).color.setHex(candyColor);
-                (obs.material as THREE.MeshStandardMaterial).emissive.setHex(candyColor);
-                (obs.material as THREE.MeshStandardMaterial).emissiveIntensity = 0.3;
-                obs.userData.isCandy = true;
-
-                game.particleSystem.emit(obs.position.clone(), candyColor, 5, 3.0, 0.4, 0.6);
-                game.particleSystem.emit(obs.position.clone(), 0xffffff, 3, 2.0, 0.3, 0.4);
-
-                if (radius < 0.6 && Math.random() < 0.05) {
-                    game.particleSystem.emit(obs.position.clone(), candyColor, 10, 4.0, 0.6, 1.0);
-                    game.obstacleSystem.splitAsteroid(obs);
-                    game.audioSystem.playMagicSound('happy');
-                }
-            }
-        }
-    }
-
-    if (hasRainbowComet && rainbowTimeRemaining < 1.0 && rainbowTimeRemaining > 0) {
+    const rainbowTimeRemaining = rainbowEffect?.isActive ? rainbowEffect.timeRemaining : 0;
+    if (rainbowTimeRemaining > 0 && rainbowTimeRemaining < 1.0) {
         const fadeRatio = rainbowTimeRemaining;
-        if (player) {
-            const rocket = player.children[0];
-            if (rocket) {
-                rocket.traverse((child: any) => {
-                    if (child.isMesh && child.material && child.material.emissiveIntensity !== undefined) {
-                        child.material.emissiveIntensity *= fadeRatio;
-                    }
-                });
-            }
+        const rocket = player.children[0];
+        if (rocket) {
+            rocket.traverse((child: THREE.Object3D) => {
+                const mesh = child as THREE.Mesh;
+                if (mesh.isMesh && mesh.material && 'emissiveIntensity' in (mesh.material as THREE.MeshStandardMaterial)) {
+                    (mesh.material as THREE.MeshStandardMaterial).emissiveIntensity *= fadeRatio;
+                }
+            });
         }
     }
 
-    if (game.debugSystem.isEnabled('magicalEffects')) {
-        game.effectManager.update(delta);
-    }
+    game.effectManager.update(delta);
 
     const isMagicActive = game.effectManager.hasEffect(MagicalEffectType.RAINBOW_TRAIL) ||
                           game.effectManager.hasEffect(MagicalEffectType.HEART_BUBBLE);

--- a/src/main/loop_combat/weapons.ts
+++ b/src/main/loop_combat/weapons.ts
@@ -7,6 +7,34 @@ import type { CandyFlavor } from '../../candy_materials';
 import { updateCombatBossKraken } from './boss';
 import { onBarnacleOpened, updateProjectileAnchorPanic } from './friends';
 
+const BUTTERFLY_COLORS = [0xffb6c1, 0xdda0dd, 0x87ceeb, 0x98fb98, 0xf0e68c];
+
+function transformAsteroidToButterflies(obs: THREE.Object3D): void {
+    const mesh = obs as THREE.Mesh;
+    const pastel = BUTTERFLY_COLORS[Math.floor(Math.random() * BUTTERFLY_COLORS.length)];
+    (mesh.material as THREE.MeshStandardMaterial).color.setHex(pastel);
+    (mesh.material as THREE.MeshStandardMaterial).emissive.setHex(pastel);
+    (mesh.material as THREE.MeshStandardMaterial).emissiveIntensity = 0.4;
+    mesh.userData.isCandy = true;
+
+    for (let b = 0; b < 4; b++) {
+        const offset = new THREE.Vector3(
+            (Math.random() - 0.5) * 2,
+            (Math.random() - 0.5) * 2,
+            (Math.random() - 0.5) * 0.5
+        );
+        game.particleSystem.emit(
+            mesh.position.clone().add(offset),
+            pastel,
+            3,
+            3.0,
+            0.35,
+            0.8
+        );
+    }
+    game.audioSystem.playMagicSound('happy');
+}
+
 /** Destroy one obstacle with the standard projectile-hit effects (also used by Glitch Grenades). */
 export function blastObstacle(obs: THREE.Object3D): void {
     if (obs.userData.isCandyAsteroid) {
@@ -39,6 +67,8 @@ export function updateCombatWeapons(delta: number): void {
     if (projectiles.length === 0) return;
 
     const obstacles = game.obstacleSystem.getObstacles();
+    const butterflyBlast = game.powerUpManager.getCombinedModifiers().asteroidsToButterflies;
+
     for (let i = obstacles.length - 1; i >= 0; i--) {
         const obs = obstacles[i];
         const obsRadius = obs.userData.radius || 1.0;
@@ -48,6 +78,11 @@ export function updateCombatWeapons(delta: number): void {
 
             const dist = proj.mesh.position.distanceTo(obs.position);
             if (dist < obsRadius + 0.5) {
+                if (butterflyBlast && !obs.userData.isCandyAsteroid) {
+                    transformAsteroidToButterflies(obs);
+                    proj.deactivate();
+                    break;
+                }
                 blastObstacle(obs);
 
                 proj.deactivate();

--- a/src/main/player_update.ts
+++ b/src/main/player_update.ts
@@ -15,9 +15,13 @@ import { DogAnimationState } from '../dog_cockpit';
 export function updatePlayer(delta: number) {
     // Don't update if player hasn't loaded yet
     if (!player) return;
+
+    const modifiers = game.powerUpManager.getCombinedModifiers();
+    const hasFairyWings = game.powerUpManager.hasPowerUp(PowerUpType.FAIRY_DOG_WINGS);
     
     // Auto-scroll (constant forward movement)
-    player.position.x += playerState.autoScrollSpeed * delta;
+    const speedMult = modifiers.speedMultiplier ?? 1.0;
+    player.position.x += playerState.autoScrollSpeed * speedMult * delta;
 
     // --- UPGRADED: Gravity and Momentum Flight ---
     let targetSpeed = 0;
@@ -52,9 +56,6 @@ export function updatePlayer(delta: number) {
         }
     }
     
-    const modifiers = game.powerUpManager.getCombinedModifiers();
-    const hasFairyWings = game.powerUpManager.hasPowerUp(PowerUpType.FAIRY_DOG_WINGS);
-
     if (isMovingUp) {
         targetSpeed = CONFIG.player.maxSpeedY;
     } else if (isMovingDown) {
@@ -84,6 +85,17 @@ export function updatePlayer(delta: number) {
     }
     
     playerState.currentSpeedY += (targetSpeed - playerState.currentSpeedY) * accel * delta;
+
+    if (hasFairyWings && keys.run) {
+        // Float glide handled above via targetSpeed
+    } else if (game.powerUpManager.hasPowerUp(PowerUpType.MAGIC_PAINTBRUSH)) {
+        playerState.currentSpeedY = game.magicPaintbrushSystem.applyGuideForce(
+            player.position,
+            playerState.currentSpeedY,
+            delta
+        );
+    }
+
     player.position.y += playerState.currentSpeedY * delta;
     
     // Soft boundaries - keep player on screen (Y: -10 to +15)

--- a/src/main/startup_callbacks.ts
+++ b/src/main/startup_callbacks.ts
@@ -3,8 +3,7 @@ import { player } from '../player_loader';
 import { playerState, CONFIG, setIsGamePaused, isGamePaused } from '../game_config';
 import { game } from '../game_runtime';
 import { updateHealthDisplay } from '../ui_controls';
-import { PowerUpType } from '../powerup_manager';
-import { MagicalEffectType } from '../magical_effects';
+import { syncMagicalEffectsFromActive } from '../powerup_manager';
 import { DogAnimationState } from '../dog_cockpit';
 import { ShakeType } from '../juice_effects';
 import { updateBoostDisplay, updateRollDisplay, updateTetherDisplay, showRollPopup } from './hud_displays';
@@ -45,31 +44,18 @@ export function wireStartupCallbacks(): void {
     game.orbManager.onPowerUpReady = () => {
         const triggered = game.powerUpManager.collectOrb();
         if (triggered && player) {
-            game.dogController.triggerAnimation(DogAnimationState.POWER_UP, 2.0);
             game.juiceManager.flashRainbow(0.5);
             game.juiceManager.burstMagic(player.position.clone());
-            const activeEffects = game.powerUpManager.getActiveEffects();
-            activeEffects.forEach(effect => {
-                switch (effect.type) {
-                    case PowerUpType.RAINBOW_COMET_TAIL:
-                        game.effectManager.activateEffect(MagicalEffectType.RAINBOW_TRAIL, effect.duration);
-                        break;
-                    case PowerUpType.FLOWER_CROWN_BOOST:
-                        game.effectManager.activateEffect(MagicalEffectType.STARDUST_FIELD, effect.duration);
-                        break;
-                    case PowerUpType.BUBBLEGUM_SHIELD:
-                        game.effectManager.activateEffect(MagicalEffectType.HEART_BUBBLE, effect.duration);
-                        break;
-                    case PowerUpType.TWINKLE_STAR_MAGNET:
-                        game.effectManager.activateEffect(MagicalEffectType.STARDUST_FIELD, effect.duration);
-                        break;
-                    case PowerUpType.BUTTERFLY_ESCORT:
-                        game.effectManager.activateEffect(MagicalEffectType.BUTTERFLY_SWARM, effect.duration);
-                        break;
-                    case PowerUpType.UNICORN_HORN_BLAST:
-                        game.effectManager.activateEffect(MagicalEffectType.GLITTER_BEAM, effect.duration);
-                        break;
-                }
+            syncMagicalEffectsFromActive({
+                effectManager: game.effectManager,
+                audioSystem: game.audioSystem,
+                dogController: game.dogController,
+                juiceManager: game.juiceManager,
+                powerUpManager: game.powerUpManager,
+                getPlayerPosition: () => player?.position,
+                onHudHealthUpdate: () => {
+                    game.hudManager.updateHealth(playerState.health, playerState.maxHealth);
+                },
             });
         }
     };
@@ -86,8 +72,12 @@ export function wireStartupCallbacks(): void {
 
     const originalAddScore = game.hudManager.addScore.bind(game.hudManager);
     game.hudManager.addScore = (points: number) => {
+        let scaled = points;
+        if (game.powerUpManager.getCombinedModifiers().doubleValue) {
+            scaled *= 2;
+        }
         const mult = performance.now() < game.scoreMultiplierUntil ? game.scoreMultiplierValue : 1;
-        originalAddScore(Math.round(points * mult));
+        originalAddScore(Math.round(scaled * mult));
     };
 
     game.discoveryManager.onSpeciesDiscovered = (speciesId, name, totalThisRun, _isNewEver) => {

--- a/src/obstacle_system/manager.ts
+++ b/src/obstacle_system/manager.ts
@@ -130,8 +130,19 @@ export class ObstacleSystem implements ObstacleSystemHost {
             obs.rotation.y += obs.userData.rotationSpeedY * delta;
             obs.rotation.z += obs.userData.rotationSpeedZ * delta;
 
+            const puMods = this.options.getPowerUpModifiers?.();
+            const slowMult = puMods?.obstaclesSlowed ? (puMods.obstacleSlowFactor ?? 1) : 1;
+
             if (obs.userData.velocity) {
-                obs.position.addScaledVector(obs.userData.velocity, delta);
+                obs.position.addScaledVector(obs.userData.velocity, delta * slowMult);
+            }
+
+            if (puMods?.obstaclesSlowed) {
+                const dx = obs.position.x - playerX;
+                const dy = obs.position.y - playerY;
+                if (Math.abs(dx) < 22 && Math.abs(dy) < 10) {
+                    obs.position.y -= dy * 0.025 * delta * 60;
+                }
             }
 
             if (obs.userData.isCandyAsteroid) {
@@ -262,7 +273,11 @@ export class ObstacleSystem implements ObstacleSystemHost {
                     : { shieldActive: false, shieldBouncesAsteroids: false };
                 if (modifiers.shieldBouncesAsteroids && this.bounceCooldown <= 0) {
                     handleBounce(this, hitObs);
-                } else if (!this.options.playerState.invincible && !this.options.playerState.inSafeHarbor) {
+                } else if (
+                    !this.options.playerState.invincible
+                    && !modifiers.invincible
+                    && !this.options.playerState.inSafeHarbor
+                ) {
                     if (this.bounceCooldown <= 0 && this.options.tryConsumeButterflyCharge?.()) {
                         this.options.onButterflySave?.(hitObs.position);
                     } else if (this.options.tryConsumeSwarmEscort?.(hitObs.position.clone(), hitRadius)) {

--- a/src/powerup_manager/index.ts
+++ b/src/powerup_manager/index.ts
@@ -2,4 +2,5 @@ export * from './types';
 export * from './powerup_effect';
 export * from './manager';
 export * from './manager_visuals';
+export * from './powerup_hooks';
 export { default } from './singleton';

--- a/src/powerup_manager/manager.ts
+++ b/src/powerup_manager/manager.ts
@@ -171,14 +171,7 @@ export class PowerUpManager {
         
         createEffectVisuals(this.getVisualContext(), type);
         
-        if (this.audioSystem) {
-            this.audioSystem.play('powerup');
-        }
-
         const powerUpCfg = POWER_UP_CONFIGS[type];
-        if (this.dogController) {
-            this.dogController.triggerAnimation('power_up', 2.0);
-        }
         if (this.rocket) {
             this.particleSystem.emit(
                 this.rocket.position.clone(),

--- a/src/powerup_manager/manager_visuals.ts
+++ b/src/powerup_manager/manager_visuals.ts
@@ -53,6 +53,30 @@ export function createEffectVisuals(ctx: PowerUpManagerVisualContext, type: Powe
         case PowerUpType.FAIRY_DOG_WINGS:
             createFairyDogWings(ctx, config);
             break;
+        case PowerUpType.DREAM_CLOUD_CARPET:
+            createDreamCloudCarpet(ctx, config);
+            break;
+        case PowerUpType.LULLABY_LANTERN:
+            createLullabyLantern(ctx, config);
+            break;
+        case PowerUpType.PUPPY_HUG_HUG:
+            createPuppyHugAura(ctx, config);
+            break;
+        case PowerUpType.MOONBEAM_SLIDE:
+            createMoonbeamSlide(ctx, config);
+            break;
+        case PowerUpType.FAIRY_GODMOTHER_SPARKLE:
+            createFairyGodmotherSparkle(ctx, config);
+            break;
+        case PowerUpType.CANDY_CANE_VORTEX:
+            createCandyCaneVortex(ctx, config);
+            break;
+        case PowerUpType.MAGIC_PAINTBRUSH:
+            createMagicPaintbrush(ctx, config);
+            break;
+        case PowerUpType.BEST_FRIEND_FOREVER_AURA:
+            createBestFriendAura(ctx, config);
+            break;
     }
 
     createEffectLight(ctx, type, config.color);
@@ -208,6 +232,264 @@ export function createFairyDogWings(ctx: PowerUpManagerVisualContext, config: Po
 
     ctx.fairyWingsMesh = wingsGroup;
     ctx.rocket.add(wingsGroup);
+    ctx.effectMeshes.set(PowerUpType.FAIRY_DOG_WINGS, wingsGroup);
+}
+
+export function createDreamCloudCarpet(ctx: PowerUpManagerVisualContext, config: PowerUpConfig): void {
+    if (!ctx.rocket) return;
+
+    const carpetGroup = new THREE.Group();
+    carpetGroup.position.set(0, -1.2, 0);
+
+    const puffCount = 5;
+    for (let i = 0; i < puffCount; i++) {
+        const puff = new THREE.Mesh(
+            new THREE.SphereGeometry(0.5 + Math.random() * 0.2, 8, 8),
+            new THREE.MeshBasicMaterial({
+                color: i % 2 === 0 ? config.color : config.secondaryColor,
+                transparent: true,
+                opacity: 0.7,
+            })
+        );
+        puff.position.set((i - 2) * 0.55, Math.sin(i) * 0.1, (Math.random() - 0.5) * 0.3);
+        carpetGroup.add(puff);
+    }
+
+    const rainbowStrip = new THREE.Mesh(
+        new THREE.PlaneGeometry(3.2, 0.25),
+        new THREE.MeshBasicMaterial({
+            color: 0xffb6c1,
+            transparent: true,
+            opacity: 0.5,
+            side: THREE.DoubleSide,
+        })
+    );
+    rainbowStrip.rotation.x = -Math.PI / 2;
+    rainbowStrip.position.y = 0.15;
+    carpetGroup.add(rainbowStrip);
+
+    ctx.rocket.add(carpetGroup);
+    ctx.effectMeshes.set(PowerUpType.DREAM_CLOUD_CARPET, carpetGroup);
+}
+
+export function createLullabyLantern(ctx: PowerUpManagerVisualContext, config: PowerUpConfig): void {
+    if (!ctx.rocket) return;
+
+    const lanternGroup = new THREE.Group();
+    lanternGroup.position.set(0.8, 1.2, 0.5);
+
+    const body = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.25, 0.3, 0.5, 8),
+        new THREE.MeshBasicMaterial({ color: config.color, transparent: true, opacity: 0.9 })
+    );
+    lanternGroup.add(body);
+
+    const glow = new THREE.Mesh(
+        new THREE.SphereGeometry(0.35, 8, 8),
+        new THREE.MeshBasicMaterial({
+            color: config.secondaryColor,
+            transparent: true,
+            opacity: 0.35,
+            blending: THREE.AdditiveBlending,
+        })
+    );
+    glow.position.y = 0.1;
+    lanternGroup.add(glow);
+
+    const tassel = new THREE.Mesh(
+        new THREE.ConeGeometry(0.08, 0.25, 6),
+        new THREE.MeshBasicMaterial({ color: 0xff4500 })
+    );
+    tassel.position.y = -0.35;
+    lanternGroup.add(tassel);
+
+    ctx.rocket.add(lanternGroup);
+    ctx.effectMeshes.set(PowerUpType.LULLABY_LANTERN, lanternGroup);
+}
+
+export function createPuppyHugAura(ctx: PowerUpManagerVisualContext, config: PowerUpConfig): void {
+    if (!ctx.rocket) return;
+
+    const auraGroup = new THREE.Group();
+    const ring = new THREE.Mesh(
+        new THREE.TorusGeometry(1.6, 0.12, 8, 24),
+        new THREE.MeshBasicMaterial({
+            color: config.color,
+            transparent: true,
+            opacity: 0.55,
+            blending: THREE.AdditiveBlending,
+        })
+    );
+    auraGroup.add(ring);
+
+    const heart = new THREE.Mesh(
+        new THREE.SphereGeometry(0.25, 8, 8),
+        new THREE.MeshBasicMaterial({ color: config.secondaryColor })
+    );
+    heart.position.set(0, 1.4, 0.3);
+    heart.scale.set(1.2, 1, 0.8);
+    auraGroup.add(heart);
+
+    ctx.rocket.add(auraGroup);
+    ctx.effectMeshes.set(PowerUpType.PUPPY_HUG_HUG, auraGroup);
+}
+
+export function createMoonbeamSlide(ctx: PowerUpManagerVisualContext, config: PowerUpConfig): void {
+    if (!ctx.rocket) return;
+
+    const slideGroup = new THREE.Group();
+    slideGroup.position.set(-1.5, -0.3, 0);
+
+    const beam = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.08, 0.25, 3, 8),
+        new THREE.MeshBasicMaterial({
+            color: config.color,
+            transparent: true,
+            opacity: 0.6,
+            blending: THREE.AdditiveBlending,
+        })
+    );
+    beam.rotation.z = Math.PI / 2;
+    slideGroup.add(beam);
+
+    const tip = new THREE.Mesh(
+        new THREE.OctahedronGeometry(0.2),
+        new THREE.MeshBasicMaterial({ color: config.secondaryColor })
+    );
+    tip.position.set(-1.6, 0, 0);
+    slideGroup.add(tip);
+
+    ctx.rocket.add(slideGroup);
+    ctx.effectMeshes.set(PowerUpType.MOONBEAM_SLIDE, slideGroup);
+}
+
+export function createFairyGodmotherSparkle(ctx: PowerUpManagerVisualContext, config: PowerUpConfig): void {
+    if (!ctx.rocket) return;
+
+    const fairyGroup = new THREE.Group();
+    fairyGroup.position.set(1.2, 1.5, 0.4);
+
+    const body = new THREE.Mesh(
+        new THREE.SphereGeometry(0.2, 8, 8),
+        new THREE.MeshBasicMaterial({ color: config.secondaryColor })
+    );
+    fairyGroup.add(body);
+
+    const wings = new THREE.Mesh(
+        new THREE.CircleGeometry(0.35, 6),
+        new THREE.MeshBasicMaterial({
+            color: config.color,
+            transparent: true,
+            opacity: 0.7,
+            side: THREE.DoubleSide,
+        })
+    );
+    wings.rotation.y = Math.PI / 2;
+    fairyGroup.add(wings);
+
+    const wand = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.02, 0.02, 0.4, 4),
+        new THREE.MeshBasicMaterial({ color: 0xffd700 })
+    );
+    wand.position.set(0.25, -0.1, 0);
+    wand.rotation.z = -0.5;
+    fairyGroup.add(wand);
+
+    ctx.rocket.add(fairyGroup);
+    ctx.effectMeshes.set(PowerUpType.FAIRY_GODMOTHER_SPARKLE, fairyGroup);
+}
+
+export function createCandyCaneVortex(ctx: PowerUpManagerVisualContext, config: PowerUpConfig): void {
+    if (!ctx.rocket) return;
+
+    const vortexGroup = new THREE.Group();
+
+    const stripeCount = 6;
+    for (let i = 0; i < stripeCount; i++) {
+        const angle = (i / stripeCount) * Math.PI * 2;
+        const stripe = new THREE.Mesh(
+            new THREE.BoxGeometry(0.15, 1.8, 0.15),
+            new THREE.MeshBasicMaterial({
+                color: i % 2 === 0 ? config.color : config.secondaryColor,
+                transparent: true,
+                opacity: 0.8,
+            })
+        );
+        stripe.position.set(Math.cos(angle) * 1.2, Math.sin(angle) * 1.2, 0);
+        stripe.rotation.z = angle;
+        vortexGroup.add(stripe);
+    }
+
+    ctx.rocket.add(vortexGroup);
+    ctx.effectMeshes.set(PowerUpType.CANDY_CANE_VORTEX, vortexGroup);
+}
+
+export function createMagicPaintbrush(ctx: PowerUpManagerVisualContext, config: PowerUpConfig): void {
+    if (!ctx.rocket) return;
+
+    const brushGroup = new THREE.Group();
+    brushGroup.position.set(0.6, 0.2, 0.8);
+
+    const handle = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.04, 0.04, 0.5, 6),
+        new THREE.MeshBasicMaterial({ color: 0x8b4513 })
+    );
+    handle.rotation.z = Math.PI / 4;
+    brushGroup.add(handle);
+
+    const bristles = new THREE.Mesh(
+        new THREE.ConeGeometry(0.12, 0.2, 8),
+        new THREE.MeshBasicMaterial({ color: config.color })
+    );
+    bristles.position.set(0.2, 0.2, 0);
+    bristles.rotation.z = Math.PI / 4;
+    brushGroup.add(bristles);
+
+    const tipGlow = new THREE.Mesh(
+        new THREE.SphereGeometry(0.08, 6, 6),
+        new THREE.MeshBasicMaterial({
+            color: config.secondaryColor,
+            transparent: true,
+            opacity: 0.8,
+            blending: THREE.AdditiveBlending,
+        })
+    );
+    tipGlow.position.set(0.28, 0.28, 0);
+    brushGroup.add(tipGlow);
+
+    ctx.rocket.add(brushGroup);
+    ctx.effectMeshes.set(PowerUpType.MAGIC_PAINTBRUSH, brushGroup);
+}
+
+export function createBestFriendAura(ctx: PowerUpManagerVisualContext, config: PowerUpConfig): void {
+    if (!ctx.rocket) return;
+
+    const auraGroup = new THREE.Group();
+
+    const innerRing = new THREE.Mesh(
+        new THREE.TorusGeometry(1.4, 0.08, 8, 32),
+        new THREE.MeshBasicMaterial({
+            color: config.color,
+            transparent: true,
+            opacity: 0.5,
+            blending: THREE.AdditiveBlending,
+        })
+    );
+    auraGroup.add(innerRing);
+
+    const outerRing = new THREE.Mesh(
+        new THREE.TorusGeometry(1.9, 0.05, 8, 32),
+        new THREE.MeshBasicMaterial({
+            color: config.secondaryColor,
+            transparent: true,
+            opacity: 0.35,
+            blending: THREE.AdditiveBlending,
+        })
+    );
+    auraGroup.add(outerRing);
+
+    ctx.rocket.add(auraGroup);
+    ctx.effectMeshes.set(PowerUpType.BEST_FRIEND_FOREVER_AURA, auraGroup);
 }
 
 export function createStarlightTiara(ctx: PowerUpManagerVisualContext, config: PowerUpConfig): void {
@@ -315,7 +597,6 @@ export function updateEffectPosition(ctx: PowerUpManagerVisualContext, type: Pow
             break;
         case PowerUpType.FAIRY_DOG_WINGS:
             if (ctx.fairyWingsMesh) {
-                // Animate wing flapping
                 const now = Date.now() * 0.008;
                 const leftWing = ctx.fairyWingsMesh.children[0];
                 const rightWing = ctx.fairyWingsMesh.children[1];
@@ -327,6 +608,73 @@ export function updateEffectPosition(ctx: PowerUpManagerVisualContext, type: Pow
                 }
             }
             break;
+        case PowerUpType.STARLIGHT_TIARA: {
+            const tiara = ctx.effectMeshes.get(PowerUpType.STARLIGHT_TIARA);
+            if (tiara) {
+                const pulse = 1 + Math.sin(Date.now() * 0.006) * 0.08;
+                tiara.scale.set(pulse, pulse, pulse);
+                tiara.rotation.y = Math.sin(Date.now() * 0.002) * 0.15;
+            }
+            break;
+        }
+        case PowerUpType.DREAM_CLOUD_CARPET: {
+            const carpet = ctx.effectMeshes.get(PowerUpType.DREAM_CLOUD_CARPET);
+            if (carpet) {
+                carpet.position.y = -1.2 + Math.sin(Date.now() * 0.003) * 0.15;
+            }
+            break;
+        }
+        case PowerUpType.LULLABY_LANTERN: {
+            const lantern = ctx.effectMeshes.get(PowerUpType.LULLABY_LANTERN);
+            if (lantern) {
+                lantern.rotation.z = Math.sin(Date.now() * 0.002) * 0.12;
+                const glow = lantern.children[1];
+                if (glow) {
+                    const s = 1 + Math.sin(Date.now() * 0.005) * 0.15;
+                    glow.scale.set(s, s, s);
+                }
+            }
+            break;
+        }
+        case PowerUpType.PUPPY_HUG_HUG:
+        case PowerUpType.BEST_FRIEND_FOREVER_AURA: {
+            const aura = ctx.effectMeshes.get(type);
+            if (aura) {
+                const pulse = 1 + Math.sin(Date.now() * 0.004) * 0.1;
+                aura.scale.set(pulse, pulse, pulse);
+                aura.rotation.z += 0.015;
+            }
+            break;
+        }
+        case PowerUpType.MOONBEAM_SLIDE: {
+            const slide = ctx.effectMeshes.get(PowerUpType.MOONBEAM_SLIDE);
+            if (slide) {
+                slide.children[0].scale.x = 1 + Math.sin(Date.now() * 0.008) * 0.2;
+            }
+            break;
+        }
+        case PowerUpType.FAIRY_GODMOTHER_SPARKLE: {
+            const fairy = ctx.effectMeshes.get(PowerUpType.FAIRY_GODMOTHER_SPARKLE);
+            if (fairy) {
+                fairy.position.y = 1.5 + Math.sin(Date.now() * 0.005) * 0.2;
+                fairy.rotation.y += 0.03;
+            }
+            break;
+        }
+        case PowerUpType.CANDY_CANE_VORTEX: {
+            const vortex = ctx.effectMeshes.get(PowerUpType.CANDY_CANE_VORTEX);
+            if (vortex) {
+                vortex.rotation.z += 0.06;
+            }
+            break;
+        }
+        case PowerUpType.MAGIC_PAINTBRUSH: {
+            const brush = ctx.effectMeshes.get(PowerUpType.MAGIC_PAINTBRUSH);
+            if (brush) {
+                brush.rotation.z = Math.sin(Date.now() * 0.006) * 0.2;
+            }
+            break;
+        }
     }
 }
 
@@ -460,6 +808,8 @@ export function removeEffectVisuals(ctx: PowerUpManagerVisualContext, type: Powe
                 ctx.fairyWingsMesh.parent.remove(ctx.fairyWingsMesh);
             }
             ctx.fairyWingsMesh = undefined;
+            break;
+        case PowerUpType.STARLIGHT_TIARA:
             break;
     }
 }

--- a/src/powerup_manager/powerup_hooks.ts
+++ b/src/powerup_manager/powerup_hooks.ts
@@ -1,0 +1,157 @@
+import * as THREE from 'three';
+import { PowerUpType, POWER_UP_CONFIGS, type PowerUpConfig } from './types';
+import { getEffectForPowerUp } from '../magical_effects/factories';
+import { MagicalEffectType } from '../magical_effects';
+import { DogAnimationState } from '../dog_cockpit';
+import type { EffectManager } from '../magical_effects/effect_manager';
+import type { AudioSystem } from '../audio_system';
+import type { DogCockpitController } from '../dog_cockpit';
+import type { JuiceManager } from '../juice_effects';
+import type { PowerUpManager } from './manager';
+import { playerState } from '../game_config';
+import { updateHealthDisplay } from '../ui_controls';
+
+export interface PowerUpHookContext {
+    effectManager: EffectManager;
+    audioSystem: AudioSystem;
+    dogController: DogCockpitController;
+    juiceManager: JuiceManager;
+    powerUpManager: PowerUpManager;
+    getPlayerPosition: () => THREE.Vector3 | undefined;
+    onHudHealthUpdate?: () => void;
+}
+
+const AMBIENT_EFFECTS = new Set<MagicalEffectType>([
+    MagicalEffectType.CONFETTI_BURST,
+    MagicalEffectType.HEART_RAIN,
+    MagicalEffectType.STAR_CASCADE,
+    MagicalEffectType.RAINBOW_SPIRAL,
+    MagicalEffectType.SPARKLE_FIELD,
+]);
+
+const DOG_REACTIONS: Partial<Record<PowerUpType, DogAnimationState>> = {
+    [PowerUpType.PUPPY_HUG_HUG]: DogAnimationState.DELIGHTED,
+    [PowerUpType.FAIRY_GODMOTHER_SPARKLE]: DogAnimationState.DELIGHTED,
+    [PowerUpType.BEST_FRIEND_FOREVER_AURA]: DogAnimationState.DELIGHTED,
+    [PowerUpType.LULLABY_LANTERN]: DogAnimationState.CURIOUS,
+    [PowerUpType.MAGIC_PAINTBRUSH]: DogAnimationState.CURIOUS,
+};
+
+function activateMagicalEffect(ctx: PowerUpHookContext, type: PowerUpType, duration: number): void {
+    const magicalType = getEffectForPowerUp(type);
+    if (!magicalType) return;
+
+    if (AMBIENT_EFFECTS.has(magicalType)) {
+        const pos = ctx.getPlayerPosition();
+        if (!pos) return;
+        switch (magicalType) {
+            case MagicalEffectType.CONFETTI_BURST:
+                ctx.effectManager.spawnConfettiBurst(pos);
+                break;
+            case MagicalEffectType.HEART_RAIN:
+                ctx.effectManager.spawnHeartRain(pos, duration);
+                break;
+            case MagicalEffectType.STAR_CASCADE:
+                ctx.effectManager.spawnStarCascade(pos, duration);
+                break;
+            case MagicalEffectType.RAINBOW_SPIRAL:
+                ctx.effectManager.spawnRainbowSpiral(pos, duration);
+                break;
+            case MagicalEffectType.SPARKLE_FIELD:
+                ctx.effectManager.spawnSparkleField(pos, duration);
+                break;
+        }
+        return;
+    }
+
+    ctx.effectManager.activateEffect(magicalType, duration);
+}
+
+function grantFairyGodmotherBonus(ctx: PowerUpHookContext): void {
+    const tiers: (1 | 2)[] = [1, 2];
+    const tier = tiers[Math.floor(Math.random() * tiers.length)];
+    const available = Object.values(POWER_UP_CONFIGS)
+        .filter((c) => c.tier === tier && c.type !== PowerUpType.FAIRY_GODMOTHER_SPARKLE)
+        .map((c) => c.type);
+
+    if (available.length === 0) return;
+
+    const grant = available[Math.floor(Math.random() * available.length)];
+    window.setTimeout(() => {
+        ctx.powerUpManager.activatePowerUp(grant);
+        const pos = ctx.getPlayerPosition();
+        if (pos) {
+            ctx.juiceManager.showFloatingText('A gift!', pos, '#ffd700', 22);
+        }
+    }, 500);
+}
+
+export function handlePowerUpStart(ctx: PowerUpHookContext, type: PowerUpType, config: PowerUpConfig): void {
+    activateMagicalEffect(ctx, type, config.duration);
+
+    switch (type) {
+        case PowerUpType.RAINBOW_COMET_TAIL:
+            ctx.audioSystem.playCometActivate();
+            ctx.juiceManager.flashRainbow(0.8);
+            break;
+        case PowerUpType.BUBBLEGUM_SHIELD:
+            ctx.audioSystem.playShieldActivate();
+            break;
+        case PowerUpType.FLOWER_CROWN_BOOST:
+        case PowerUpType.TWINKLE_STAR_MAGNET:
+        case PowerUpType.UNICORN_HORN_BLAST:
+        case PowerUpType.BUTTERFLY_ESCORT:
+            break;
+        case PowerUpType.PUPPY_HUG_HUG:
+            if (playerState.health < playerState.maxHealth) {
+                playerState.health++;
+                ctx.onHudHealthUpdate?.();
+                updateHealthDisplay(playerState);
+                const pos = ctx.getPlayerPosition();
+                if (pos) {
+                    ctx.juiceManager.showFloatingText('+1 Heart!', pos.clone().add(new THREE.Vector3(0, 1.5, 0)), '#ff6699', 24);
+                }
+            }
+            break;
+        case PowerUpType.FAIRY_GODMOTHER_SPARKLE:
+            grantFairyGodmotherBonus(ctx);
+            ctx.juiceManager.flashRainbow(0.6);
+            break;
+        case PowerUpType.BEST_FRIEND_FOREVER_AURA:
+            ctx.audioSystem.activateMagicMusic(config.duration * 1000);
+            break;
+        case PowerUpType.MAGIC_PAINTBRUSH: {
+            const paintPos = ctx.getPlayerPosition();
+            if (paintPos) {
+                ctx.juiceManager.showFloatingText('Paint a rainbow path!', paintPos, '#ff69b4', 20);
+            }
+            break;
+        }
+        default:
+            break;
+    }
+
+    ctx.audioSystem.playPowerUpCue(config.soundEffect);
+
+    const dogAnim = DOG_REACTIONS[type] ?? DogAnimationState.POWER_UP;
+    ctx.dogController.triggerAnimation(dogAnim, 2.0);
+}
+
+export function handlePowerUpEnd(ctx: PowerUpHookContext, type: PowerUpType, _config: PowerUpConfig): void {
+    if (type === PowerUpType.BUBBLEGUM_SHIELD) {
+        const pos = ctx.getPlayerPosition();
+        if (pos) {
+            ctx.audioSystem.playShieldBreak();
+            ctx.juiceManager.showFloatingText('Pop!', pos, '#ff69b4', 24);
+            ctx.juiceManager.burstMagic(pos.clone());
+        }
+    }
+}
+
+/** Re-activate magical effects after orb-triggered power-up (mirrors start hooks). */
+export function syncMagicalEffectsFromActive(ctx: PowerUpHookContext): void {
+    const active = ctx.powerUpManager.getActiveEffects();
+    for (const effect of active) {
+        activateMagicalEffect(ctx, effect.type, effect.duration);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes the "configured but invisible" gap for whimsical Tier 2–3 power-ups by wiring visuals, gameplay modifiers, audio cues, and composition-root hooks for all 16 existing `PowerUpType` entries (no new enum values).

## Changes

### Audit & central hooks
- Added [`docs/POWER_UP_STATUS.md`](docs/POWER_UP_STATUS.md) — status matrix for modifiers / visuals / hooks / audio / dog reactions
- New [`src/powerup_manager/powerup_hooks.ts`](src/powerup_manager/powerup_hooks.ts) — single activation/deactivation path used by `create_game_systems.ts` and `startup_callbacks.ts`

### Tier 2–3 visuals (`manager_visuals.ts`)
Distinct meshes while active for:
- Dream Cloud Carpet, Lullaby Lantern, Puppy Hug Hug
- Moonbeam Slide, Fairy Godmother Sparkle, Candy Cane Vortex
- Magic Paintbrush, Best Friend Forever Aura
- Fixes: Fairy Dog Wings registered in `effectMeshes`; Starlight Tiara animated

### Gameplay modifiers (composition root / combat loop)
- **Generic** auto-collect, magnet pull, asteroids→candy, invincibility, double score
- **Obstacle slow + lullaby sway** in `obstacle_system/manager.ts`
- **Speed multiplier** in `player_update.ts`
- **Time scale** (BFF Aura) in `loop_combat/index.ts`
- **Unicorn butterfly transform** on projectile hit in `loop_combat/weapons.ts`

### Magic Paintbrush
- New [`src/magic_paintbrush.ts`](src/magic_paintbrush.ts) — mouse-drag rainbow path segments with decoration budget cap (36)
- Left-click drag paints; rocket is gently guided along the painted path
- Cleared on power-up end

### Fairy Godmother Sparkle
- On activate, grants a random tier 1–2 power-up (excluding self) after a short delay

### Audio & dog reactions
- `playPowerUpCue()` procedural stubs for all config `soundEffect` strings (`powerup_cloud`, `powerup_vortex`, etc.)
- Per-type dog animations: DELIGHTED (Puppy Hug, Fairy Godmother, BFF) and CURIOUS (Lullaby Lantern, Paintbrush)

## Verification
- `npm run check` — pass (0 typecheck errors)
- `npm run build` — pass
- `npm run test:smoke` — 2/2 pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dcf7738-04f9-4a07-8085-6d03a8fc7e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dcf7738-04f9-4a07-8085-6d03a8fc7e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new visual effects, animations, audio cues, and character reactions for multiple power-ups.
  * Added the Magic Paintbrush power-up, allowing players to paint rainbow paths that guide movement.
  * Added butterfly transformations, candy vortex effects, automatic item collection, and asteroid interactions.
  * Power-ups now support effects such as bonus health, invincibility, movement changes, obstacle slowing, and doubled scoring.
* **Bug Fixes**
  * Improved synchronization of power-up effects and cleanup when effects end.
  * Combat updates now consistently respect power-up time scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->