### PR TITLE
Dream Portal bonus rooms + Galactic Core finale backdrop

### DIFF
--- a/docs/PERFORMANCE_BUDGETS.md
+++ b/docs/PERFORMANCE_BUDGETS.md
@@ -110,6 +110,9 @@ Use `?renderer=webgl` on headless/cloud; real GPU + WebGPU is preferred for the 
 | `nebula_cloud_puffs` | `nebula.ts` | 45 cloud instances (3 layers) |
 | `nebula_energy_motes` | `nebula.ts` | 50 particle/mote instances |
 | `nebula_ribbons` | `nebula.ts` | 24 ribbon sheets (3 layers) |
+| `dream_portal` | `dream_portal.ts` | ≤3 bonus-room doors per level |
+| `dream_room_props` | `dream_portal.ts` | Bonus-room contents: instanced toys + jellies + exit ring/lantern |
+| `galactic_core` | `galactic_core.ts` | Single finale backdrop set-piece (4 meshes, additive) |
 
 ## Related files
 
@@ -144,13 +147,19 @@ WASM collision (`public/build/optimized.wasm`, ~3 KB) stays on the critical path
 | Level | Example async modules |
 |-------|------------------------|
 | 1 Neon Garden | *(none — pastel nebula + liquid metal are eager)* |
-| 2 Asteroid Belt | `ghost_debris`, `black_hole`, `chroma_shift`, `storm_geodes`, `slingable_objects` |
-| 3 Orbital Descent | `meteor_shower`, `planetary_horizon`, `reentry`, `bubble_coral` |
+| 2 Asteroid Belt | `ghost_debris`, `black_hole`, `chroma_shift`, `storm_geodes`, `slingable_objects`, `dream_portal` |
+| 3 Orbital Descent | `meteor_shower`, `planetary_horizon`, `reentry`, `bubble_coral`, `dream_portal` |
 | 4 Rusty Gauntlet | `industrial_background`, `industrial_geometry`, `bubble_coral`, slingables |
 | 5 Astral Leviathan | `biological_background`, `cosmic_dust`, `void_jellyfish`, `starlight_koi`, `bubble_coral`, industrial geometry (whale ribs) |
-| 6 Aqua Expanse | `waterfall`, `aquatic_life`, `boss_system`, plus koi / coral / jellyfish as flagged |
+| 6 Aqua Expanse | `waterfall`, `aquatic_life`, `boss_system`, `galactic_core`, plus koi / coral / jellyfish as flagged |
 
-Typical async chunk sizes (minified): 2–11 KB each (e.g. `waterfall` ~8 KB, `boss_system` ~10 KB, `industrial_background` ~11 KB).
+Typical async chunk sizes (minified): 2–13 KB each (e.g. `waterfall` ~8 KB, `boss_system` ~10 KB, `industrial_background` ~11 KB, `dream_portal` ~12 KB, `galactic_core` ~5 KB).
+
+Two guardrails for these: the deferred module must not be statically imported by
+anything in the entry graph (Vite prints "dynamically imported … but also
+statically imported by" and folds it back into `index-*.js`), and shared
+constants belong in an eager module — `DREAM_ROOM_Y` lives in `game_config.ts`
+for exactly that reason.
 
 Slingable prototype props load in the background after first click via `ensureSlingableSystems()` — they do not block Level 1 start.
 

--- a/docs/SIDE_SCROLLER_OBJECTS.md
+++ b/docs/SIDE_SCROLLER_OBJECTS.md
@@ -165,6 +165,8 @@ Supported flags (add only the ones a level needs; absent/false means deactivate)
 | `cosmicDust`        | CosmicDustSystem       | 5                | Independent flag; Level 5 composes it with biological |
 | `waterfall`         | WaterfallSystem        | 6                | Aqua Expanse vertical effects |
 | `aquaticLife`       | AquaticLifeManager     | 6                | Jellyfish/kelp/plankton; spawns/clears from the current level flag |
+| `dreamPortals`      | DreamPortalSystem      | 2–3              | Bonus-room doorways: `{ enabled, portals: [{ x, y, z?, durationSeconds?, toyCount?, orbCount?, hazardCount?, theme? }] }` |
+| `galacticCore`      | GalacticCoreSystem     | 6                | Finale backdrop: `{ enabled, approachStartX, approachEndX, startOffsetX, endOffsetX, startZ, endZ, baseY?, intensity?, innerColor?, outerColor? }` |
 
 Example for a new level that mixes:
 
@@ -181,6 +183,70 @@ Example for a new level that mixes:
 ```
 
 In `LevelManager` the plugin table is iterated so enabling systems is just data. Special setup (levelDistance, black-hole placement, cloud hiding) happens inside the activate/deactivate closures for the relevant plugins. Aquatic life uses the same `environments.aquaticLife` flag from the main loop because it also emits HUD/audio encounter events.
+
+## Dream Portals (bonus rooms)
+
+`src/dream_portal.ts` — secret cloud doorways that drop the player into a short
+bonus room and hand them back to the main run.
+
+**Placement.** Doors are declared per level in `environments.dreamPortals.portals`
+with **absolute world X** (same space as `gravLensCorridors.startX` and
+`LEVEL_DISTANCE_BOUNDARIES`). `spawnDreamPortalsForLevel()` runs from
+`onLevelStart`, mirroring how grav-lens corridors and artifacts are placed.
+Each door is one-shot per run.
+
+**The pocket.** The bonus room is *not* a second scene. It is a pocket of the
+same scene parked at `DREAM_ROOM_Y` (4000, exported from `game_config.ts`).
+Entering:
+
+1. saves the player's Y and `autoScrollSpeed`, then teleports the player to the pocket;
+2. sets `playerState.worldOriginY = DREAM_ROOM_Y` — `player_update.ts` measures the
+   soft flight clamp against that origin, so the ±(-10, +15) band travels with the player;
+3. parks `autoScrollSpeed` at 0 and snaps the camera.
+
+Because the LevelManager stream, obstacle spawner and orb cleanup are all keyed
+off camera/player **X**, freezing X freezes the main run in place — nothing is
+torn down, so `hub → continue → portal → exit → hub` stays coherent. Level
+progression and chunk prefetch are additionally gated on
+`dreamPortalSystem.isInRoom()`.
+
+Inside the pocket the player's X is frozen, so the *room* scrolls past them:
+`roomGroup` (static anchor: backdrop + exit ring) holds a `roomScroll` child
+that slides left at `ROOM_SCROLL_SPEED`, carrying the instanced toys, the drifting
+dream jellies and the hero lantern.
+
+**Exit is always available** — the exit ring is pinned directly above the player
+(arms after 2 s), and the room timer is a hard backstop, so there is no soft-lock.
+
+**Rewards reuse existing systems** (no parallel economy): star orbs come from
+`OrbManager`, cores from `SaveManager.addCores`, score from `HUDManager.addScore`,
+and both the door (`speciesId: 'dreamPortal'`) and the room's hero lantern
+(`speciesId: 'dreamLantern'`) are fed to `DiscoveryManager` as scan targets.
+Pocket orbs are cleaned up on exit via `OrbManager.cleanupOrbsAboveY()`.
+
+Interaction tests are measured in the **XY plane** (`distanceXY`): the player never
+leaves `z = 0`, so anything gated on 3D distance at a decorative depth would be
+unreachable.
+
+## Galactic Core (finale backdrop)
+
+`src/galactic_core.ts` — event-horizon sphere, TSL accretion disk (`RingGeometry`
+with layered radial/angular noise, additive), photon halo and a spiral "swirl
+veil" that fakes mild lensing without any postprocessing pass.
+
+It is a **camera-relative parallax backdrop**, not a world-anchored prop: the
+core sits `offsetX` ahead of the camera at depth `z`, and the approach ramp —
+driven by the player's world X between `approachStartX` and `approachEndX`,
+eased — walks both toward their "end" values. That is what makes the finale read
+as a slow fall toward something enormous.
+
+Gameplay hooks are deliberately small (`src/main/galactic_core_update.ts`):
+plasma bolts bend toward the core inside 240 units, and the ship trembles once
+the ramp passes 0.7. `getStarfieldWarp()` is exposed for parallax layers that
+want to smear on the approach.
+
+WebGL2 (`?renderer=webgl`) gets simpler `MeshBasicMaterial` stand-ins and lower
+geometry segment counts instead of the node materials.
 
 ## Wiring checklist (important)
 

--- a/src/collectibles.ts
+++ b/src/collectibles.ts
@@ -605,6 +605,20 @@ export class OrbManager {
         }
     }
     
+    /**
+     * Remove orbs parked above a Y threshold. Used to tear down the Dream
+     * Portal bonus-room fountain without touching main-run orbs.
+     */
+    cleanupOrbsAboveY(y: number): void {
+        for (let i = this.orbs.length - 1; i >= 0; i--) {
+            const orb = this.orbs[i];
+            if (orb.mesh.position.y > y) {
+                orb.destroy(this.scene);
+                this.orbs.splice(i, 1);
+            }
+        }
+    }
+
     /** Get all active orb positions (for debugging or AI) */
     getOrbPositions(): { position: THREE.Vector3; type: OrbType }[] {
         return this.orbs

--- a/src/create_game_systems.ts
+++ b/src/create_game_systems.ts
@@ -23,6 +23,8 @@ import {
     createChromaShiftSystemStub,
     createStormGeodeSystemStub,
     createBlackHoleSystemStub,
+    createGalacticCoreSystemStub,
+    createDreamPortalSystemStub,
     createWishLanternSystemStub,
     createWeatherSystemStub,
     createDancingJellyMossSystemStub,
@@ -37,6 +39,8 @@ import type { IndustrialBackgroundSystem } from './industrial_background';
 import type { CosmicDustSystem } from './cosmic_dust';
 import { PastelNebulaSystem } from './pastel_nebula';
 import type { BlackHoleSystem } from './black_hole';
+import type { GalacticCoreSystem } from './galactic_core';
+import type { DreamPortalSystem } from './dream_portal';
 import type { WishLanternSystem } from './wish_lanterns';
 import type { WeatherSystem } from './weather_system';
 import type { DancingJellyMossSystem } from './dancing_jelly_moss';
@@ -115,6 +119,8 @@ export type GameSystems = {
     stormGeodeSystem: StormGeodeSystem;
     crystalChimeManager: CrystalChimeManager;
     blackHoleSystem: BlackHoleSystem;
+    galacticCoreSystem: GalacticCoreSystem;
+    dreamPortalSystem: DreamPortalSystem;
     gravLensManager: GravLensManager;
     derelictBuoyManager: DerelictBuoyManager;
     dataMonolithManager: DataMonolithManager;
@@ -137,6 +143,7 @@ export type LevelEnvironmentSystemExports = {
     chromaShiftSystem: ChromaShiftSystem;
     stormGeodeSystem: StormGeodeSystem;
     blackHoleSystem: BlackHoleSystem;
+    galacticCoreSystem: GalacticCoreSystem;
     wishLanternSystem: WishLanternSystem;
     dynamicStarfieldSystem: DynamicStarfieldSystem;
 };
@@ -310,6 +317,8 @@ export function createGameSystems(deps: CreateGameSystemsDeps): GameSystems {
     const stormGeodeSystem: StormGeodeSystem = createStormGeodeSystemStub();
     const crystalChimeManager = new CrystalChimeManager(scene, particleSystem, audioSystem);
     const blackHoleSystem: BlackHoleSystem = createBlackHoleSystemStub();
+    const galacticCoreSystem: GalacticCoreSystem = createGalacticCoreSystemStub();
+    const dreamPortalSystem: DreamPortalSystem = createDreamPortalSystemStub();
     const wishLanternSystem: WishLanternSystem = createWishLanternSystemStub();
     const weatherSystem: WeatherSystem = createWeatherSystemStub();
     const dancingJellyMossSystem: DancingJellyMossSystem = createDancingJellyMossSystemStub();
@@ -360,6 +369,8 @@ export function createGameSystems(deps: CreateGameSystemsDeps): GameSystems {
         stormGeodeSystem,
         crystalChimeManager,
         blackHoleSystem,
+        galacticCoreSystem,
+        dreamPortalSystem,
         wishLanternSystem,
         weatherSystem,
         dancingJellyMossSystem,

--- a/src/deferred_system_stubs.ts
+++ b/src/deferred_system_stubs.ts
@@ -1,4 +1,6 @@
 import type { BlackHoleSystem } from './black_hole';
+import type { GalacticCoreSystem } from './galactic_core';
+import type { DreamPortalSystem } from './dream_portal';
 import type { MeteorShowerSystem } from './meteor_shower';
 import type { PlanetaryHorizonSystem } from './planetary_horizon';
 import type { ReEntrySystem } from './reentry';
@@ -76,6 +78,32 @@ export function createBlackHoleSystemStub(): BlackHoleSystem {
         getPlayerPullForce: () => 0,
         handleProjectileInteractions: noop
     } as unknown as BlackHoleSystem;
+}
+
+export function createGalacticCoreSystemStub(): GalacticCoreSystem {
+    return {
+        active: false,
+        activate: noop,
+        deactivate: noop,
+        update: noop,
+        cleanup: noop,
+        getApproachIntensity: () => 0,
+        getStarfieldWarp: () => 0,
+        getProjectilePull: (_pos: unknown, _delta: number, out?: unknown) => out
+    } as unknown as GalacticCoreSystem;
+}
+
+export function createDreamPortalSystemStub(): DreamPortalSystem {
+    return {
+        spawnPortals: noop,
+        clear: noop,
+        update: noop,
+        cleanup: noop,
+        getScannables: () => [],
+        isActive: () => false,
+        isInRoom: () => false,
+        getRoomOriginY: () => 0
+    } as unknown as DreamPortalSystem;
 }
 
 export function createMeteorShowerSystemStub(): MeteorShowerSystem {

--- a/src/discovery_system.ts
+++ b/src/discovery_system.ts
@@ -23,6 +23,8 @@ export const SPECIES_NAMES: Record<string, string> = {
     iceNeedleCluster: 'Ice Needle Cluster',
     gravityAnchor: 'Gravity Anchor',
     gravLens: 'Grav-Lens',
+    dreamPortal: 'Dream Portal Door',
+    dreamLantern: 'Dream Lantern',
     derelictBuoy: 'Derelict Buoy',
     dataMonolith: 'Data Monolith',
     sporeCloud: 'Spore Cloud',

--- a/src/dream_portal.ts
+++ b/src/dream_portal.ts
@@ -1,0 +1,875 @@
+/**
+ * Dream Portal Doors — secret cloud doorways that drop the player into a short
+ * bonus "dream room" and hand them back to the main run afterwards.
+ *
+ * How the pocket works
+ * --------------------
+ * The dream room is not a second scene: it is a pocket of the same scene parked
+ * far above the playfield (`DREAM_ROOM_Y`). Entering teleports the player up
+ * there, parks `autoScrollSpeed` at 0 and raises the player's vertical clamp
+ * origin (`playerState.worldOriginY`), so the LevelManager stream, obstacle
+ * spawner and orb cleanup — all keyed off camera/player X — simply stop
+ * advancing. Exiting restores Y, the clamp origin and the scroll speed, so the
+ * main run resumes exactly where it paused. No level state is torn down, which
+ * is what keeps hub → continue → portal → exit → hub coherent.
+ *
+ * Rewards deliberately reuse existing systems (star orbs via `OrbManager`, cores
+ * via `SaveManager`, scan targets via `DiscoveryManager`) — no parallel economy.
+ *
+ * Deferred-loaded via `level_systems_loader` when a level declares
+ * `environments.dreamPortals`.
+ */
+
+import * as THREE from 'three';
+import { decorationBudget } from './decoration_budget';
+// Vertical offset of the bonus pocket — far enough that nothing in the main
+// playfield (|y| < ~60) can collide with, or be collided by, the room.
+import { DREAM_ROOM_Y } from './game_config';
+
+const DEFAULT_DURATION = 35;
+const DEFAULT_TOY_COUNT = 18;
+const DEFAULT_ORB_COUNT = 8;
+const DEFAULT_HAZARD_COUNT = 4;
+
+/** The player's X is frozen inside the pocket, so the room scrolls past them
+ *  instead — same side-scroller reading, zero drift in the main world. */
+const ROOM_SCROLL_SPEED = 7;
+
+const PROMPT_RADIUS = 26;
+const ENTER_RADIUS = 3.2;
+const TOY_COLLECT_RADIUS = 2.4;
+const HAZARD_RADIUS = 2.6;
+const EXIT_RING_RADIUS = 3.6;
+/** Exit ring stays inert briefly so arriving next to it can't bounce you out. */
+const EXIT_ARM_DELAY = 2.0;
+const TRANSITION_DURATION = 0.45;
+
+const TOY_SCORE = 60;
+const TOY_CORES = 2;
+const COMPLETION_CORES = 12;
+const COMPLETION_SCORE = 250;
+
+const THEME_COLORS = {
+    pastel: { sky: 0x2b1f4a, glow: 0xffc8f0, accent: 0x9fe8ff },
+    candy: { sky: 0x3a1730, glow: 0xffd1e8, accent: 0xffe9a8 },
+    aurora: { sky: 0x102a3a, glow: 0xa8ffe0, accent: 0xc8b4ff }
+} as const;
+
+export type DreamPortalTheme = keyof typeof THEME_COLORS;
+
+/** Level-config placement for a single portal door. */
+export type DreamPortalPlacement = {
+    /** World X of the door. */
+    x: number;
+    y?: number;
+    z?: number;
+    /** Seconds the player gets inside the room (defaults to 35). */
+    durationSeconds?: number;
+    toyCount?: number;
+    orbCount?: number;
+    hazardCount?: number;
+    theme?: DreamPortalTheme;
+};
+
+export type DreamPortalReward = {
+    cores: number;
+    score: number;
+    toysCollected: number;
+    toysTotal: number;
+    /** True when every toy in the room was gathered before the timer ran out. */
+    cleared: boolean;
+};
+
+/** Everything the system needs from the game context, injected by the caller. */
+export type DreamPortalCallbacks = {
+    getPlayer: () => THREE.Object3D | null;
+    /** Current auto-scroll speed (saved on enter, restored on exit). */
+    getScrollSpeed: () => number;
+    setScrollSpeed: (speed: number) => void;
+    /** Raises/lowers the player's vertical clamp origin (see `player_update`). */
+    setWorldOriginY: (y: number) => void;
+    /** Snap the camera after a teleport so it doesn't lerp across the gap. */
+    snapCamera: (y: number) => void;
+    /** Gentle push applied when the player bumps a dream jelly. */
+    nudgePlayer: (dx: number, dy: number) => void;
+    spawnOrb: (x: number, y: number, z: number) => void;
+    onEnter?: (portalPosition: THREE.Vector3) => void;
+    onExit?: (reward: DreamPortalReward, exitPosition: THREE.Vector3) => void;
+    onToyCollected?: (position: THREE.Vector3, score: number) => void;
+    onBumper?: (position: THREE.Vector3) => void;
+    onPromptShown?: (portalPosition: THREE.Vector3) => void;
+};
+
+type PortalInstance = {
+    group: THREE.Group;
+    ring: THREE.Mesh;
+    core: THREE.Mesh;
+    placement: Required<Omit<DreamPortalPlacement, 'theme'>> & { theme: DreamPortalTheme };
+    used: boolean;
+    phase: number;
+};
+
+type ToyState = {
+    base: THREE.Vector3;
+    phase: number;
+    spin: number;
+    scale: number;
+    collected: boolean;
+};
+
+type HazardState = {
+    mesh: THREE.Mesh;
+    base: THREE.Vector3;
+    phase: number;
+    amplitude: number;
+    cooldown: number;
+};
+
+type PortalState = 'idle' | 'entering' | 'inRoom' | 'exiting';
+
+/**
+ * The player never leaves z = 0, so every interaction test is measured in the
+ * XY plane (with a loose depth tolerance) — otherwise props parked at a
+ * decorative depth would be literally unreachable.
+ */
+function distanceXY(a: THREE.Vector3, b: THREE.Vector3): number {
+    return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+function makeGlowMaterial(hex: number, opacity: number): THREE.MeshBasicMaterial {
+    return new THREE.MeshBasicMaterial({
+        color: hex,
+        transparent: true,
+        opacity,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+        fog: false
+    });
+}
+
+export class DreamPortalSystem {
+    private readonly scene: THREE.Scene;
+    private readonly cb: DreamPortalCallbacks;
+
+    private portals: PortalInstance[] = [];
+    private state: PortalState = 'idle';
+
+    // --- room ---------------------------------------------------------------
+    /** Static pocket anchor (backdrop + exit ring). */
+    private roomGroup: THREE.Group | null = null;
+    /** Child of the anchor that slides left so props flow past the player. */
+    private roomScroll: THREE.Group | null = null;
+    private backdrop: THREE.Mesh | null = null;
+    private toyMesh: THREE.InstancedMesh | null = null;
+    private toys: ToyState[] = [];
+    private hazards: HazardState[] = [];
+    private exitRing: THREE.Mesh | null = null;
+    private heroLantern: THREE.Group | null = null;
+    private readonly dummy = new THREE.Object3D();
+
+    // --- run state ----------------------------------------------------------
+    private activePortal: PortalInstance | null = null;
+    private transitionTimer = 0;
+    private transitionDone = false;
+    private roomTimer = 0;
+    private roomDuration = DEFAULT_DURATION;
+    private roomElapsed = 0;
+    private toysCollected = 0;
+    private returnY = 0;
+    private savedScrollSpeed = 8;
+    /** True only between the two teleports, so teardown can't restore twice. */
+    private inPocket = false;
+
+    // --- ui -----------------------------------------------------------------
+    private promptEl: HTMLDivElement | null = null;
+    private hudEl: HTMLDivElement | null = null;
+    private hudBarEl: HTMLDivElement | null = null;
+    private hudLabelEl: HTMLDivElement | null = null;
+
+    constructor(scene: THREE.Scene, callbacks: DreamPortalCallbacks) {
+        this.scene = scene;
+        this.cb = callbacks;
+
+        decorationBudget.register('dream_portal', {
+            label: 'Dream portal doors',
+            category: 'effects',
+            maxActive: 3
+        });
+        decorationBudget.register('dream_room_props', {
+            label: 'Dream room props (instanced)',
+            category: 'effects',
+            maxActive: DEFAULT_TOY_COUNT + DEFAULT_HAZARD_COUNT + 2
+        });
+    }
+
+    // =========================================================================
+    // Portal doors
+    // =========================================================================
+
+    spawnPortals(placements: DreamPortalPlacement[]): void {
+        this.clear();
+        for (const placement of placements) {
+            if (!decorationBudget.reportSpawn('dream_portal')) break;
+            this.portals.push(this._createPortal(placement));
+        }
+    }
+
+    clear(): void {
+        if (this.state !== 'idle') this._forceExit();
+        for (const portal of this.portals) {
+            this.scene.remove(portal.group);
+            portal.group.traverse((child) => {
+                if (child instanceof THREE.Mesh) {
+                    child.geometry.dispose();
+                    const mat = child.material;
+                    if (Array.isArray(mat)) mat.forEach((m) => m.dispose());
+                    else mat.dispose();
+                }
+            });
+            decorationBudget.reportDestroy('dream_portal');
+        }
+        this.portals = [];
+        this._hidePrompt();
+    }
+
+    /** Scan targets: the doors themselves, plus the room's hero lantern. */
+    getScannables(): THREE.Object3D[] {
+        const targets: THREE.Object3D[] = this.portals.map((p) => p.group);
+        if (this.inPocket && this.heroLantern) targets.push(this.heroLantern);
+        return targets;
+    }
+
+    isActive(): boolean {
+        return this.state !== 'idle';
+    }
+
+    /** True while the player is physically inside the pocket — this is what
+     *  gates main-run logic (level progression, prefetch). */
+    isInRoom(): boolean {
+        return this.inPocket;
+    }
+
+    getRoomOriginY(): number {
+        return DREAM_ROOM_Y;
+    }
+
+    private _createPortal(placement: DreamPortalPlacement): PortalInstance {
+        const theme = placement.theme ?? 'pastel';
+        const colors = THEME_COLORS[theme];
+        const group = new THREE.Group();
+        group.position.set(placement.x, placement.y ?? 4, placement.z ?? -1);
+
+        // Doorway ring
+        const ring = new THREE.Mesh(
+            new THREE.TorusGeometry(3.0, 0.34, 10, 36),
+            makeGlowMaterial(colors.glow, 0.85)
+        );
+        group.add(ring);
+
+        // Shimmering "door" disc the player flies through
+        const core = new THREE.Mesh(
+            new THREE.CircleGeometry(2.75, 32),
+            makeGlowMaterial(colors.accent, 0.35)
+        );
+        core.position.z = -0.05;
+        group.add(core);
+
+        // A couple of orbiting sparkles so the door reads as magical at distance
+        for (let i = 0; i < 3; i++) {
+            const spark = new THREE.Mesh(
+                new THREE.SphereGeometry(0.22, 8, 6),
+                makeGlowMaterial(0xffffff, 0.9)
+            );
+            spark.userData.orbitAngle = (i / 3) * Math.PI * 2;
+            spark.name = 'dreamPortalSpark';
+            group.add(spark);
+        }
+
+        group.userData.type = 'dreamPortal';
+        group.userData.speciesId = 'dreamPortal';
+        this.scene.add(group);
+
+        return {
+            group,
+            ring,
+            core,
+            placement: {
+                x: placement.x,
+                y: placement.y ?? 4,
+                z: placement.z ?? -1,
+                durationSeconds: placement.durationSeconds ?? DEFAULT_DURATION,
+                toyCount: placement.toyCount ?? DEFAULT_TOY_COUNT,
+                orbCount: placement.orbCount ?? DEFAULT_ORB_COUNT,
+                hazardCount: placement.hazardCount ?? DEFAULT_HAZARD_COUNT,
+                theme
+            },
+            used: false,
+            phase: Math.random() * Math.PI * 2
+        };
+    }
+
+    // =========================================================================
+    // Frame update
+    // =========================================================================
+
+    update(delta: number, time: number): void {
+        const player = this.cb.getPlayer();
+        if (!player) return;
+
+        this._animatePortals(delta, time);
+
+        switch (this.state) {
+            case 'idle':
+                this._updateIdle(player.position);
+                break;
+            case 'entering':
+                this._updateTransition(delta, true);
+                break;
+            case 'inRoom':
+                this._updateRoom(delta, time, player.position);
+                break;
+            case 'exiting':
+                this._updateTransition(delta, false);
+                break;
+        }
+    }
+
+    private _animatePortals(delta: number, time: number): void {
+        for (const portal of this.portals) {
+            portal.phase += delta;
+            const pulse = 1 + Math.sin(time * 2.2 + portal.phase) * 0.06;
+            portal.ring.scale.setScalar(pulse);
+            portal.ring.rotation.z += delta * 0.35;
+            const coreMat = portal.core.material as THREE.MeshBasicMaterial;
+            coreMat.opacity = portal.used
+                ? 0.08
+                : 0.28 + Math.sin(time * 3.1 + portal.phase) * 0.1;
+
+            for (const child of portal.group.children) {
+                if (child.name !== 'dreamPortalSpark' || !(child instanceof THREE.Mesh)) continue;
+                const angle = (child.userData.orbitAngle ?? 0) + time * 1.4;
+                child.position.set(Math.cos(angle) * 3.1, Math.sin(angle) * 3.1, 0.2);
+                (child.material as THREE.MeshBasicMaterial).opacity = portal.used ? 0.15 : 0.9;
+            }
+        }
+    }
+
+    private _updateIdle(playerPos: THREE.Vector3): void {
+        let nearest: PortalInstance | null = null;
+        let nearestDist = Infinity;
+
+        for (const portal of this.portals) {
+            if (portal.used) continue;
+            const dist = distanceXY(portal.group.position, playerPos);
+            if (dist < nearestDist) {
+                nearest = portal;
+                nearestDist = dist;
+            }
+        }
+
+        if (!nearest || nearestDist > PROMPT_RADIUS) {
+            this._hidePrompt();
+            return;
+        }
+
+        this._showPrompt();
+        this.cb.onPromptShown?.(nearest.group.position);
+
+        if (nearestDist <= ENTER_RADIUS) {
+            this._beginEnter(nearest);
+        }
+    }
+
+    // =========================================================================
+    // Enter / exit
+    // =========================================================================
+
+    private _beginEnter(portal: PortalInstance): void {
+        this.activePortal = portal;
+        portal.used = true;
+        this.state = 'entering';
+        this.transitionTimer = 0;
+        this.transitionDone = false;
+        this._hidePrompt();
+        this.cb.onEnter?.(portal.group.position.clone());
+    }
+
+    private _updateTransition(delta: number, entering: boolean): void {
+        this.transitionTimer += delta;
+
+        // Teleport at the midpoint so the flash covers the cut.
+        if (!this.transitionDone && this.transitionTimer >= TRANSITION_DURATION * 0.5) {
+            this.transitionDone = true;
+            if (entering) this._enterRoom();
+            else this._leaveRoom();
+        }
+
+        if (this.transitionTimer >= TRANSITION_DURATION) {
+            this.state = entering ? 'inRoom' : 'idle';
+            this.transitionTimer = 0;
+            this.transitionDone = false;
+            if (!entering) this.activePortal = null;
+        }
+    }
+
+    private _enterRoom(): void {
+        const player = this.cb.getPlayer();
+        const portal = this.activePortal;
+        if (!player || !portal) return;
+
+        this.returnY = player.position.y;
+        this.savedScrollSpeed = this.cb.getScrollSpeed();
+
+        const room = this._ensureRoom();
+        room.position.set(player.position.x, DREAM_ROOM_Y, 0);
+        room.visible = true;
+
+        this._layoutRoom(portal);
+
+        player.position.y = DREAM_ROOM_Y;
+        this.cb.setWorldOriginY(DREAM_ROOM_Y);
+        this.cb.setScrollSpeed(0);
+        this.cb.snapCamera(DREAM_ROOM_Y);
+
+        this.roomDuration = portal.placement.durationSeconds;
+        this.roomTimer = this.roomDuration;
+        this.roomElapsed = 0;
+        this.toysCollected = 0;
+
+        // Star orbs come from the real OrbManager — same economy as the main
+        // run. The player's X is frozen here, so the fountain is a vertical
+        // column they climb and dive through.
+        const orbCount = portal.placement.orbCount;
+        for (let i = 0; i < orbCount; i++) {
+            const t = orbCount > 1 ? i / (orbCount - 1) : 0.5;
+            this.cb.spawnOrb(
+                player.position.x + Math.sin(t * Math.PI * 3) * 1.2,
+                DREAM_ROOM_Y - 8 + t * 19,
+                0
+            );
+        }
+
+        this.inPocket = true;
+        this._showRoomHud();
+    }
+
+    private _leaveRoom(): void {
+        if (!this.inPocket) return;
+        this.inPocket = false;
+        const player = this.cb.getPlayer();
+        if (player) {
+            player.position.y = THREE.MathUtils.clamp(this.returnY, -10, 15);
+            this.cb.snapCamera(player.position.y);
+        }
+        this.cb.setWorldOriginY(0);
+        this.cb.setScrollSpeed(this.savedScrollSpeed);
+        if (this.roomGroup) this.roomGroup.visible = false;
+        this._hideRoomHud();
+    }
+
+    /** Emergency teardown (level change / cleanup while the room is open). */
+    private _forceExit(): void {
+        this._leaveRoom();
+        this.state = 'idle';
+        this.activePortal = null;
+        this.transitionTimer = 0;
+        this.transitionDone = false;
+    }
+
+    private _beginExit(): void {
+        if (this.state !== 'inRoom') return;
+        this.state = 'exiting';
+        this.transitionTimer = 0;
+        this.transitionDone = false;
+
+        const toysTotal = this.toys.length;
+        const cleared = toysTotal > 0 && this.toysCollected >= toysTotal;
+        const reward: DreamPortalReward = {
+            cores: COMPLETION_CORES + this.toysCollected * TOY_CORES + (cleared ? 10 : 0),
+            score: COMPLETION_SCORE + (cleared ? 300 : 0),
+            toysCollected: this.toysCollected,
+            toysTotal,
+            cleared
+        };
+        const exitPos = this.cb.getPlayer()?.position.clone() ?? new THREE.Vector3();
+        this.cb.onExit?.(reward, exitPos);
+    }
+
+    // =========================================================================
+    // Bonus room
+    // =========================================================================
+
+    private _ensureRoom(): THREE.Group {
+        if (this.roomGroup) return this.roomGroup;
+
+        const room = new THREE.Group();
+        room.visible = false;
+        const scroll = new THREE.Group();
+        room.add(scroll);
+
+        // Soft dome so the pocket doesn't read as empty space.
+        this.backdrop = new THREE.Mesh(
+            new THREE.SphereGeometry(200, 24, 16),
+            new THREE.MeshBasicMaterial({
+                color: THEME_COLORS.pastel.sky,
+                side: THREE.BackSide,
+                fog: false,
+                depthWrite: false
+            })
+        );
+        room.add(this.backdrop);
+
+        // Floating toys — one InstancedMesh for the whole set.
+        const toyGeo = new THREE.IcosahedronGeometry(0.95, 0);
+        const toyMat = new THREE.MeshBasicMaterial({ fog: false });
+        this.toyMesh = new THREE.InstancedMesh(toyGeo, toyMat, DEFAULT_TOY_COUNT);
+        this.toyMesh.frustumCulled = false;
+        this.toyMesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+        scroll.add(this.toyMesh);
+
+        // Gentle hazards: drifting dream jellies that bump, never damage.
+        const hazardGeo = new THREE.SphereGeometry(1.6, 12, 10);
+        for (let i = 0; i < DEFAULT_HAZARD_COUNT; i++) {
+            const mesh = new THREE.Mesh(hazardGeo, makeGlowMaterial(0xaa88ff, 0.45));
+            mesh.visible = false;
+            scroll.add(mesh);
+            this.hazards.push({
+                mesh,
+                base: new THREE.Vector3(),
+                phase: Math.random() * Math.PI * 2,
+                amplitude: 3 + Math.random() * 3,
+                cooldown: 0
+            });
+        }
+
+        // Exit ring — pinned above the player (the pocket's "climb out" door),
+        // so it is always reachable and can never strand the player.
+        this.exitRing = new THREE.Mesh(
+            new THREE.TorusGeometry(3.4, 0.3, 10, 32),
+            makeGlowMaterial(0x9fffd0, 0.9)
+        );
+        this.exitRing.position.set(0, 13, 0);
+        room.add(this.exitRing);
+
+        // Hero lantern — the room's scannable, wired into DiscoveryManager.
+        const lantern = new THREE.Group();
+        const lanternBody = new THREE.Mesh(
+            new THREE.OctahedronGeometry(1.4, 0),
+            makeGlowMaterial(0xffe9a8, 0.85)
+        );
+        const lanternHalo = new THREE.Mesh(
+            new THREE.SphereGeometry(2.4, 12, 10),
+            makeGlowMaterial(0xffd1e8, 0.22)
+        );
+        lantern.add(lanternBody, lanternHalo);
+        lantern.userData.type = 'dreamLantern';
+        lantern.userData.speciesId = 'dreamLantern';
+        scroll.add(lantern);
+        this.heroLantern = lantern;
+
+        this.scene.add(room);
+        this.roomGroup = room;
+        this.roomScroll = scroll;
+        return room;
+    }
+
+    /** Re-seed toy / hazard / exit placement for this visit. */
+    private _layoutRoom(portal: PortalInstance): void {
+        const colors = THEME_COLORS[portal.placement.theme];
+        if (this.backdrop) {
+            (this.backdrop.material as THREE.MeshBasicMaterial).color.setHex(colors.sky);
+        }
+        if (this.roomScroll) this.roomScroll.position.set(0, 0, 0);
+
+        // Props are laid out along the distance the room will scroll, so they
+        // arrive steadily across the visit rather than all at once.
+        const span = ROOM_SCROLL_SPEED * portal.placement.durationSeconds;
+        const toyCount = Math.min(portal.placement.toyCount, DEFAULT_TOY_COUNT);
+        this.toys = [];
+        if (this.toyMesh) {
+            this.toyMesh.count = toyCount;
+            const toyColor = new THREE.Color();
+            for (let i = 0; i < toyCount; i++) {
+                const t = i / Math.max(1, toyCount - 1);
+                const base = new THREE.Vector3(
+                    14 + t * (span - 28) + (Math.random() - 0.5) * 6,
+                    (Math.random() - 0.5) * 17,
+                    (Math.random() - 0.5) * 4
+                );
+                this.toys.push({
+                    base,
+                    phase: Math.random() * Math.PI * 2,
+                    spin: 0.4 + Math.random() * 0.8,
+                    scale: 0.8 + Math.random() * 0.5,
+                    collected: false
+                });
+                toyColor.setHSL((t * 0.8 + Math.random() * 0.1) % 1, 0.75, 0.65);
+                this.toyMesh.setColorAt(i, toyColor);
+            }
+            if (this.toyMesh.instanceColor) this.toyMesh.instanceColor.needsUpdate = true;
+        }
+
+        const hazardCount = Math.min(portal.placement.hazardCount, this.hazards.length);
+        this.hazards.forEach((hazard, i) => {
+            const enabled = i < hazardCount;
+            hazard.mesh.visible = enabled;
+            if (!enabled) return;
+            hazard.base.set(
+                30 + ((i + 0.5) / Math.max(1, hazardCount)) * (span - 60),
+                (Math.random() - 0.5) * 12,
+                (Math.random() - 0.5) * 3
+            );
+            hazard.phase = Math.random() * Math.PI * 2;
+            hazard.cooldown = 0;
+            (hazard.mesh.material as THREE.MeshBasicMaterial).color.setHex(colors.accent);
+        });
+
+        if (this.heroLantern) this.heroLantern.position.set(span * 0.45, 8, -2);
+
+        decorationBudget.syncCount('dream_room_props', toyCount + hazardCount + 2);
+    }
+
+    private _updateRoom(delta: number, time: number, playerPos: THREE.Vector3): void {
+        const room = this.roomGroup;
+        const scroll = this.roomScroll;
+        if (!room || !scroll) return;
+
+        this.roomElapsed += delta;
+        this.roomTimer = Math.max(0, this.roomTimer - delta);
+
+        // Slide the prop layer past the (X-frozen) player.
+        scroll.position.x -= ROOM_SCROLL_SPEED * delta;
+        const scrollOrigin = room.position.clone().add(scroll.position);
+
+        this._updateToys(delta, time, playerPos, scrollOrigin);
+        this._updateHazards(delta, time, playerPos, scrollOrigin);
+
+        if (this.heroLantern) {
+            this.heroLantern.rotation.y += delta * 0.6;
+            this.heroLantern.position.y = 8 + Math.sin(time * 1.2) * 0.8;
+        }
+
+        // Exit ring: pulses, arms after a short delay, then flies you home.
+        if (this.exitRing) {
+            const armed = this.roomElapsed >= EXIT_ARM_DELAY;
+            const pulse = 1 + Math.sin(time * 3) * 0.08;
+            this.exitRing.scale.setScalar(pulse);
+            this.exitRing.rotation.y += delta * 0.8;
+            (this.exitRing.material as THREE.MeshBasicMaterial).opacity = armed ? 0.9 : 0.3;
+
+            if (armed) {
+                const ringWorld = this.exitRing.position.clone().add(room.position);
+                if (distanceXY(ringWorld, playerPos) <= EXIT_RING_RADIUS) {
+                    this._beginExit();
+                    return;
+                }
+            }
+        }
+
+        this._updateRoomHud();
+
+        if (this.roomTimer <= 0) {
+            this._beginExit();
+        }
+    }
+
+    private _updateToys(
+        delta: number,
+        time: number,
+        playerPos: THREE.Vector3,
+        roomOrigin: THREE.Vector3
+    ): void {
+        if (!this.toyMesh) return;
+
+        for (let i = 0; i < this.toys.length; i++) {
+            const toy = this.toys[i];
+            if (toy.collected) continue;
+
+            toy.phase += delta;
+            const bob = Math.sin(time * 1.4 + toy.phase) * 0.7;
+            const localX = toy.base.x;
+            const localY = toy.base.y + bob;
+            const localZ = toy.base.z;
+
+            const worldX = roomOrigin.x + localX;
+            const worldY = roomOrigin.y + localY;
+            const worldZ = roomOrigin.z + localZ;
+
+            const dist = Math.hypot(worldX - playerPos.x, worldY - playerPos.y);
+            if (dist <= TOY_COLLECT_RADIUS) {
+                toy.collected = true;
+                this.toysCollected++;
+                this.dummy.position.set(localX, localY, localZ);
+                this.dummy.scale.setScalar(0);
+                this.dummy.rotation.set(0, 0, 0);
+                this.dummy.updateMatrix();
+                this.toyMesh.setMatrixAt(i, this.dummy.matrix);
+                this.cb.onToyCollected?.(new THREE.Vector3(worldX, worldY, worldZ), TOY_SCORE);
+                continue;
+            }
+
+            this.dummy.position.set(localX, localY, localZ);
+            this.dummy.rotation.set(toy.phase * toy.spin, toy.phase * toy.spin * 0.7, 0);
+            this.dummy.scale.setScalar(toy.scale);
+            this.dummy.updateMatrix();
+            this.toyMesh.setMatrixAt(i, this.dummy.matrix);
+        }
+        this.toyMesh.instanceMatrix.needsUpdate = true;
+    }
+
+    private _updateHazards(
+        delta: number,
+        time: number,
+        playerPos: THREE.Vector3,
+        roomOrigin: THREE.Vector3
+    ): void {
+        for (const hazard of this.hazards) {
+            if (!hazard.mesh.visible) continue;
+
+            hazard.phase += delta * 0.6;
+            hazard.mesh.position.set(
+                hazard.base.x + Math.sin(hazard.phase) * 2.5,
+                hazard.base.y + Math.cos(hazard.phase * 0.8) * hazard.amplitude,
+                hazard.base.z
+            );
+            const wobble = 1 + Math.sin(time * 2 + hazard.phase) * 0.08;
+            hazard.mesh.scale.set(wobble, 1 / wobble, wobble);
+
+            if (hazard.cooldown > 0) {
+                hazard.cooldown = Math.max(0, hazard.cooldown - delta);
+                continue;
+            }
+
+            const worldPos = hazard.mesh.position.clone().add(roomOrigin);
+            const dx = playerPos.x - worldPos.x;
+            const dy = playerPos.y - worldPos.y;
+            const dist = Math.hypot(dx, dy);
+            if (dist <= HAZARD_RADIUS && dist > 0.001) {
+                // Gentle bump: pushes the player away, never costs health.
+                hazard.cooldown = 0.6;
+                this.cb.nudgePlayer((dx / dist) * 2.0, (dy / dist) * 7.0);
+                this.cb.onBumper?.(worldPos);
+            }
+        }
+    }
+
+    // =========================================================================
+    // UI (prompt + room timer). Touch-friendly: informational only, the player
+    // enters and exits by flying, so nothing here needs to be tappable.
+    // =========================================================================
+
+    private _showPrompt(): void {
+        if (this.promptEl) return;
+        const el = document.createElement('div');
+        el.id = 'dream-portal-prompt';
+        el.textContent = '✨ Dream Door — fly through it!';
+        el.style.cssText = `
+            position: fixed;
+            left: 50%;
+            bottom: 18%;
+            transform: translateX(-50%);
+            padding: 10px 20px;
+            border-radius: 22px;
+            background: rgba(40, 20, 70, 0.72);
+            border: 2px solid rgba(255, 200, 240, 0.85);
+            color: #ffe9ff;
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            font-size: clamp(14px, 3.4vw, 20px);
+            font-weight: bold;
+            text-shadow: 0 0 10px rgba(0, 0, 0, 0.6);
+            pointer-events: none;
+            user-select: none;
+            z-index: 600;
+        `;
+        document.body.appendChild(el);
+        this.promptEl = el;
+    }
+
+    private _hidePrompt(): void {
+        this.promptEl?.remove();
+        this.promptEl = null;
+    }
+
+    private _showRoomHud(): void {
+        if (this.hudEl) return;
+
+        const el = document.createElement('div');
+        el.id = 'dream-room-hud';
+        el.style.cssText = `
+            position: fixed;
+            left: 50%;
+            top: 12%;
+            transform: translateX(-50%);
+            width: min(340px, 70vw);
+            padding: 8px 14px;
+            border-radius: 16px;
+            background: rgba(30, 16, 55, 0.68);
+            border: 2px solid rgba(200, 180, 255, 0.7);
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            color: #f4e8ff;
+            pointer-events: none;
+            user-select: none;
+            z-index: 600;
+        `;
+
+        const label = document.createElement('div');
+        label.style.cssText = 'font-size: clamp(12px, 3vw, 16px); font-weight: bold; margin-bottom: 6px; text-align: center;';
+        el.appendChild(label);
+
+        const track = document.createElement('div');
+        track.style.cssText = 'height: 8px; border-radius: 4px; background: rgba(255,255,255,0.18); overflow: hidden;';
+        const bar = document.createElement('div');
+        bar.style.cssText = 'height: 100%; width: 100%; border-radius: 4px; background: linear-gradient(90deg, #9fe8ff, #ffc8f0);';
+        track.appendChild(bar);
+        el.appendChild(track);
+
+        document.body.appendChild(el);
+        this.hudEl = el;
+        this.hudBarEl = bar;
+        this.hudLabelEl = label;
+        this._updateRoomHud();
+    }
+
+    private _updateRoomHud(): void {
+        if (!this.hudEl || !this.hudBarEl || !this.hudLabelEl) return;
+        const pct = this.roomDuration > 0 ? (this.roomTimer / this.roomDuration) * 100 : 0;
+        this.hudBarEl.style.width = `${Math.max(0, Math.min(100, pct)).toFixed(1)}%`;
+        this.hudLabelEl.textContent =
+            `💤 Dream Room — toys ${this.toysCollected}/${this.toys.length} · ${Math.ceil(this.roomTimer)}s · ⬆ ring to leave`;
+    }
+
+    private _hideRoomHud(): void {
+        this.hudEl?.remove();
+        this.hudEl = null;
+        this.hudBarEl = null;
+        this.hudLabelEl = null;
+    }
+
+    // =========================================================================
+
+    cleanup(): void {
+        this.clear();
+        this._hideRoomHud();
+
+        if (this.roomGroup) {
+            this.scene.remove(this.roomGroup);
+            this.roomGroup.traverse((child) => {
+                if (child instanceof THREE.Mesh) {
+                    child.geometry.dispose();
+                    const mat = child.material;
+                    if (Array.isArray(mat)) mat.forEach((m) => m.dispose());
+                    else mat.dispose();
+                }
+            });
+            this.roomGroup = null;
+            this.roomScroll = null;
+            this.backdrop = null;
+            this.toyMesh = null;
+            this.exitRing = null;
+            this.heroLantern = null;
+            this.hazards = [];
+            this.toys = [];
+            decorationBudget.syncCount('dream_room_props', 0);
+        }
+    }
+}

--- a/src/galactic_core.ts
+++ b/src/galactic_core.ts
@@ -1,0 +1,414 @@
+/**
+ * Galactic Core / Accretion Disk — finale background set-piece (future-plan §10).
+ *
+ * A massive, slowly spinning singularity parked deep in the background with a
+ * glowing accretion disk, a photon halo, and a swirl veil that fakes mild
+ * gravitational lensing. Everything is additive + unlit and lives on a single
+ * parallax group, so the cost is a handful of draw calls regardless of level
+ * length.
+ *
+ * Gameplay hooks are deliberately small (this is a backdrop, not a boss):
+ *  - `getProjectilePull()` bends plasma bolts that fly near the core.
+ *  - `getStarfieldWarp()` reports how strongly parallax layers should smear.
+ *  - `getApproachIntensity()` ramps 0→1 as the player closes in, so the loop can
+ *    swell audio / juice without duplicating the distance math.
+ *
+ * Deferred-loaded via `level_systems_loader` when a level declares
+ * `environments.galacticCore`, so levels 1–5 never pay for the chunk.
+ */
+
+import * as THREE from 'three';
+import { MeshBasicNodeMaterial } from 'three/webgpu';
+import {
+    time,
+    uv,
+    vec2,
+    vec3,
+    vec4,
+    color,
+    uniform,
+    mix,
+    sin,
+    cos,
+    float,
+    length,
+    smoothstep,
+    positionLocal
+} from 'three/tsl';
+import { decorationBudget } from './decoration_budget';
+
+/**
+ * Level-config payload (see `LevelEnvironments.galacticCore`).
+ *
+ * The core is a camera-relative parallax backdrop, not a world-anchored prop:
+ * it sits `offsetX` ahead of the camera at depth `z`, and the approach ramp
+ * (driven by the player's world X between `approachStartX` and `approachEndX`)
+ * walks both values from their "start" to their "end" pair. That is what makes
+ * the finale read as a slow fall toward something enormous.
+ */
+export type GalacticCoreConfig = {
+    enabled: boolean;
+    /** World X where the approach begins (ramp = 0). */
+    approachStartX?: number;
+    /** World X where the approach completes (ramp = 1). */
+    approachEndX?: number;
+    /** Camera-relative X offset at ramp 0 / ramp 1. */
+    startOffsetX?: number;
+    endOffsetX?: number;
+    /** Depth at ramp 0 / ramp 1 (more negative = further away). */
+    startZ?: number;
+    endZ?: number;
+    baseY?: number;
+    /** Uniform scale on the whole set-piece (1 = ~150 unit disk radius). */
+    scale?: number;
+    /** Disk brightness multiplier (0.6–1.6 is the readable band). */
+    intensity?: number;
+    /** Inner disk colour (hot side). */
+    innerColor?: number;
+    /** Outer disk colour (cool side). */
+    outerColor?: number;
+};
+
+const EVENT_HORIZON_RADIUS = 26;
+const DISK_INNER_RADIUS = 34;
+const DISK_OUTER_RADIUS = 150;
+const HALO_OUTER_RADIUS = 44;
+const VEIL_RADIUS = 190;
+/** Projectiles only feel the core inside this radius (gameplay toy, not GR). */
+const PROJECTILE_PULL_RADIUS = 240;
+const PROJECTILE_PULL_STRENGTH = 5.5;
+
+function useLiteMaterials(): boolean {
+    return typeof window !== 'undefined' && window.usingWebGL === true;
+}
+
+/**
+ * Accretion disk: layered radial + angular noise scrolling against the disk's
+ * own rotation, masked to a ring and tinted from hot core to cool rim.
+ */
+function createDiskMaterial(
+    intensityUniform: ReturnType<typeof uniform>,
+    innerColor: number,
+    outerColor: number
+): THREE.Material {
+    if (useLiteMaterials()) {
+        // WebGL2 fallback: no node graph, just a soft additive ring.
+        return new THREE.MeshBasicMaterial({
+            color: innerColor,
+            transparent: true,
+            opacity: 0.5,
+            blending: THREE.AdditiveBlending,
+            side: THREE.DoubleSide,
+            depthWrite: false
+        });
+    }
+
+    const mat = new MeshBasicNodeMaterial({
+        transparent: true,
+        blending: THREE.AdditiveBlending,
+        side: THREE.DoubleSide,
+        depthWrite: false
+    });
+
+    const pos = positionLocal.xy;
+    const dist = length(pos);
+    const normalizedDist = dist
+        .sub(DISK_INNER_RADIUS)
+        .div(DISK_OUTER_RADIUS - DISK_INNER_RADIUS);
+
+    // Counter-rotate the sampling frame so the billow reads as orbital motion.
+    const spin = time.mul(0.18);
+    const c = cos(spin);
+    const s = sin(spin);
+    const rotated = vec2(
+        pos.x.mul(c).sub(pos.y.mul(s)),
+        pos.x.mul(s).add(pos.y.mul(c))
+    );
+    const angle = rotated.y.atan2(rotated.x);
+
+    // Three octaves of cheap sine noise — enough billow without a texture.
+    const band1 = sin(normalizedDist.mul(14.0).sub(time.mul(1.6)));
+    const band2 = sin(normalizedDist.mul(38.0).add(time.mul(2.4)));
+    const swirl1 = sin(angle.mul(7.0).add(normalizedDist.mul(9.0)).sub(time.mul(1.1)));
+    const swirl2 = cos(angle.mul(15.0).sub(normalizedDist.mul(4.0)).add(time.mul(1.9)));
+    const billow = band1
+        .mul(0.35)
+        .add(band2.mul(0.2))
+        .add(swirl1.mul(0.3))
+        .add(swirl2.mul(0.15))
+        .mul(0.5)
+        .add(0.55);
+
+    const innerFade = smoothstep(0.0, 0.08, normalizedDist);
+    const outerFade = smoothstep(0.72, 1.0, normalizedDist).oneMinus();
+    const diskMask = innerFade.mul(outerFade);
+
+    const hot = color(0xffffff);
+    const mid = color(innerColor);
+    const rim = color(outerColor);
+    const tint = mix(
+        mix(hot, mid, smoothstep(0.0, 0.35, normalizedDist)),
+        rim,
+        smoothstep(0.35, 0.85, normalizedDist)
+    );
+
+    const intensity = float(0.55).add(intensityUniform.mul(0.9));
+    mat.colorNode = vec4(
+        tint.mul(float(1.2).add(billow.mul(0.8))).mul(intensity),
+        billow.mul(diskMask).pow(1.4).mul(intensity)
+    );
+
+    return mat;
+}
+
+/** Photon halo hugging the event horizon; brightens on approach. */
+function createHaloMaterial(
+    intensityUniform: ReturnType<typeof uniform>,
+    tintColor: number
+): THREE.Material {
+    if (useLiteMaterials()) {
+        return new THREE.MeshBasicMaterial({
+            color: tintColor,
+            transparent: true,
+            opacity: 0.45,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false
+        });
+    }
+
+    const mat = new MeshBasicNodeMaterial({
+        transparent: true,
+        blending: THREE.AdditiveBlending,
+        side: THREE.FrontSide,
+        depthWrite: false
+    });
+
+    const dist = length(positionLocal.xy);
+    const normalizedDist = dist
+        .sub(EVENT_HORIZON_RADIUS)
+        .div(HALO_OUTER_RADIUS - EVENT_HORIZON_RADIUS);
+
+    const ring = smoothstep(0.0, 0.12, normalizedDist)
+        .mul(smoothstep(0.12, 1.0, normalizedDist).oneMinus());
+    const shimmer = sin(time.mul(1.4)).mul(0.12).add(1.0);
+    const alpha = ring.mul(0.85).mul(shimmer).mul(float(0.5).add(intensityUniform.mul(0.8)));
+
+    mat.colorNode = vec4(color(tintColor), alpha);
+    return mat;
+}
+
+/**
+ * Swirl veil: a wide, very faint disc whose UVs spiral inward. Read against the
+ * starfield it approximates lensing smear without any postprocessing pass.
+ */
+function createVeilMaterial(intensityUniform: ReturnType<typeof uniform>): THREE.Material {
+    if (useLiteMaterials()) {
+        return new THREE.MeshBasicMaterial({
+            color: 0x223355,
+            transparent: true,
+            opacity: 0.12,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false
+        });
+    }
+
+    const mat = new MeshBasicNodeMaterial({
+        transparent: true,
+        blending: THREE.AdditiveBlending,
+        side: THREE.FrontSide,
+        depthWrite: false
+    });
+
+    const centered = uv().sub(0.5);
+    const r = length(centered).mul(2.0); // 0 at centre, 1 at rim
+    const theta = centered.y.atan2(centered.x);
+
+    // Spiral arms tighten toward the horizon — the "bend" cue.
+    const spiral = sin(theta.mul(2.0).add(r.mul(-9.0)).add(time.mul(0.5)));
+    const falloff = smoothstep(1.0, 0.15, r).mul(smoothstep(0.05, 0.2, r));
+    const alpha = spiral
+        .mul(0.5)
+        .add(0.5)
+        .mul(falloff)
+        .mul(0.28)
+        .mul(float(0.35).add(intensityUniform.mul(0.65)));
+
+    mat.colorNode = vec4(mix(color(0x6688ff), color(0xffccee), r), alpha);
+    return mat;
+}
+
+export class GalacticCoreSystem {
+    readonly scene: THREE.Scene;
+    active = false;
+
+    readonly group: THREE.Group;
+    private readonly eventHorizon: THREE.Mesh;
+    private readonly disk: THREE.Mesh;
+    private readonly halo: THREE.Mesh;
+    private readonly veil: THREE.Mesh;
+
+    private approachStartX = 4200;
+    private approachEndX = 5200;
+    private startOffsetX = 320;
+    private endOffsetX = 95;
+    private startZ = -1150;
+    private endZ = -470;
+    private baseY = 90;
+    private intensityScale = 1.0;
+
+    private readonly intensityUniform = uniform(0.0);
+    private approach = 0;
+    private elapsed = 0;
+
+    constructor(scene: THREE.Scene, config?: GalacticCoreConfig) {
+        this.scene = scene;
+        this.group = new THREE.Group();
+        this.group.renderOrder = -20;
+
+        const innerColor = config?.innerColor ?? 0xffb066;
+        const outerColor = config?.outerColor ?? 0x7733aa;
+
+        this.eventHorizon = new THREE.Mesh(
+            new THREE.SphereGeometry(EVENT_HORIZON_RADIUS, useLiteMaterials() ? 20 : 40, useLiteMaterials() ? 16 : 32),
+            new THREE.MeshBasicMaterial({ color: 0x000000, fog: false })
+        );
+
+        this.disk = new THREE.Mesh(
+            new THREE.RingGeometry(
+                DISK_INNER_RADIUS,
+                DISK_OUTER_RADIUS,
+                useLiteMaterials() ? 48 : 96,
+                1
+            ),
+            createDiskMaterial(this.intensityUniform, innerColor, outerColor)
+        );
+        this.disk.rotation.x = -Math.PI * 0.42;
+        this.disk.rotation.y = Math.PI * 0.08;
+        this.disk.position.z = -2;
+
+        this.halo = new THREE.Mesh(
+            new THREE.RingGeometry(EVENT_HORIZON_RADIUS, HALO_OUTER_RADIUS, useLiteMaterials() ? 32 : 64),
+            createHaloMaterial(this.intensityUniform, innerColor)
+        );
+        this.halo.position.z = 1;
+
+        this.veil = new THREE.Mesh(
+            new THREE.PlaneGeometry(VEIL_RADIUS * 2, VEIL_RADIUS * 2),
+            createVeilMaterial(this.intensityUniform)
+        );
+        this.veil.position.z = -4;
+
+        this.group.add(this.veil, this.disk, this.eventHorizon, this.halo);
+        this.group.visible = false;
+        this.group.frustumCulled = false;
+        scene.add(this.group);
+
+        decorationBudget.register('galactic_core', {
+            label: 'Galactic core (background)',
+            category: 'background3d',
+            maxActive: 1
+        });
+    }
+
+    activate(config?: GalacticCoreConfig): void {
+        if (config?.approachStartX !== undefined) this.approachStartX = config.approachStartX;
+        if (config?.approachEndX !== undefined) this.approachEndX = config.approachEndX;
+        if (config?.startOffsetX !== undefined) this.startOffsetX = config.startOffsetX;
+        if (config?.endOffsetX !== undefined) this.endOffsetX = config.endOffsetX;
+        if (config?.startZ !== undefined) this.startZ = config.startZ;
+        if (config?.endZ !== undefined) this.endZ = config.endZ;
+        if (config?.baseY !== undefined) this.baseY = config.baseY;
+        if (config?.intensity !== undefined) this.intensityScale = config.intensity;
+        if (config?.scale !== undefined) this.group.scale.setScalar(config.scale);
+
+        if (this.active) return;
+        this.active = true;
+        this.group.visible = true;
+        decorationBudget.syncCount('galactic_core', 1);
+    }
+
+    deactivate(): void {
+        if (!this.active) return;
+        this.active = false;
+        this.group.visible = false;
+        this.approach = 0;
+        this.intensityUniform.value = 0;
+        decorationBudget.syncCount('galactic_core', 0);
+    }
+
+    /** 0 (far away) → 1 (right on top of the core). */
+    getApproachIntensity(): number {
+        return this.approach;
+    }
+
+    /** How hard parallax layers should smear toward the core (0–1). */
+    getStarfieldWarp(): number {
+        return this.active ? this.approach * 0.6 : 0;
+    }
+
+    getCorePosition(): THREE.Vector3 {
+        return this.group.position;
+    }
+
+    /**
+     * Mild lensing for plasma bolts flying near the core: a perpendicular-ish
+     * nudge toward the singularity that scales with proximity. Returns the
+     * velocity delta for this frame (caller adds it).
+     */
+    getProjectilePull(projectilePos: THREE.Vector3, delta: number, out = new THREE.Vector3()): THREE.Vector3 {
+        out.set(0, 0, 0);
+        if (!this.active) return out;
+
+        const core = this.group.position;
+        const dx = core.x - projectilePos.x;
+        const dy = core.y - projectilePos.y;
+        const dist = Math.hypot(dx, dy);
+        if (dist > PROJECTILE_PULL_RADIUS || dist < 1) return out;
+
+        const falloff = 1 - dist / PROJECTILE_PULL_RADIUS;
+        const strength = PROJECTILE_PULL_STRENGTH * falloff * falloff * delta;
+        out.set((dx / dist) * strength, (dy / dist) * strength, 0);
+        return out;
+    }
+
+    update(delta: number, cameraX: number, playerPos?: THREE.Vector3): void {
+        if (!this.active) return;
+
+        this.elapsed += delta;
+
+        const referenceX = playerPos?.x ?? cameraX;
+        const span = Math.max(1, this.approachEndX - this.approachStartX);
+        const raw = THREE.MathUtils.clamp((referenceX - this.approachStartX) / span, 0, 1);
+        // Ease-in so the swell lands on the final stretch instead of creeping.
+        this.approach = raw * raw;
+        this.intensityUniform.value = this.approach * this.intensityScale;
+
+        // Camera-relative parallax: the core drifts in and forward as the ramp
+        // climbs, so it grows on screen without ever entering the playfield.
+        const offsetX = THREE.MathUtils.lerp(this.startOffsetX, this.endOffsetX, this.approach);
+        const z = THREE.MathUtils.lerp(this.startZ, this.endZ, this.approach);
+        this.group.position.set(
+            cameraX + offsetX,
+            this.baseY + Math.sin(this.elapsed * 0.08) * 4,
+            z
+        );
+
+        // Lazy tumble on the disk so the silhouette keeps changing.
+        this.disk.rotation.z = this.elapsed * 0.05;
+        this.disk.rotation.x = -Math.PI * 0.42 + Math.sin(this.elapsed * 0.12) * 0.04;
+        this.veil.rotation.z = -this.elapsed * 0.02;
+    }
+
+    cleanup(): void {
+        this.scene.remove(this.group);
+        this.group.traverse((child) => {
+            if (child instanceof THREE.Mesh) {
+                child.geometry.dispose();
+                const mat = child.material;
+                if (Array.isArray(mat)) mat.forEach((m) => m.dispose());
+                else mat.dispose();
+            }
+        });
+        decorationBudget.syncCount('galactic_core', 0);
+    }
+}

--- a/src/game_config.ts
+++ b/src/game_config.ts
@@ -54,8 +54,21 @@ export const playerState = {
     gravLensBoostMultiplier: 1,
     // Artifact hacking (Derelict Buoy extraction): shields drop, thruster to 30%.
     hackExtractionTimer: 0,
-    hackThrusterEfficiency: 1
+    hackThrusterEfficiency: 1,
+    /**
+     * Vertical origin the player's soft flight bounds are measured against.
+     * 0 during the main run; raised to DREAM_ROOM_Y while a Dream Portal bonus
+     * room is open (see `dream_portal.ts`).
+     */
+    worldOriginY: 0
 };
+
+/**
+ * Vertical offset of the Dream Portal bonus pocket (see `dream_portal.ts`).
+ * Lives here so the eager loop can reason about the pocket without pulling the
+ * deferred portal chunk into the entry bundle.
+ */
+export const DREAM_ROOM_Y = 4000;
 
 export let isGamePaused = false;
 export let gameStarted = false;

--- a/src/level_config.ts
+++ b/src/level_config.ts
@@ -59,6 +59,45 @@ export type BubbleCoralEnvironmentConfig = {
 
 export type MeteorShowerEnvironmentConfig = boolean;
 
+/** Galactic Core / accretion-disk finale backdrop (see `galactic_core.ts`). */
+export type GalacticCoreEnvironmentConfig = {
+    enabled: boolean;
+    /** World X where the approach ramp starts / completes. */
+    approachStartX?: number;
+    approachEndX?: number;
+    /** Camera-relative X offset at ramp 0 / ramp 1. */
+    startOffsetX?: number;
+    endOffsetX?: number;
+    /** Depth at ramp 0 / ramp 1 (more negative = further away). */
+    startZ?: number;
+    endZ?: number;
+    baseY?: number;
+    scale?: number;
+    /** Disk brightness multiplier (0.6–1.6 reads well). */
+    intensity?: number;
+    innerColor?: number;
+    outerColor?: number;
+};
+
+/** Dream Portal doors + their bonus rooms (see `dream_portal.ts`). */
+export type DreamPortalsEnvironmentConfig = {
+    enabled: boolean;
+    portals: DreamPortalPlacementConfig[];
+};
+
+export type DreamPortalPlacementConfig = {
+    /** Absolute world X of the door (same space as `gravLensCorridors.startX`). */
+    x: number;
+    y?: number;
+    z?: number;
+    /** Seconds inside the bonus room (defaults to 35). */
+    durationSeconds?: number;
+    toyCount?: number;
+    orbCount?: number;
+    hazardCount?: number;
+    theme?: 'pastel' | 'candy' | 'aurora';
+};
+
 export type GravLensPlacement = {
     offsetX: number;
     y: number;
@@ -116,6 +155,10 @@ export type LevelEnvironments = {
     dancingJellyMoss?: boolean | { density?: number };
     weather?: boolean;
     dynamicStarfield?: boolean | { speedScaling?: number };
+    /** Finale backdrop: singularity + accretion disk (deferred chunk). */
+    galacticCore?: GalacticCoreEnvironmentConfig;
+    /** Secret bonus-room doorways (deferred chunk). */
+    dreamPortals?: DreamPortalsEnvironmentConfig;
 };
 
 // Cumulative player-x thresholds for the journey toward the Moon.
@@ -325,7 +368,14 @@ export const LEVEL_CONFIG: { [key: number]: LevelConfig } = {
             ghostDebris: { density: 100 },
             godRays: { enabled: true, density: 1.0, baseIntensity: 0.8, color: 0xffcc88, speedMultiplier: 1.2 },
             lightning: { enabled: true, density: 1.5 },
-            blackHole: { enabled: true, baseX: 3000, baseY: 100 }
+            blackHole: { enabled: true, baseX: 3000, baseY: 100 },
+            // Dream Portal door tucked between the two grav-lens corridors.
+            dreamPortals: {
+                enabled: true,
+                portals: [
+                    { x: 820, y: 7, z: -1, theme: 'candy', durationSeconds: 32 }
+                ]
+            }
         },
         vignettes: {
             geodeClearings: 0.5
@@ -397,7 +447,14 @@ export const LEVEL_CONFIG: { [key: number]: LevelConfig } = {
             lightning: { enabled: true, density: 2.0, color: 0xaa44ff },
             planetaryHorizon: true,
             reEntry: true,
-            bubbleCoral: { density: 0.7 }
+            bubbleCoral: { density: 0.7 },
+            // Second Dream Portal, before the level-3 grav-lens corridor.
+            dreamPortals: {
+                enabled: true,
+                portals: [
+                    { x: 1660, y: -3, z: -1, theme: 'aurora', durationSeconds: 38, toyCount: 16 }
+                ]
+            }
         },
         vignettes: {
             roseArches: 1.2
@@ -608,7 +665,22 @@ export const LEVEL_CONFIG: { [key: number]: LevelConfig } = {
             nebulaRibbons: true,
             voidJellyfish: { density: 40 },
             moonPalace: true,
-            weather: true
+            weather: true,
+            // Finale beat: the Galactic Core swells across the last stretch of
+            // the run (level 6 spans x 4200 → 5200, the Moon threshold).
+            galacticCore: {
+                enabled: true,
+                approachStartX: 4300,
+                approachEndX: 5200,
+                startOffsetX: 340,
+                endOffsetX: 95,
+                startZ: -1150,
+                endZ: -470,
+                baseY: 95,
+                intensity: 1.15,
+                innerColor: 0xffb066,
+                outerColor: 0x7a3fb5
+            }
         }
     }
 };

--- a/src/level_manager/environment_plugins.ts
+++ b/src/level_manager/environment_plugins.ts
@@ -58,6 +58,11 @@ export function buildEnvironmentPlugins(
             deactivate: () => host.blackHoleSystem.deactivate()
         },
         {
+            flag: 'galacticCore',
+            activate: (coreConfig) => host.galacticCoreSystem.activate(coreConfig),
+            deactivate: () => host.galacticCoreSystem.deactivate()
+        },
+        {
             flag: 'industrial',
             activate: (config: any) => host.industrialSystem.activate(typeof config === 'object' ? config : undefined),
             deactivate: () => host.industrialSystem.deactivate()

--- a/src/level_manager/manager.ts
+++ b/src/level_manager/manager.ts
@@ -85,6 +85,7 @@ export class LevelManager {
     planetaryHorizonSystem: LevelEnvironmentPorts['planetaryHorizonSystem'];
     moonPalaceSystem: LevelEnvironmentPorts['moonPalaceSystem'];
     blackHoleSystem: LevelEnvironmentPorts['blackHoleSystem'];
+    galacticCoreSystem: LevelEnvironmentPorts['galacticCoreSystem'];
     reEntrySystem: LevelEnvironmentPorts['reEntrySystem'];
     chromaShiftSystem: LevelEnvironmentPorts['chromaShiftSystem'];
     stormGeodeSystem: LevelEnvironmentPorts['stormGeodeSystem'];
@@ -135,6 +136,7 @@ export class LevelManager {
         this.planetaryHorizonSystem = options.env.planetaryHorizonSystem;
         this.moonPalaceSystem = options.env.moonPalaceSystem;
         this.blackHoleSystem = options.env.blackHoleSystem;
+        this.galacticCoreSystem = options.env.galacticCoreSystem;
         this.reEntrySystem = options.env.reEntrySystem;
         this.chromaShiftSystem = options.env.chromaShiftSystem;
         this.stormGeodeSystem = options.env.stormGeodeSystem;
@@ -381,6 +383,7 @@ export class LevelManager {
         if (enabled('ghostDebris') && this.ghostDebrisSystem) this.ghostDebrisSystem.update(delta, cameraX);
         if (enabled('voidJellyfish') && this.voidJellyfishSystem) this.voidJellyfishSystem.update(delta, cameraX, playerPos);
         if (this.blackHoleSystem) this.blackHoleSystem.update(delta, cameraX, playerPos);
+        if (this.galacticCoreSystem) this.galacticCoreSystem.update(delta, cameraX, playerPos);
         if (enabled('chromaShift')) this.chromaShiftSystem.update(delta, playerPos);
         if (enabled('stormGeodes') && this.stormGeodeSystem) this.stormGeodeSystem.update(delta, cameraX, playerPos);
         this.wishLanternSystem.update(delta, cameraX, playerPos);

--- a/src/level_manager/types.ts
+++ b/src/level_manager/types.ts
@@ -31,6 +31,7 @@ import type { CosmicDustSystem } from '../cosmic_dust';
 import type { PlanetaryHorizonSystem } from '../planetary_horizon';
 import type { MoonPalaceSystem } from '../moon_palace';
 import type { BlackHoleSystem } from '../black_hole';
+import type { GalacticCoreSystem } from '../galactic_core';
 import type { ReEntrySystem } from '../reentry';
 import type { ChromaShiftSystem } from '../chroma_shift';
 import type { StormGeodeSystem } from '../storm_geodes';
@@ -89,6 +90,7 @@ export type LevelEnvironmentPorts = {
     planetaryHorizonSystem: PlanetaryHorizonSystem;
     moonPalaceSystem: MoonPalaceSystem;
     blackHoleSystem: BlackHoleSystem;
+    galacticCoreSystem: GalacticCoreSystem;
     reEntrySystem: ReEntrySystem;
     chromaShiftSystem: ChromaShiftSystem;
     stormGeodeSystem: StormGeodeSystem;

--- a/src/level_systems_loader.ts
+++ b/src/level_systems_loader.ts
@@ -13,6 +13,7 @@ import {
     shouldSpawnBubbleCoral
 } from './level_spawn_rules';
 import { scene, camera } from './scene_context';
+import { createDreamPortalCallbacks } from './main/dream_portal_update';
 
 type SystemKey =
     | 'reEntry'
@@ -27,6 +28,8 @@ type SystemKey =
     | 'chromaShift'
     | 'stormGeode'
     | 'blackHole'
+    | 'galacticCore'
+    | 'dreamPortals'
     | 'ghostDebris'
     | 'voidJellyfish'
     | 'industrialGeometry'
@@ -166,6 +169,19 @@ async function loadSystem(key: SystemKey): Promise<void> {
                 installEnvPartial({ blackHoleSystem: new BlackHoleSystem(scene) });
                 break;
             }
+            case 'galacticCore': {
+                const { GalacticCoreSystem } = await import('./galactic_core');
+                installEnvPartial({ galacticCoreSystem: new GalacticCoreSystem(scene) });
+                break;
+            }
+            case 'dreamPortals': {
+                const { DreamPortalSystem } = await import('./dream_portal');
+                assignGameSystem(
+                    'dreamPortalSystem',
+                    new DreamPortalSystem(scene, createDreamPortalCallbacks())
+                );
+                break;
+            }
             case 'ghostDebris': {
                 const { GhostDebrisSystem } = await import('./ghost_debris');
                 game.ghostDebrisSystem = new GhostDebrisSystem(scene);
@@ -251,6 +267,8 @@ export function systemsNeededForLevel(cfg: LevelConfig | undefined): SystemKey[]
     if (isEnvironmentEnabled(env.planetaryHorizon)) keys.add('planetaryHorizon');
     if (isEnvironmentEnabled(env.moonPalace)) keys.add('moonPalace');
     if (isEnvironmentEnabled(env.blackHole)) keys.add('blackHole');
+    if (isEnvironmentEnabled(env.galacticCore)) keys.add('galacticCore');
+    if (isEnvironmentEnabled(env.dreamPortals)) keys.add('dreamPortals');
     if (isEnvironmentEnabled(env.ghostDebris)) keys.add('ghostDebris');
     if (isEnvironmentEnabled(env.voidJellyfish)) keys.add('voidJellyfish');
     if (isEnvironmentEnabled(env.aquaticLife)) keys.add('aquaticLife');

--- a/src/main/dream_portal_update.ts
+++ b/src/main/dream_portal_update.ts
@@ -1,0 +1,121 @@
+/**
+ * Dream Portal orchestration: binds the `DreamPortalSystem` to the game context
+ * (orbs, cores, score, juice, audio) and drives it from the main loop.
+ *
+ * The system itself owns no game singletons — everything it needs arrives
+ * through {@link createDreamPortalCallbacks}, which is also what the deferred
+ * loader uses when it constructs the system for a level that declares
+ * `environments.dreamPortals`.
+ */
+
+import * as THREE from 'three';
+import { camera } from '../scene_context';
+import { player } from '../player_loader';
+import { playerState, DREAM_ROOM_Y } from '../game_config';
+import { game } from '../game_runtime';
+import { ShakeType } from '../juice_effects';
+import { DogAnimationState } from '../dog_cockpit';
+import { VictoryState } from '../victory_system';
+import type { DreamPortalCallbacks } from '../dream_portal';
+import type { LevelConfig } from '../level_config';
+
+/** Anything above this Y belongs to the bonus pocket, never the main run. */
+const POCKET_Y_FLOOR = DREAM_ROOM_Y - 500;
+
+function clearPocketOrbs(): void {
+    game.orbManager.cleanupOrbsAboveY(POCKET_Y_FLOOR);
+}
+
+export function createDreamPortalCallbacks(): DreamPortalCallbacks {
+    return {
+        getPlayer: () => player,
+        getScrollSpeed: () => playerState.autoScrollSpeed,
+        setScrollSpeed: (speed) => {
+            playerState.autoScrollSpeed = speed;
+            playerState.currentSpeedY = 0;
+        },
+        setWorldOriginY: (y) => {
+            playerState.worldOriginY = y;
+        },
+        snapCamera: (y) => {
+            // Skip the follow lerp — otherwise the camera crawls across the gap.
+            camera.position.y = y + 2;
+        },
+        nudgePlayer: (dx, dy) => {
+            playerState.currentSpeedY += dy;
+            if (player) player.position.x += dx * 0.08;
+        },
+        spawnOrb: (x, y, z) => {
+            game.orbManager.spawnStarOrb(x, y, z);
+        },
+
+        onEnter: (portalPosition) => {
+            clearPocketOrbs();
+            game.juiceManager.flashRainbow(0.6);
+            game.juiceManager.burstMagic(portalPosition.clone());
+            game.juiceManager.showFloatingText('Dream Door!', portalPosition.clone(), '#ffc8f0', 28);
+            game.dogController.triggerAnimation(DogAnimationState.DELIGHTED, 1.4);
+            game.audioSystem.playMagicSequence('power_up');
+        },
+
+        onToyCollected: (position, score) => {
+            game.hudManager.addScore(score);
+            playerState.cores += 2;
+            game.saveManager.addCores(2);
+            game.juiceManager.spawnSparkles(position, new THREE.Color(0xffe9a8), 8);
+            game.audioSystem.playCollect();
+        },
+
+        onBumper: (position) => {
+            game.juiceManager.shakeScreen(ShakeType.LIGHT, 0.12);
+            game.juiceManager.spawnSparkles(position, new THREE.Color(0xaa88ff), 6);
+            game.audioSystem.play('sparkle', 0.35);
+        },
+
+        onExit: (reward, exitPosition) => {
+            clearPocketOrbs();
+
+            playerState.cores += reward.cores;
+            game.saveManager.addCores(reward.cores);
+            game.hudManager.addScore(reward.score);
+
+            const label = reward.cleared
+                ? `Dream Cleared! +${reward.cores} Cores`
+                : `Sweet dreams! +${reward.cores} Cores`;
+            const anchor = player?.position.clone() ?? exitPosition;
+            game.juiceManager.showFloatingText(label, anchor, '#9fe8ff', 28);
+            game.juiceManager.flashRainbow(0.8);
+            game.juiceManager.burstMagic(anchor);
+            game.dogController.triggerAnimation(DogAnimationState.VICTORY, 1.6);
+            game.audioSystem.playMagicSequence('power_up');
+            game.friendsManager.cheerFlotilla(anchor);
+        }
+    };
+}
+
+/** Per-level portal placement — mirrors `spawnGravLensCorridorsForLevel`. */
+export function spawnDreamPortalsForLevel(cfg: LevelConfig): void {
+    game.dreamPortalSystem.clear();
+
+    const config = cfg.environments?.dreamPortals;
+    if (!config?.enabled || !config.portals?.length) return;
+    game.dreamPortalSystem.spawnPortals(config.portals);
+}
+
+/**
+ * Frame hook. Portals stay dormant during boss fights and the victory approach
+ * so a bonus room can never interrupt a scripted sequence.
+ */
+export function updateDreamPortals(delta: number, time: number): void {
+    if (!player) return;
+    const system = game.dreamPortalSystem;
+    if (!system) return;
+
+    if (!system.isActive()) {
+        if (playerState.bossActive) return;
+        if (game.victorySystem.getState() !== VictoryState.NONE) return;
+        if (game.moonGateSequenceActive) return;
+    }
+
+    system.update(delta, time);
+}

--- a/src/main/galactic_core_update.ts
+++ b/src/main/galactic_core_update.ts
@@ -1,0 +1,29 @@
+/**
+ * Galactic Core gameplay hooks: mild projectile lensing plus a low rumble as
+ * the finale approach peaks. The backdrop itself is driven by LevelManager.
+ */
+
+import * as THREE from 'three';
+import { game } from '../game_runtime';
+import { ShakeType } from '../juice_effects';
+
+const pullVec = new THREE.Vector3();
+
+export function updateGalacticCoreEffects(delta: number): void {
+    const core = game.galacticCoreSystem;
+    if (!core?.active) return;
+
+    // Plasma bolts bend toward the singularity when they fly near it.
+    const projectiles = game.weaponSystem.getActiveProjectiles();
+    for (const proj of projectiles) {
+        if (!proj.active) continue;
+        core.getProjectilePull(proj.mesh.position, delta, pullVec);
+        if (pullVec.lengthSq() > 0) proj.velocity.add(pullVec);
+    }
+
+    // Deep in the approach, the ship trembles in the core's gravity well.
+    const approach = core.getApproachIntensity();
+    if (approach > 0.7 && Math.random() < delta * (approach - 0.7) * 3) {
+        game.juiceManager.shakeScreen(ShakeType.LIGHT, 0.1);
+    }
+}

--- a/src/main/loop_world.ts
+++ b/src/main/loop_world.ts
@@ -27,6 +27,8 @@ import { updateCamera } from './camera_system';
 import { updateShadowQuality, updateShadowCulling } from './render_helpers';
 import { updateGravLensSystems } from './grav_lens_update';
 import { updateArtifacts } from './artifact_update';
+import { updateDreamPortals } from './dream_portal_update';
+import { updateGalacticCoreEffects } from './galactic_core_update';
 export function updateLoopWorld(delta: number, time: number): void {
         // "Path to the Moon" gate animates independently of the planet horizon
         game.planetaryHorizonSystem.updateMoonGate(delta);
@@ -97,6 +99,12 @@ export function updateLoopWorld(delta: number, time: number): void {
         if (player) {
             updateArtifacts(delta);
         }
+
+        // Dream Portal doors + bonus rooms (levels 2–3)
+        updateDreamPortals(delta, time);
+
+        // Galactic Core finale: projectile lensing + approach rumble (level 6)
+        updateGalacticCoreEffects(delta);
     
         // Update Level Manager (and Clouds)
         if (player) {
@@ -121,7 +129,8 @@ export function updateLoopWorld(delta: number, time: number): void {
                 ...geoScannables,
                 ...game.friendsManager.getScannables(),
                 ...game.creatureManager.getScannables(),
-                ...game.slingableObjectSystem.getScannables()
+                ...game.slingableObjectSystem.getScannables(),
+                ...game.dreamPortalSystem.getScannables()
             ]);
             if (game.debugSystem.isEnabled('butterflySwarm')) {
                 const nowSec = performance.now() * 0.001;

--- a/src/main/player_update.ts
+++ b/src/main/player_update.ts
@@ -98,12 +98,14 @@ export function updatePlayer(delta: number) {
 
     player.position.y += playerState.currentSpeedY * delta;
     
-    // Soft boundaries - keep player on screen (Y: -10 to +15)
-    if (player.position.y > 15) {
-        player.position.y = 15;
+    // Soft boundaries - keep player on screen (Y: origin-10 to origin+15).
+    // `worldOriginY` is 0 in the main run and DREAM_ROOM_Y inside a bonus room.
+    const originY = playerState.worldOriginY;
+    if (player.position.y > originY + 15) {
+        player.position.y = originY + 15;
         playerState.currentSpeedY = Math.min(0, playerState.currentSpeedY);
-    } else if (player.position.y < -10) {
-        player.position.y = -10;
+    } else if (player.position.y < originY - 10) {
+        player.position.y = originY - 10;
         playerState.currentSpeedY = Math.max(0, playerState.currentSpeedY);
     }
     
@@ -448,9 +450,13 @@ export function updatePlayer(delta: number) {
     // --- AUDIO SYSTEM ---
     game.audioSystem.updateEngineState(playerState.currentSpeedY, isMovingUp, isMovingDown, isBoosting);
 
-    // Level Checking — prefetch next level chunk before boundary crossing
-    maybePrefetchNextLevel(player.position.x, game.levelManager.currentLevel);
-    game.levelManager.checkProgress(player.position.x);
+    // Level Checking — prefetch next level chunk before boundary crossing.
+    // Frozen while a Dream Portal room is open: the main run is paused in place,
+    // so neither streaming nor a level transition should fire.
+    if (!game.dreamPortalSystem?.isInRoom()) {
+        maybePrefetchNextLevel(player.position.x, game.levelManager.currentLevel);
+        game.levelManager.checkProgress(player.position.x);
+    }
 
     // "Survive" objectives (e.g. L4 Rusty Gauntlet) don't have a running
     // counter - treat reaching 80% of the level's span as "survived" and

--- a/src/main/startup.ts
+++ b/src/main/startup.ts
@@ -16,6 +16,7 @@ import { SlingObjectiveManager } from '../sling_objective';
 import { SlingComboManager } from '../sling_combo';
 import { TetherSystem } from '../tether_system';
 import { spawnGravLensCorridorsForLevel } from './grav_lens_update';
+import { spawnDreamPortalsForLevel } from './dream_portal_update';
 import { spawnArtifactsForLevel } from './artifact_update';
 import { DebugSystem } from '../debug_system';
 import { decorationBudget, registerDefaultDecorationBudgets } from '../decoration_budget';
@@ -176,6 +177,7 @@ function createLevelManager(
             planetaryHorizonSystem: systems.planetaryHorizonSystem,
             moonPalaceSystem: systems.moonPalaceSystem,
             blackHoleSystem: systems.blackHoleSystem,
+            galacticCoreSystem: systems.galacticCoreSystem,
             reEntrySystem: systems.reEntrySystem,
             chromaShiftSystem: systems.chromaShiftSystem,
             stormGeodeSystem: systems.stormGeodeSystem,
@@ -212,6 +214,7 @@ function createLevelManager(
             game.friendsManager.resetLevelLemurCap();
             game.toyRocketSpawnManager.spawnForLevel(game.levelManager.currentLevel, cfg);
             spawnGravLensCorridorsForLevel(game.levelManager.currentLevel, cfg);
+            spawnDreamPortalsForLevel(cfg);
             spawnArtifactsForLevel(cfg, player?.position.x ?? 0);
             game.wrenchChargeAvailable = game.saveManager.hasMemory('mine_robot');
             game.slingObjectiveManager.reset(cfg.objective?.type === 'sling' ? cfg.objective.target : 0);
@@ -461,4 +464,11 @@ export function initializeStartup(): void {
     }
 
     wireStartupCallbacks();
+
+    // Dev / `?debug` only: a handle on the composition root so set-pieces that
+    // sit deep in a run (Dream Portals, the Galactic Core approach) can be
+    // driven from the console or a browser test without playing to them.
+    if (import.meta.env.DEV || hasDebugUrlFlag('debug')) {
+        (window as unknown as { dogDash?: unknown }).dogDash = { game, playerState, scene, camera };
+    }
 }


### PR DESCRIPTION
Implements both halves of the "horizon" issue: secret Dream Portal doors with a short bonus room, and the Galactic Core / accretion-disk finale beat (`future-plan.md` §10). Both are declared in `LEVEL_CONFIG.environments` and deferred-loaded, so Level 1 pays for neither.

## Dream Portals — `src/dream_portal.ts` (levels 2–3)

Doors are placed per level from `environments.dreamPortals.portals` (absolute world X, same space as `gravLensCorridors.startX`), spawned from `onLevelStart` exactly like grav-lens corridors. A prompt appears within 26 units; flying through the door enters the room. One-shot per run.

**How the pocket works.** The room is not a second scene — it's a pocket of the same scene parked at `DREAM_ROOM_Y` (4000). Entering saves the player's Y and `autoScrollSpeed`, teleports up, raises `playerState.worldOriginY` (the soft flight clamp in `player_update.ts` is now measured against that origin, so the band travels with the player) and parks the scroll at 0. Streaming, obstacle spawning and orb cleanup are all keyed off camera/player **X**, so freezing X freezes the main run in place — nothing is torn down, and exit restores Y, clamp origin and scroll speed. Level progression and prefetch are additionally gated on `isInRoom()`.

Inside, the player's X is frozen, so the *room* scrolls past them: a static anchor (backdrop + exit ring) holds a sliding prop layer with instanced toys, drifting dream jellies (bump, never damage) and a hero lantern.

**No soft-lock:** the exit ring is pinned directly above the player (arms after 2 s) and the room timer is a hard backstop.

**No parallel economy:** the orb fountain is real `OrbManager` star orbs, cores go through `SaveManager.addCores`, score through `HUDManager.addScore`, and both the door (`dreamPortal`) and the lantern (`dreamLantern`) are registered as `DiscoveryManager` scan targets. Pocket orbs are cleaned up on exit via the new `OrbManager.cleanupOrbsAboveY()`.

All interaction tests use XY-plane distance — the player never leaves `z = 0`, so anything gated on 3D distance at a decorative depth would have been literally unreachable.

## Galactic Core — `src/galactic_core.ts` (level 6)

Event-horizon sphere, TSL accretion disk (`RingGeometry` + layered radial/angular noise, additive), photon halo, and a spiral "swirl veil" that fakes mild lensing with no postprocessing pass (no new packages). It is a camera-relative parallax backdrop: it sits `offsetX` ahead of the camera at depth `z`, and an eased approach ramp driven by the player's world X between `approachStartX`/`approachEndX` walks both toward their end values, so it drifts in and grows across the finale.

Gameplay hooks stay small (`src/main/galactic_core_update.ts`): plasma bolts bend toward the core within 240 units, and the ship trembles once the ramp passes 0.7. WebGL2 (`?renderer=webgl`) gets `MeshBasicMaterial` stand-ins and lower segment counts.

## Also

- Decoration budgets registered for `dream_portal`, `dream_room_props`, `galactic_core`.
- Dev / `?debug`-only `window.dogDash` handle on the composition root, so set-pieces that sit deep in a run can be driven from the console or a browser test without playing to them.
- Docs: new sections in `docs/SIDE_SCROLLER_OBJECTS.md` (environments table + both systems) and `docs/PERFORMANCE_BUDGETS.md` (registrar rows + per-level chunk map, plus the two deferred-chunk guardrails I hit).

## Verification

- `npm run typecheck` — no new errors (the 4 baseline entries in `obstacle_system/manager.ts` are pre-existing on `main`; baseline file left untouched).
- `node tools/check_braces.cjs` — pass.
- `npm run build` — `dream_portal-*.js` (12.4 KB) and `galactic_core-*.js` (4.8 KB) split as their own async chunks; entry unchanged.
- `npm run test:smoke` — both WebGL/SwiftShader smoke tests pass.
- Drove both features end to end in a throwaway Playwright spec on the WebGL path (deleted before commit): entering the L2 portal teleports to the pocket with `worldOriginY` raised, scroll at 0, orb fountain spawned and 2 scan targets live; a toy collect grants cores; the exit ring restores Y, clamp origin, scroll speed and level, cleans up pocket orbs and awards cores, with no page errors. On level 6 the core activates and its approach ramps 0 → 0.79 as the player closes on the Moon threshold.

## Notes

Manual runtime verification on a WebGPU browser (Chrome/Edge 113+) is still worth doing for the disk/veil node materials — headless only exercises the WebGL2 path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhSfENF2v7Jisoo7LCdL7z)_