### PR TITLE
Wire C++ Verlet soft-body for hero Jelly-Moss cores (Option A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,6 @@ jobs:
 
       - name: Verify C++ WASM instantiates
         run: npm run verify:cpp-wasm
+
+      - name: Verify soft-body Verlet consumer (Option A)
+        run: npm run verify:cpp-softbody

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ JS writes object positions directly into the `Float32Array` views, then calls th
 | Performance guardrails | `decoration_budget.ts`, `docs/PERFORMANCE_BUDGETS.md` |
 | Progression & economy | `upgrade_system.ts`, `powerup_manager.ts`, `collectibles.ts`, `save_manager.ts`, `boost_system.ts`, `roll_system.ts` |
 | Characters | `dog_cockpit/`, `space_friends.ts`, `player_loader.ts` |
-| Physics & WASM | `physics_utils.ts`, `wasm_loader.ts`, `assembly/index.ts` (supported); `cpp/` experimental — [docs/WASM_BACKENDS.md](docs/WASM_BACKENDS.md) |
+| Physics & WASM | `physics_utils.ts`, `wasm_loader.ts`, `jelly_moss_softbody.ts` (C++ Verlet opt-in), `assembly/index.ts` (supported); `cpp/` experimental — [docs/WASM_BACKENDS.md](docs/WASM_BACKENDS.md) |
 | Audio | `audio_system/` |
 | Game-wide config / composition root | `game_config.ts`, `create_game_systems.ts`, `game_runtime.ts` (`GameContext`); see `docs/GAME_CONTEXT.md` |
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -2,9 +2,11 @@
 
 > **Product status:** AssemblyScript is the supported collision backend. This tree is optional and not required for `npm run dev` / `npm run build`. See [docs/WASM_BACKENDS.md](../docs/WASM_BACKENDS.md).
 
-Optional WebAssembly backend compiled with [Emscripten](https://emscripten.org/). It mirrors the AssemblyScript collision API and also exports **Verlet physics** (`stepPhysics`, body accessors) and **fractal noise** (`fractalNoise2D`, `fractalNoise3D`). Those extras are **not** wired into TypeScript gameplay yet.
+Optional WebAssembly backend compiled with [Emscripten](https://emscripten.org/). It mirrors the AssemblyScript collision API and also exports **Verlet physics** (`stepPhysics`, body accessors) and **fractal noise** (`fractalNoise2D`, `fractalNoise3D`).
 
-The default game build uses AssemblyScript only. Enable the C++ backend at runtime with `VITE_CPP_WASM=true` after building and copying `game_cpp.wasm` (falls back to AS if the binary is missing).
+**Gameplay consumer (Option A):** Verlet drives soft-body nets for up to 3 hero Nebula Jelly-Moss cores via [`src/jelly_moss_softbody.ts`](../src/jelly_moss_softbody.ts). Fractal noise remains unused by TypeScript for now.
+
+The default game build uses AssemblyScript only. Enable the C++ backend at runtime with `VITE_CPP_WASM=true` after building and copying `game_cpp.wasm` (falls back to AS if the binary is missing — no crash).
 
 ## Quick start
 
@@ -22,7 +24,8 @@ From the repo root:
 
 ```bash
 npm run build:cpp-wasm          # release build → build/ + public/build/
-npm run verify:cpp-wasm         # instantiate check (Node)
+npm run verify:cpp-wasm         # instantiate + light Verlet call check
+npm run verify:cpp-softbody     # soft-body consumer path (alloc/impulse/step/read)
 ```
 
 Set `EMSDK` if your checkout is not in a default location:
@@ -52,6 +55,7 @@ npm run build:cpp-wasm:docker
 | `npm run build:cpp-wasm:docker` | Docker build (no local emsdk) |
 | `npm run copy:cpp-wasm` | Copy `build/game_cpp.wasm` → `public/build/` |
 | `npm run verify:cpp-wasm` | Node smoke-check of `public/build/game_cpp.wasm` |
+| `npm run verify:cpp-softbody` | Node check of Verlet soft-body consumer exports |
 | `npm run build:all-wasm` | AS always; C++ only if emsdk/docker available |
 
 ## Runtime
@@ -60,7 +64,9 @@ npm run build:cpp-wasm:docker
 VITE_CPP_WASM=true npm run dev
 ```
 
-If `game_cpp.wasm` is missing or fails to load, `wasm_loader.ts` falls back to AssemblyScript automatically.
+If `game_cpp.wasm` is missing or fails to load, `wasm_loader.ts` falls back to AssemblyScript automatically. Soft-body stays idle; Jelly-Moss keeps shader wobble.
+
+Breadcrumbs: `window.wasmBackend`, `window.jellyMossSoftBodyActive`, `window.jellyMossSoftBodyHeroCount`.
 
 ## Troubleshooting
 
@@ -68,7 +74,13 @@ If `game_cpp.wasm` is missing or fails to load, `wasm_loader.ts` falls back to A
 |---------|-----|
 | `loadWasm(Cpp)` falls back to AS | Run `npm run build:cpp-wasm` and confirm `public/build/game_cpp.wasm` exists |
 | emsdk not found | `source emsdk_env.sh` or use `build:cpp-wasm:docker` |
+| Soft-body inactive with C++ loaded | Confirm hero mosses spawned (deferred prototype content) and `jellyMossSoftBodyHeroCount > 0` |
+
+## Native tests
+
+`BUILD_NATIVE_TESTS` stays disabled — `cpp/tests/*.cpp` was never checked in. Re-add only when real native tests land (see `CMakeLists.txt` comment).
 
 ## Future
 
-Wire Verlet/noise from TS (or drop this tree) before treating C++ as a supported production path.
+- Fractal-noise biome density (Option B) still available via unused `fractalNoise2D` exports.
+- Liquid-metal / vacuum-kelp soft interactions can reuse the same Verlet helpers.

--- a/docs/WASM_BACKENDS.md
+++ b/docs/WASM_BACKENDS.md
@@ -45,6 +45,9 @@ npm run build:cpp-wasm:docker       # Docker, no local emsdk
 npm run verify:cpp-wasm
 npm run verify:cpp-softbody         # exercises Verlet consumer path
 
+# Optional: AS + C++ when emsdk is available (skips C++ if missing)
+npm run build:all-wasm
+
 # Optional browser breadcrumb check (preview must serve dist with VITE_CPP_WASM=true):
 #   VITE_CPP_WASM=true npm run build && npx vite preview --port 4173
 #   npm run smoke:cpp-softbody

--- a/docs/WASM_BACKENDS.md
+++ b/docs/WASM_BACKENDS.md
@@ -40,14 +40,14 @@ When C++ WASM is loaded:
 3. Core mesh positions are written back each frame (bone-like offsets). Membrane shader wobble remains the AS fallback.
 
 ```bash
-# Build + copy experimental artifact
 npm run build:cpp-wasm              # local emsdk
 npm run build:cpp-wasm:docker       # Docker, no local emsdk
 npm run verify:cpp-wasm
 npm run verify:cpp-softbody         # exercises Verlet consumer path
 
-# Optional: AS + C++ when emsdk is available (skips C++ if missing)
-npm run build:all-wasm
+# Optional browser breadcrumb check (preview must serve dist with VITE_CPP_WASM=true):
+#   VITE_CPP_WASM=true npm run build && npx vite preview --port 4173
+#   npm run smoke:cpp-softbody
 ```
 
 Runtime opt-in (falls back to AssemblyScript if the C++ binary is missing — **no crash**):

--- a/docs/WASM_BACKENDS.md
+++ b/docs/WASM_BACKENDS.md
@@ -4,21 +4,15 @@
 
 **Dog Dash ships and documents AssemblyScript collision WASM as the only supported physics path for development, production, and CI.**
 
-The C++/Emscripten tree under [`cpp/`](../cpp/) is **experimental / parked**. It mirrors the collision API and also exports Verlet physics and fractal noise, but:
-
-- Those extras are **not** called from TypeScript gameplay today
-- `game_cpp.wasm` is **not** part of the default `public/build/` tree
-- Emscripten is **not** required to clone, `npm run dev`, or `npm run build`
-
-Revisit dual-backend product integration only if a concrete gameplay feature needs Verlet or WASM noise (see “Future” below).
+The C++/Emscripten tree under [`cpp/`](../cpp/) is **experimental / opt-in**. It mirrors the collision API and also exports Verlet physics and fractal noise.
 
 | | **AssemblyScript (supported)** | **C++ (experimental)** |
 |---|------------------------------|------------------------|
 | **Binary** | `public/build/optimized.wasm` (~3 KB) | `public/build/game_cpp.wasm` (optional) |
 | **Default build** | Yes — `predev` / `prebuild` | No |
-| **Toolchain** | `asc` via npm | Emscripten emsdk or Docker |
+| **Toolchain** | `asc` via npm (`--initialMemory 2 --optimize`) — AS-only; not coupled to C++ | Emscripten emsdk or Docker |
 | **Collision API** | Asteroids, spores, boss hitboxes | Same symbols (parity) |
-| **Verlet / noise** | — | Present in C++ only; unused by TS |
+| **Verlet / noise** | — | Verlet consumed by Jelly-Moss soft-body (Option A); noise still unused |
 | **Onboarding** | Required | Not required |
 
 ## Default path (what you need day-to-day)
@@ -33,49 +27,57 @@ No Emscripten. Collision runs through [`assembly/index.ts`](../assembly/index.ts
 
 If WASM fails to load, obstacle checks use a **JavaScript circle/sphere fallback** so gameplay does not crash (see `checkCircleCollisionJs` / `checkSphereCollisionJs` in [`src/physics_utils.ts`](../src/physics_utils.ts)).
 
-## Experimental C++ backend
+## Experimental C++ backend + Option A (soft-body Jelly-Moss)
 
-Kept for portable builds and future experiments. Details: [`cpp/README.md`](../cpp/README.md).
+Kept for portable builds and soft-body experiments. Details: [`cpp/README.md`](../cpp/README.md).
+
+**Chosen deliverable: Option A — Verlet soft-body for 1–3 hero Nebula Jelly-Moss cores.**
+
+When C++ WASM is loaded:
+
+1. [`src/jelly_moss_softbody.ts`](../src/jelly_moss_softbody.ts) calls `allocPhysicsBodies` / `stepPhysics` / body accessors.
+2. Up to three deferred hero mosses attach a small core net; projectile / player hits add impulses.
+3. Core mesh positions are written back each frame (bone-like offsets). Membrane shader wobble remains the AS fallback.
 
 ```bash
-# Only if you intentionally want the C++ artifact
+# Build + copy experimental artifact
 npm run build:cpp-wasm              # local emsdk
 npm run build:cpp-wasm:docker       # Docker, no local emsdk
 npm run verify:cpp-wasm
+npm run verify:cpp-softbody         # exercises Verlet consumer path
 
 # Optional: AS + C++ when emsdk is available (skips C++ if missing)
 npm run build:all-wasm
 ```
 
-Runtime opt-in (still falls back to AssemblyScript if the C++ binary is missing):
+Runtime opt-in (falls back to AssemblyScript if the C++ binary is missing — **no crash**):
 
 ```bash
 VITE_CPP_WASM=true npm run dev
 ```
 
-**Do not** treat `VITE_CPP_WASM` as a supported production configuration until a gameplay consumer of Verlet/noise lands and CI smoke covers that flag.
+Runtime breadcrumbs (for smoke / debugging):
 
-C++-only exports (`allocPhysicsBodies`, `stepPhysics`, `fractalNoise2D`, …) remain typed as `Partial<CppExtrasExports>` on `WasmExports` for the loader; they are **not** wired into the game loop.
+- `window.wasmBackend` — `'cpp' | 'assemblyscript' | null`
+- `window.jellyMossSoftBodyActive` — `true` when Verlet is driving ≥1 hero moss
+- `window.jellyMossSoftBodyHeroCount` — attached hero count (0–3)
+
+`asc` flags (`--initialMemory 2 --optimize`) stay on the AssemblyScript `build:wasm` script only. C++ memory growth is handled by `refreshMemoryView()` after `allocPhysicsBodies` (and other `alloc*` calls).
+
+Native host tests: `BUILD_NATIVE_TESTS` stays off — see comment in [`cpp/CMakeLists.txt`](../cpp/CMakeLists.txt).
 
 ## CI
 
 - **typecheck-and-build** / **smoke**: AssemblyScript WASM only (required path).
-- **cpp-wasm**: optional job (Emscripten). Failures do not block merge; confirms the experimental tree still builds when runners have emsdk.
+- **cpp-wasm**: optional job (Emscripten, `continue-on-error`). Builds `game_cpp.wasm`, runs `verify:cpp-wasm` + `verify:cpp-softbody`. Failures do not block merge.
 
 ## Null WASM
 
-`game.wasmExports` is typed `WasmExports | null`. Load failure leaves it `null`; obstacle collision must not assume exports exist.
-
-## Future (when Option B would make sense)
-
-1. Wire at least one gameplay caller of Verlet or noise.
-2. Ensure `npm run build:cpp-wasm && npm run copy:cpp-wasm` is verified in an optional CI job (already sketched).
-3. Document production opt-in and smoke under `VITE_CPP_WASM=true`.
-
-Until then, expand **AssemblyScript** if new collision primitives are needed.
+`game.wasmExports` is typed `WasmExports | null`. Load failure leaves it `null`; obstacle collision must not assume exports exist. Soft-body bind is a no-op when the handle is null or backend is AssemblyScript.
 
 ## Further reading
 
 - [`cpp/README.md`](../cpp/README.md) — emsdk / Docker for experimental builds
 - [`src/wasm_loader.ts`](../src/wasm_loader.ts) — loader API and export types
+- [`src/jelly_moss_softbody.ts`](../src/jelly_moss_softbody.ts) — Option A Verlet consumer
 - [`assembly/index.ts`](../assembly/index.ts) — supported collision source

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "copy:cpp-wasm": "node -e \"const fs=require('fs'); const src='build/game_cpp.wasm'; const dest='public/build/game_cpp.wasm'; if(fs.existsSync(src)){fs.mkdirSync('public/build',{recursive:true}); fs.copyFileSync(src,dest); console.log('Copied',dest);} else { console.log('Skip copy:cpp-wasm — build/game_cpp.wasm missing (experimental; AS-only default).'); }\"",
     "verify:cpp-wasm": "node scripts/verify-cpp-wasm.mjs",
     "verify:cpp-softbody": "node scripts/verify-cpp-softbody.mjs",
+    "smoke:cpp-softbody": "node scripts/smoke-cpp-softbody.mjs",
     "predev": "npm run build:wasm && npm run copy:wasm",
     "watch:wasm": "node scripts/watch-wasm.cjs",
     "typecheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:all-wasm": "npm run build:wasm && npm run copy:wasm && bash scripts/build-cpp-wasm-if-available.sh",
     "copy:cpp-wasm": "node -e \"const fs=require('fs'); const src='build/game_cpp.wasm'; const dest='public/build/game_cpp.wasm'; if(fs.existsSync(src)){fs.mkdirSync('public/build',{recursive:true}); fs.copyFileSync(src,dest); console.log('Copied',dest);} else { console.log('Skip copy:cpp-wasm — build/game_cpp.wasm missing (experimental; AS-only default).'); }\"",
     "verify:cpp-wasm": "node scripts/verify-cpp-wasm.mjs",
+    "verify:cpp-softbody": "node scripts/verify-cpp-softbody.mjs",
     "predev": "npm run build:wasm && npm run copy:wasm",
     "watch:wasm": "node scripts/watch-wasm.cjs",
     "typecheck": "tsc --noEmit",

--- a/scripts/smoke-cpp-softbody.mjs
+++ b/scripts/smoke-cpp-softbody.mjs
@@ -1,0 +1,66 @@
+/**
+ * One-off smoke: VITE_CPP_WASM build reports cpp backend + soft-body after gameplay start.
+ * Run against vite preview on :4173 with game_cpp.wasm present.
+ */
+import { chromium } from '@playwright/test';
+
+const url = 'http://127.0.0.1:4173/?renderer=webgl';
+const chromePath = process.env.PLAYWRIGHT_CHROME_PATH || '/usr/local/bin/google-chrome';
+
+const browser = await chromium.launch({
+    executablePath: chromePath,
+    headless: true,
+    args: [
+        '--use-gl=angle',
+        '--use-angle=swiftshader',
+        '--enable-unsafe-swiftshader',
+        '--ignore-gpu-blocklist',
+    ],
+});
+
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push(e.message));
+
+await page.goto(url, { waitUntil: 'networkidle' });
+await page.waitForFunction(() => window.usingWebGL === true, null, { timeout: 30000 });
+
+// Wait for wasm load breadcrumb
+await page.waitForFunction(() => window.wasmBackend === 'cpp' || window.wasmBackend === 'assemblyscript', null, {
+    timeout: 15000,
+});
+
+const before = await page.evaluate(() => ({
+    wasmBackend: window.wasmBackend,
+    softActive: window.jellyMossSoftBodyActive,
+    heroes: window.jellyMossSoftBodyHeroCount,
+}));
+
+await page.locator('#instructions').click();
+await page.waitForTimeout(2500);
+
+const after = await page.evaluate(() => ({
+    wasmBackend: window.wasmBackend,
+    softActive: window.jellyMossSoftBodyActive,
+    heroes: window.jellyMossSoftBodyHeroCount,
+}));
+
+console.log('before gameplay:', before);
+console.log('after gameplay:', after);
+console.log('page errors:', errors);
+
+if (after.wasmBackend !== 'cpp') {
+    console.error('FAIL: expected wasmBackend=cpp');
+    process.exit(1);
+}
+if (!after.softActive || (after.heroes ?? 0) < 1) {
+    console.error('FAIL: expected soft-body active with ≥1 hero after deferred spawn');
+    process.exit(1);
+}
+if (errors.length) {
+    console.error('FAIL: page errors');
+    process.exit(1);
+}
+
+console.log('✅ VITE_CPP_WASM soft-body path OK');
+await browser.close();

--- a/scripts/verify-cpp-softbody.mjs
+++ b/scripts/verify-cpp-softbody.mjs
@@ -1,0 +1,68 @@
+/**
+ * verify-cpp-softbody.mjs
+ *
+ * Node smoke for Option A: exercise C++-only Verlet exports the same way
+ * jelly_moss_softbody.ts does (alloc → set → accelerate → step → read).
+ * Requires public/build/game_cpp.wasm (npm run build:cpp-wasm).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const wasmPath = path.join(repoRoot, 'public/build/game_cpp.wasm');
+
+if (!fs.existsSync(wasmPath)) {
+    console.error(`❌ Missing ${wasmPath} — run: npm run build:cpp-wasm`);
+    process.exit(1);
+}
+
+const bytes = fs.readFileSync(wasmPath);
+const { instance } = await WebAssembly.instantiate(bytes, {
+    env: { emscripten_notify_memory_growth: () => {} },
+});
+const e = instance.exports;
+
+const need = [
+    'allocPhysicsBodies',
+    'stepPhysics',
+    'getBodyPositionX',
+    'getBodyPositionY',
+    'setBodyPosition',
+    'addBodyAcceleration',
+];
+for (const name of need) {
+    if (typeof e[name] !== 'function') {
+        console.error(`❌ Missing export ${name}`);
+        process.exit(1);
+    }
+}
+
+const count = 6;
+e.allocPhysicsBodies(count);
+// Refresh view after possible growth (mirrors refreshMemoryView)
+const _mem = new Float32Array(e.memory.buffer);
+
+// Rest ring (hero core net)
+for (let i = 0; i < count; i++) {
+    const angle = (i / count) * Math.PI * 2;
+    e.setBodyPosition(i, Math.cos(angle), Math.sin(angle));
+}
+
+// Impulse on body 0
+e.addBodyAcceleration(0, 40, -15);
+e.stepPhysics(count, 1 / 60, 0);
+
+const x0 = e.getBodyPositionX(0);
+const y0 = e.getBodyPositionY(0);
+if (!Number.isFinite(x0) || !Number.isFinite(y0)) {
+    console.error('❌ Non-finite body position after stepPhysics');
+    process.exit(1);
+}
+if (x0 === 1 && y0 === 0) {
+    console.error('❌ Body 0 did not move after impulse + step (soft-body consumer broken)');
+    process.exit(1);
+}
+
+console.log(`✅ C++ soft-body Verlet consumer verified (body0 → ${x0.toFixed(4)}, ${y0.toFixed(4)})`);

--- a/scripts/verify-cpp-wasm.mjs
+++ b/scripts/verify-cpp-wasm.mjs
@@ -58,4 +58,15 @@ if (!(exports.memory instanceof WebAssembly.Memory)) {
     process.exit(1);
 }
 
+// Light call smoke: alloc + step (same symbols jelly_moss_softbody uses)
+exports.allocPhysicsBodies(2);
+exports.setBodyPosition(0, 1, 2);
+exports.addBodyAcceleration(0, 10, 0);
+exports.stepPhysics(2, 0.016, 0);
+const x = exports.getBodyPositionX(0);
+if (!Number.isFinite(x)) {
+    console.error('❌ stepPhysics produced non-finite position');
+    process.exit(1);
+}
+
 console.log(`✅ C++ WASM verified (${wasmPath})`);

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -27,6 +27,7 @@ import type { ParticleSystem } from './particles';
 import type { WeaponSystem } from './weapons';
 import type { LiquidMetalSystem } from './geological';
 import { disposeObject } from './utils';
+import { jellyMossSoftBody } from './jelly_moss_softbody';
 
 /** Injected by bootstrap — environment never imports composition-root singletons. */
 export type EnvironmentSystems = {
@@ -90,6 +91,8 @@ export function createJellyMossAtPosition(x: number, y: number, z: number, size?
     jellyMoss.userData.speciesId = 'nebulaJellyMoss';
     scene.add(jellyMoss);
     jellyMosses.push(jellyMoss);
+    // Opt-in C++ Verlet soft-body for up to 3 hero mosses; no-op on AS default.
+    jellyMossSoftBody.tryAttach(jellyMoss);
     return jellyMoss;
 }
 
@@ -267,6 +270,7 @@ export function cleanupGeologicalObjects(cameraX: number) {
     for (let i = jellyMosses.length - 1; i >= 0; i--) {
         const jellyMoss = jellyMosses[i];
         if (jellyMoss.position.x < cutoff) {
+            jellyMossSoftBody.detach(jellyMoss);
             scene.remove(jellyMoss);
             disposeObject(jellyMoss);
             jellyMosses.splice(i, 1);

--- a/src/game_runtime.ts
+++ b/src/game_runtime.ts
@@ -19,7 +19,7 @@ import type { DebugSystem } from './debug_system';
 import type { VideoTumblingStar } from './video_tumbling_star';
 import type { GameManagers } from './game_managers';
 import type { GameSystems } from './create_game_systems';
-import type { WasmExports } from './wasm_loader';
+import type { WasmBackend, WasmExports } from './wasm_loader';
 import { playerState } from './game_config';
 import type {
     CollisionDebugOverlay,
@@ -33,6 +33,8 @@ export interface GameContext extends GameSystems, GameManagers {
 
     wasmExports: WasmExports | null;
     wasmMemory: Float32Array | null;
+    /** Active WASM backend after load (null if both backends failed). */
+    wasmBackend: WasmBackend | null;
 
     ghostDebrisSystem: GhostDebrisSystem;
     voidJellyfishSystem: VoidJellyfishSystem;
@@ -127,6 +129,7 @@ export function createGameContextFrameState(): Pick<
     GameContext,
     | 'wasmExports'
     | 'wasmMemory'
+    | 'wasmBackend'
     | 'clock'
     | 'lastPlayerDamageTime'
     | 'aquaticLifeSpawnedLevel'
@@ -171,6 +174,7 @@ export function createGameContextFrameState(): Pick<
     return {
         wasmExports: null,
         wasmMemory: null,
+        wasmBackend: null,
         clock: new THREE.Clock(),
         lastPlayerDamageTime: -999,
         aquaticLifeSpawnedLevel: null,

--- a/src/geological/geodes.ts
+++ b/src/geological/geodes.ts
@@ -33,6 +33,7 @@ import {
 import { ParticleSystem } from '../particles';
 import { disposeObject } from '../utils';
 import type { TSLNode } from '../tsl_types';
+import { jellyMossSoftBody } from '../jelly_moss_softbody';
 
 // --- TSL Noise Functions (3D) ---
 
@@ -336,6 +337,8 @@ export function updateNebulaJellyMoss(mesh: THREE.Mesh, delta: number, timeVal: 
 }
 
 export function destroyNebulaJellyMoss(mesh: THREE.Mesh, scene: THREE.Scene, particleSystem: ParticleSystem) {
+    jellyMossSoftBody.detach(mesh);
+
     // 1. Particle Burst
     // Emit green goo particles
     particleSystem.emit(mesh.position, 0x00ff88, 50, 8.0, 2.0, 3.0);

--- a/src/jelly_moss_softbody.ts
+++ b/src/jelly_moss_softbody.ts
@@ -1,0 +1,318 @@
+/**
+ * jelly_moss_softbody.ts
+ *
+ * Option A consumer of the experimental C++ WASM Verlet exports.
+ * When `wasm.backend === Cpp`, up to MAX_HERO_MOSSES Nebula Jelly-Moss instances
+ * get a small soft-body net for their fractal-moss cores. Springs live in TS;
+ * integration runs in WASM via `stepPhysics`.
+ *
+ * Default AssemblyScript builds leave this idle — membrane sine/fbm wobble stays.
+ *
+ * Enable: `VITE_CPP_WASM=true` after `npm run build:cpp-wasm`.
+ */
+
+import * as THREE from 'three';
+import {
+    WasmBackend,
+    refreshMemoryView,
+    type WasmExports,
+    type WasmHandle,
+} from './wasm_loader';
+
+const MAX_HERO_MOSSES = 3;
+const MAX_CORES_PER_MOSS = 8;
+const MAX_BODIES = MAX_HERO_MOSSES * MAX_CORES_PER_MOSS;
+
+const SPRING_REST = 48;
+const SPRING_NEIGHBOR = 22;
+const DAMPING = 6.5;
+const HIT_IMPULSE = 180;
+const PLAYER_IMPULSE = 35;
+
+export type SoftBodySlot = {
+    mesh: THREE.Mesh;
+    cores: THREE.Object3D[];
+    bodyStart: number;
+    bodyCount: number;
+    restX: Float32Array;
+    restY: Float32Array;
+    baseScale: number;
+};
+
+function hasCppPhysics(exports: WasmExports | null | undefined): boolean {
+    return !!(
+        exports &&
+        typeof exports.allocPhysicsBodies === 'function' &&
+        typeof exports.stepPhysics === 'function' &&
+        typeof exports.getBodyPositionX === 'function' &&
+        typeof exports.getBodyPositionY === 'function' &&
+        typeof exports.setBodyPosition === 'function' &&
+        typeof exports.addBodyAcceleration === 'function'
+    );
+}
+
+/**
+ * Soft-body controller for hero Jelly-Moss cores (C++ WASM only).
+ */
+export class JellyMossSoftBodySystem {
+    private handle: WasmHandle | null = null;
+    private slots: SoftBodySlot[] = [];
+    private bodyCount = 0;
+    private allocated = false;
+    private active = false;
+    private bound = false;
+    private pendingMeshes: THREE.Mesh[] = [];
+
+    /** True when C++ Verlet is bound and at least one hero moss is attached. */
+    get isActive(): boolean {
+        return this.active && this.slots.length > 0;
+    }
+
+    get backend(): WasmBackend | null {
+        return this.handle?.backend ?? null;
+    }
+
+    /** Bind a loaded WASM handle. No-op / disables when not Cpp or missing physics exports. */
+    bindWasm(handle: WasmHandle | null): void {
+        this.clear();
+        this.handle = null;
+        this.active = false;
+        this.allocated = false;
+        this.bodyCount = 0;
+        this.bound = true;
+
+        if (!handle || handle.backend !== WasmBackend.Cpp) {
+            this.pendingMeshes = [];
+            this.publishBreadcrumb();
+            return;
+        }
+        if (!hasCppPhysics(handle.exports)) {
+            console.warn('[jelly-moss softbody] C++ WASM missing Verlet exports; staying on shader wobble');
+            this.pendingMeshes = [];
+            this.publishBreadcrumb();
+            return;
+        }
+
+        this.handle = handle;
+        this.active = true;
+        const pending = this.pendingMeshes.splice(0);
+        for (const mesh of pending) {
+            this.tryAttach(mesh);
+        }
+        this.publishBreadcrumb();
+        console.log('[jelly-moss softbody] C++ Verlet ready (hero moss cores)');
+    }
+
+    /**
+     * Attach soft-body net to a Nebula Jelly-Moss if capacity remains.
+     * Returns true when Verlet will drive its cores.
+     */
+    tryAttach(mesh: THREE.Mesh): boolean {
+        if (!this.active || !this.handle) {
+            // Queue only while WASM load is still outstanding
+            if (!this.bound && !this.pendingMeshes.includes(mesh) && this.pendingMeshes.length < MAX_HERO_MOSSES) {
+                this.pendingMeshes.push(mesh);
+            }
+            return false;
+        }
+        if (this.slots.length >= MAX_HERO_MOSSES) return false;
+        if (this.slots.some((s) => s.mesh === mesh)) return true;
+
+        const coreGroup = mesh.children[0] as THREE.Group | undefined;
+        if (!coreGroup || coreGroup.children.length === 0) return false;
+
+        const cores = coreGroup.children.slice(0, MAX_CORES_PER_MOSS);
+        const bodyStart = this.bodyCount;
+        const bodyCount = cores.length;
+        if (bodyStart + bodyCount > MAX_BODIES) return false;
+
+        if (!this.ensureAllocation(bodyStart + bodyCount)) return false;
+
+        const restX = new Float32Array(bodyCount);
+        const restY = new Float32Array(bodyCount);
+        const exports = this.handle.exports;
+
+        for (let i = 0; i < bodyCount; i++) {
+            const core = cores[i];
+            restX[i] = core.position.x;
+            restY[i] = core.position.y;
+            const idx = bodyStart + i;
+            exports.setBodyPosition!(idx, restX[i], restY[i]);
+        }
+
+        this.bodyCount = bodyStart + bodyCount;
+        this.slots.push({
+            mesh,
+            cores,
+            bodyStart,
+            bodyCount,
+            restX,
+            restY,
+            baseScale: mesh.scale.x || 1,
+        });
+        mesh.userData.softBodyHero = true;
+        this.publishBreadcrumb();
+        return true;
+    }
+
+    /** Detach a moss (destroy / stream cleanup). Safe if never attached. */
+    detach(mesh: THREE.Mesh): void {
+        this.pendingMeshes = this.pendingMeshes.filter((m) => m !== mesh);
+        const idx = this.slots.findIndex((s) => s.mesh === mesh);
+        if (idx < 0) return;
+        mesh.userData.softBodyHero = false;
+        this.slots.splice(idx, 1);
+        this.rebuildBodyLayout();
+        this.publishBreadcrumb();
+    }
+
+    clear(): void {
+        for (const slot of this.slots) {
+            slot.mesh.userData.softBodyHero = false;
+        }
+        this.slots = [];
+        this.bodyCount = 0;
+        this.publishBreadcrumb();
+    }
+
+    /** Impulse from projectile / player in moss-local XY. */
+    applyImpulse(mesh: THREE.Mesh, localAx: number, localAy: number, strength = HIT_IMPULSE): void {
+        if (!this.active || !this.handle) return;
+        const slot = this.slots.find((s) => s.mesh === mesh);
+        if (!slot) return;
+        const exports = this.handle.exports;
+        for (let i = 0; i < slot.bodyCount; i++) {
+            exports.addBodyAcceleration!(slot.bodyStart + i, localAx * strength, localAy * strength);
+        }
+    }
+
+    /** Gentle push when the player brushes a hero moss. */
+    applyPlayerProximity(mesh: THREE.Mesh, playerLocalX: number, playerLocalY: number): void {
+        const len = Math.hypot(playerLocalX, playerLocalY) || 1;
+        this.applyImpulse(mesh, playerLocalX / len, playerLocalY / len, PLAYER_IMPULSE);
+    }
+
+    /**
+     * Per-frame: spring forces → stepPhysics → write core positions.
+     * No-op on AssemblyScript / missing C++.
+     */
+    update(delta: number): void {
+        if (!this.active || !this.handle || this.slots.length === 0 || this.bodyCount <= 0) return;
+
+        const dt = Math.min(0.05, Math.max(0.001, delta));
+        const exports = this.handle.exports;
+
+        for (const slot of this.slots) {
+            for (let i = 0; i < slot.bodyCount; i++) {
+                const idx = slot.bodyStart + i;
+                const x = exports.getBodyPositionX!(idx);
+                const y = exports.getBodyPositionY!(idx);
+
+                // Approximate velocity from Verlet prev via tiny probe: use rest spring + neighbor
+                // Rest spring
+                let ax = (slot.restX[i] - x) * SPRING_REST;
+                let ay = (slot.restY[i] - y) * SPRING_REST;
+
+                // Ring neighbor springs
+                const next = (i + 1) % slot.bodyCount;
+                const nx = exports.getBodyPositionX!(slot.bodyStart + next);
+                const ny = exports.getBodyPositionY!(slot.bodyStart + next);
+                const restDx = slot.restX[next] - slot.restX[i];
+                const restDy = slot.restY[next] - slot.restY[i];
+                const curDx = nx - x;
+                const curDy = ny - y;
+                ax += (curDx - restDx) * SPRING_NEIGHBOR;
+                ay += (curDy - restDy) * SPRING_NEIGHBOR;
+
+                // Damping toward rest (velocity-free approximation: pull back from offset)
+                ax += (slot.restX[i] - x) * DAMPING;
+                ay += (slot.restY[i] - y) * DAMPING;
+
+                exports.addBodyAcceleration!(idx, ax, ay);
+            }
+        }
+
+        // Space flora — no gravity
+        exports.stepPhysics!(this.bodyCount, dt, 0);
+
+        for (const slot of this.slots) {
+            let energy = 0;
+            for (let i = 0; i < slot.bodyCount; i++) {
+                const idx = slot.bodyStart + i;
+                const x = exports.getBodyPositionX!(idx);
+                const y = exports.getBodyPositionY!(idx);
+                const core = slot.cores[i];
+                if (core) {
+                    core.position.x = x;
+                    core.position.y = y;
+                }
+                const dx = x - slot.restX[i];
+                const dy = y - slot.restY[i];
+                energy += dx * dx + dy * dy;
+            }
+            // Subtle whole-mesh jiggle from soft-body energy (bone-like offset signal)
+            const jiggle = Math.min(0.12, Math.sqrt(energy) * 0.015);
+            const s = slot.baseScale * (1 + jiggle);
+            slot.mesh.scale.setScalar(s);
+        }
+    }
+
+    private ensureAllocation(needed: number): boolean {
+        if (!this.handle || !hasCppPhysics(this.handle.exports)) return false;
+        try {
+            this.handle.exports.allocPhysicsBodies!(Math.max(needed, MAX_BODIES));
+            refreshMemoryView(this.handle);
+            this.allocated = true;
+            return true;
+        } catch (err) {
+            console.warn('[jelly-moss softbody] allocPhysicsBodies failed:', err);
+            this.active = false;
+            this.publishBreadcrumb();
+            return false;
+        }
+    }
+
+    /** Re-pack body indices after detach (simple rebuild from current slots). */
+    private rebuildBodyLayout(): void {
+        if (!this.handle || !this.active) {
+            this.bodyCount = 0;
+            return;
+        }
+        const exports = this.handle.exports;
+        let cursor = 0;
+        for (const slot of this.slots) {
+            const newRestX = new Float32Array(slot.bodyCount);
+            const newRestY = new Float32Array(slot.bodyCount);
+            for (let i = 0; i < slot.bodyCount; i++) {
+                const core = slot.cores[i];
+                const x = core?.position.x ?? slot.restX[i];
+                const y = core?.position.y ?? slot.restY[i];
+                newRestX[i] = slot.restX[i];
+                newRestY[i] = slot.restY[i];
+                exports.setBodyPosition!(cursor + i, x, y);
+            }
+            slot.bodyStart = cursor;
+            slot.restX = newRestX;
+            slot.restY = newRestY;
+            cursor += slot.bodyCount;
+        }
+        this.bodyCount = cursor;
+    }
+
+    private publishBreadcrumb(): void {
+        if (typeof window === 'undefined') return;
+        window.jellyMossSoftBodyActive = this.isActive;
+        window.jellyMossSoftBodyHeroCount = this.slots.length;
+    }
+}
+
+/** Shared instance used by environment / geological loop / startup. */
+export const jellyMossSoftBody = new JellyMossSoftBodySystem();
+
+declare global {
+    interface Window {
+        jellyMossSoftBodyActive?: boolean;
+        jellyMossSoftBodyHeroCount?: number;
+        wasmBackend?: string | null;
+    }
+}

--- a/src/main/loop_geological.ts
+++ b/src/main/loop_geological.ts
@@ -30,6 +30,8 @@ import {
 import type { VoidRootBallUpdateContext } from '../void_root_ball';
 import { isVoidRootTethered } from '../void_root_ball';
 import { CONFIG } from '../game_config';
+import { jellyMossSoftBody } from '../jelly_moss_softbody';
+
 export function updateLoopGeological(delta: number, time: number): void {
         // --- NEW: Update Geological Objects ---
         if (game.debugSystem.isEnabled('geologicalObjects')) {
@@ -119,6 +121,9 @@ export function updateLoopGeological(delta: number, time: number): void {
                         if (proj.mesh.position.distanceTo(jellyMoss.position) < hitRadius) {
                             proj.deactivate();
                             game.particleSystem.emit(proj.mesh.position.clone(), 0x00ff88, 8, 4.0, 0.4, 0.6);
+                            // C++ Verlet impulse (no-op on AS); direction from moss center toward hit
+                            const hitDir = proj.mesh.position.clone().sub(jellyMoss.position);
+                            jellyMossSoftBody.applyImpulse(jellyMoss, hitDir.x, hitDir.y);
                             jellyMoss.userData.health = (jellyMoss.userData.health || 10) - 5;
                             jellyMoss.userData.hitCount = (jellyMoss.userData.hitCount || 0) + 1;
                             if (jellyMoss.userData.health <= 0) {
@@ -151,6 +156,13 @@ export function updateLoopGeological(delta: number, time: number): void {
                     if (dist < radius) {
                         // 1. Viscosity
                         playerState.velocity.multiplyScalar(Math.pow(0.05, delta));
+
+                        // Soft-body push from player (C++ only)
+                        jellyMossSoftBody.applyPlayerProximity(
+                            jellyMoss,
+                            player.position.x - jellyMoss.position.x,
+                            player.position.y - jellyMoss.position.y
+                        );
 
                         // 2. Stealth Effect
                         if (!jellyMoss.userData.isHiding) {
@@ -268,6 +280,9 @@ export function updateLoopGeological(delta: number, time: number): void {
                     }
                 }
             }
+
+            // C++ Verlet soft-body step for hero Jelly-Moss cores (no-op on AS)
+            jellyMossSoftBody.update(delta);
     
             // Update solar sails (iridescent rippling, unfold near player)
             if (player) {

--- a/src/main/startup.ts
+++ b/src/main/startup.ts
@@ -28,6 +28,7 @@ import { applyCraftedLoadout } from './loadout';
 import { ShakeType } from '../juice_effects';
 import { hasDebugUrlFlag } from '../renderer_mode';
 import { loadWasm as loadWasmModule } from '../wasm_loader';
+import { jellyMossSoftBody } from '../jelly_moss_softbody';
 import {
     createGameContextFrameState,
     installGameContext,
@@ -56,7 +57,11 @@ async function loadWasm(): Promise<void> {
     if (handle) {
         game.wasmExports = handle.exports;
         game.wasmMemory = handle.memory;
+        game.wasmBackend = handle.backend;
+    } else {
+        game.wasmBackend = null;
     }
+    jellyMossSoftBody.bindWasm(handle);
 }
 
 import {
@@ -65,7 +70,8 @@ import {
     createSporeCloudAtPosition, createVoidRootBallAtPosition,
     createVacuumKelpAtPosition, createIceNeedleClusterAtPosition,
     createLiquidMetalBlobAtPosition, createMagmaHeartAtPosition,
-    createGravityAnchorAtPosition, createGeodeAtPosition
+    createGravityAnchorAtPosition, createGeodeAtPosition,
+    createJellyMossAtPosition
 } from '../environment';
 import {
     createGravityAnchorWithTarsiers,
@@ -122,6 +128,11 @@ export async function spawnDeferredPrototypeContent(): Promise<void> {
         radius: 1.8, mass: 4.5,
         velocity: new THREE.Vector3(-0.9, 0.2, 0), kind: 'wreckingBall'
     });
+
+    // Hero Nebula Jelly-Moss (1–3). With VITE_CPP_WASM + game_cpp.wasm, cores use Verlet soft-body.
+    createJellyMossAtPosition(120, 4, -22, 5.5);
+    createJellyMossAtPosition(210, -3, -20, 4.2);
+    createJellyMossAtPosition(340, 6, -24, 6.0);
 }
 
 export async function spawnDeferredVideoStars(): Promise<void> {

--- a/src/obstacle_system/types.ts
+++ b/src/obstacle_system/types.ts
@@ -13,6 +13,9 @@ noteGeometryCreated();
 export type GameplayModifiers = {
     shieldActive: boolean;
     shieldBouncesAsteroids: boolean;
+    invincible?: boolean;
+    obstaclesSlowed?: boolean;
+    obstacleSlowFactor?: number;
 };
 
 export type ObstacleWasmHandle = {

--- a/src/wasm_loader.ts
+++ b/src/wasm_loader.ts
@@ -40,7 +40,11 @@ export interface CoreWasmExports {
     getObjectPtr(): number;
 }
 
-/** Extra exports available only in the experimental C++ backend (unused by gameplay today). */
+/**
+ * Extra exports available only in the experimental C++ backend.
+ * Gameplay consumer: `jelly_moss_softbody.ts` (Verlet soft-body Jelly-Moss cores)
+ * when `VITE_CPP_WASM=true` and `game_cpp.wasm` is present.
+ */
 export interface CppExtrasExports {
     // Verlet physics
     allocPhysicsBodies(count: number): number;
@@ -97,6 +101,17 @@ async function fetchAndInstantiate(
 // Backend loaders
 // ---------------------------------------------------------------------------
 
+function publishWasmBackendBreadcrumb(backend: WasmBackend | null): void {
+    if (typeof window === 'undefined') return;
+    window.wasmBackend = backend;
+}
+
+declare global {
+    interface Window {
+        wasmBackend?: string | null;
+    }
+}
+
 async function loadAssemblyScript(): Promise<WasmHandle> {
     const { instance } = await fetchAndInstantiate('./build/optimized.wasm', {
         env: { abort: () => console.warn('[WASM-AS] abort() called') },
@@ -145,16 +160,21 @@ export async function loadWasm(backend?: WasmBackend): Promise<WasmHandle | null
 
     if (useCpp) {
         try {
-            return await loadCpp();
+            const handle = await loadCpp();
+            publishWasmBackendBreadcrumb(handle.backend);
+            return handle;
         } catch (err) {
             console.warn('⚠️ Experimental C++ WASM unavailable, falling back to AssemblyScript:', err);
         }
     }
 
     try {
-        return await loadAssemblyScript();
+        const handle = await loadAssemblyScript();
+        publishWasmBackendBreadcrumb(handle.backend);
+        return handle;
     } catch (err) {
         console.error('❌ Failed to load AssemblyScript WASM:', err);
+        publishWasmBackendBreadcrumb(null);
         return null;
     }
 }

--- a/tools/typecheck_baseline.cjs
+++ b/tools/typecheck_baseline.cjs
@@ -74,9 +74,17 @@ function main() {
     const current = parseErrors(output);
     const baseline = readBaseline();
 
-    if (update || baseline.size === 0) {
+    if (update) {
         writeBaseline(current);
         console.log(`Typecheck baseline updated: ${current.size} error(s) recorded at ${path.relative(ROOT, BASELINE_PATH)}`);
+        process.exit(0);
+    }
+
+    // Missing baseline file: seed once so the ratchet has something to compare.
+    // An intentional empty baseline (Count: 0) means "strict clean" — do not auto-write.
+    if (!fs.existsSync(BASELINE_PATH)) {
+        writeBaseline(current);
+        console.log(`Typecheck baseline created: ${current.size} error(s) recorded at ${path.relative(ROOT, BASELINE_PATH)}`);
         process.exit(0);
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Choice: **Option A — Soft-body Jelly-Moss (Verlet)**

Option B (fractal-noise biome density) was deferred; `fractalNoise2D` remains available for a follow-up.

## What changed

- New gameplay consumer [`src/jelly_moss_softbody.ts`](src/jelly_moss_softbody.ts) calls C++-only exports (`allocPhysicsBodies`, `stepPhysics`, body getters/setters) when `wasm.backend === Cpp`.
- Up to **3 hero Nebula Jelly-Moss** cores get a small spring net (TS springs + WASM Verlet). Projectile / player hits add impulses; core mesh XY is written back each frame.
- **Default AS path unchanged**: soft-body is idle; membrane shader wobble stays. Missing/null C++ wasm falls back without crash.
- Deferred prototype content spawns 3 hero mosses so the consumer is reachable in-game.
- Docs: [`docs/WASM_BACKENDS.md`](docs/WASM_BACKENDS.md), [`cpp/README.md`](cpp/README.md) — `VITE_CPP_WASM=true` + `npm run build:cpp-wasm` / `verify:cpp-wasm` / `verify:cpp-softbody`.
- Optional CI `cpp-wasm` job (still `continue-on-error`) also runs `verify:cpp-softbody`.
- `asc` flags remain AS-only; `refreshMemoryView` after `allocPhysicsBodies`; `BUILD_NATIVE_TESTS` stays off (CMake comment unchanged).
- Breadcrumbs: `window.wasmBackend`, `window.jellyMossSoftBodyActive`, `window.jellyMossSoftBodyHeroCount`.
- Side fix: typecheck ratchet no longer auto-writes when baseline is intentionally empty; obstacle `GameplayModifiers` includes fields the manager already used (restores `tsc --noEmit` clean).

## Verification

- `npm run check` — clean (0 tsc errors)
- `npm run test:smoke` — passed (AS / WebGL default)
- `npm run verify:cpp-wasm` + `verify:cpp-softbody` — passed
- `VITE_CPP_WASM=true` preview + `npm run smoke:cpp-softbody` — `wasmBackend=cpp`, `jellyMossSoftBodyActive` with 3 heroes after gameplay start

## How to try

```bash
npm run build:cpp-wasm
npm run verify:cpp-wasm
npm run verify:cpp-softbody
VITE_CPP_WASM=true npm run build && npx vite preview --port 4173
npm run smoke:cpp-softbody
```

## Acceptance

- [x] Written choice of A or B in the PR description
- [x] At least one gameplay system calls a C++-only export under `VITE_CPP_WASM=true`
- [x] Default AS path unchanged
- [x] `build:cpp-wasm` / `verify:cpp-wasm` documented; optional CI still non-blocking
- [x] Null / missing C++ wasm falls back without crash
- [x] No new npm physics libraries

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a37728ed-471d-499e-8a9b-07d5a8bf11cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a37728ed-471d-499e-8a9b-07d5a8bf11cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional C++ WASM-powered soft-body physics for hero Jelly-Moss cores.
  * Jelly-Moss now reacts to projectile impacts and player proximity with dynamic movement.
  * Added runtime visibility into the active WASM backend and soft-body status.

* **Bug Fixes**
  * Improved WASM verification and fallback behavior when the experimental backend is unavailable.

* **Documentation**
  * Clarified supported and experimental WASM backends, setup steps, troubleshooting, and runtime behavior.

* **Tests**
  * Added automated verification and browser smoke checks for C++ soft-body physics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->