### PR TITLE
Fix typecheck baseline and wire Cloud Castles end-to-end

### DIFF
--- a/.github/typecheck-baseline.txt
+++ b/.github/typecheck-baseline.txt
@@ -1,10 +1,4 @@
 # TypeScript error baseline — do not edit by hand unless you know what you are doing.
 # Regenerate with: npm run typecheck:baseline:update
-# Count: 7
-src/deferred_system_stubs.ts(1,15): TS2300: Duplicate identifier 'CandyFieldSystem'.
-src/deferred_system_stubs.ts(28,15): TS2300: Duplicate identifier 'CandyFieldSystem'.
-src/level_manager/environment_plugins.ts(31,188): TS2503: Cannot find namespace 'THREE'.
-src/level_manager/manager.ts(271,33): TS2345: Argument of type 'this' is not assignable to parameter of type 'LevelPluginHost'.
-src/level_manager/types.ts(122,5): TS2300: Duplicate identifier 'candyFieldSystem'.
-src/level_manager/types.ts(132,5): TS2300: Duplicate identifier 'candyFieldSystem'.
-src/level_manager/types.ts(132,5): TS2717: Subsequent property declarations must have the same type.  Property 'candyFieldSystem' must be of type '{ activate: () => void; deactivate: () => void; update: (delta: number, cameraX: number, playerPos?: Vector3 | undefined) => void; }', but here has type 'CandyFieldSystem'.
+# Count: 0
+

--- a/src/deferred_system_stubs.ts
+++ b/src/deferred_system_stubs.ts
@@ -25,7 +25,6 @@ import type { WishLanternSystem } from './wish_lanterns';
 import type { WeatherSystem } from './weather_system';
 import type { DancingJellyMossSystem } from './dancing_jelly_moss';
 import type { DynamicStarfieldSystem } from './dynamic_starfield';
-import type { CandyFieldSystem } from './candy_obstacles/candy_field_system';
 import type { DayNightCycleSystem } from './day_night_cycle';
 import type { CloudCastlesSystem } from './cloud_castles_system';
 import type { SingingGeodeSystem } from './singing_geodes';

--- a/src/level_config.ts
+++ b/src/level_config.ts
@@ -163,6 +163,7 @@ export type LevelEnvironments = {
     /** Secret bonus-room doorways (deferred chunk). */
     dreamPortals?: DreamPortalsEnvironmentConfig;
     singingGeodes?: boolean | { density?: number };
+    cloudCastles?: boolean | { density?: number };
 };
 
 // Cumulative player-x thresholds for the journey toward the Moon.
@@ -319,7 +320,8 @@ export const LEVEL_CONFIG: { [key: number]: LevelConfig } = {
             candyPlanetRing: true,
             wishLanterns: true,
             dancingJellyMoss: true,
-            dayNightCycle: { cycleDuration: 30 }
+            dayNightCycle: { cycleDuration: 30 },
+            cloudCastles: { density: 0.6 }
         },
         vignettes: {
             treeGroves: 1.5,

--- a/src/level_manager/environment_plugins.ts
+++ b/src/level_manager/environment_plugins.ts
@@ -1,3 +1,4 @@
+import type * as THREE from 'three';
 import type {
     LevelConfig,
     LevelEnvironments,
@@ -217,6 +218,11 @@ export function buildEnvironmentPlugins(
             flag: 'singingGeodes',
             activate: (config: any) => host.singingGeodeSystem.activate(typeof config === 'object' ? config.density : undefined),
             deactivate: () => host.singingGeodeSystem.deactivate()
+        },
+        {
+            flag: 'cloudCastles',
+            activate: (config: any) => host.cloudCastlesSystem.activate(typeof config === 'object' ? config : undefined),
+            deactivate: () => host.cloudCastlesSystem.deactivate()
         }
     ];
 }

--- a/src/level_manager/manager.ts
+++ b/src/level_manager/manager.ts
@@ -58,7 +58,7 @@ export class LevelManager {
     readonly windChimeManager: WindChimeManager;
     readonly solarSailFernManager: SolarSailFernManager;
     private readonly candyManager: CandyBeltManager;
-    readonly candyFieldSystem: { activate: () => void; deactivate: () => void; update: (delta: number, cameraX: number, playerPos?: THREE.Vector3) => void; };
+    readonly candyFieldSystem: LevelEnvironmentPorts['candyFieldSystem'];
     readonly getPlayer: () => THREE.Group | null;
     readonly spawners: GeologicalSpawners;
     readonly geologicalCounts: GeologicalCounts;
@@ -117,7 +117,6 @@ export class LevelManager {
         this.windChimeManager = options.windChimeManager;
         this.solarSailFernManager = options.solarSailFernManager;
         this.candyManager = options.candyManager;
-        this.candyFieldSystem = options.candyFieldSystem;
         this.getPlayer = options.getPlayer;
         this.spawners = options.spawners;
         this.geologicalCounts = options.geologicalCounts;
@@ -394,7 +393,7 @@ export class LevelManager {
         this.dancingJellyMossSystem.update(delta, cameraX, playerPos);
         this.dynamicStarfieldSystem.update(delta, cameraX, playerPos);
         this.dayNightCycleSystem.update(delta, cameraX, playerPos);
-        this.cloudCastlesSystem?.update(delta, cameraX, playerPos);
+        if (enabled('cloudCastles') && this.cloudCastlesSystem) this.cloudCastlesSystem.update(delta, cameraX, playerPos);
         if (enabled('candyPlanetRing')) this.candyFieldSystem.update(delta, cameraX, playerPos);
         this.candyFieldSystem?.update(delta, cameraX);
         if (enabled('singingGeodes') && this.singingGeodeSystem) this.singingGeodeSystem.update(delta, cameraX, playerPos);

--- a/src/level_manager/types.ts
+++ b/src/level_manager/types.ts
@@ -119,7 +119,6 @@ export type LevelManagerOptions = {
     windChimeManager: WindChimeManager;
     solarSailFernManager: SolarSailFernManager;
     candyManager: CandyBeltManager;
-    candyFieldSystem: { activate: () => void; deactivate: () => void; update: (delta: number, cameraX: number, playerPos?: THREE.Vector3) => void; };
     getPlayer: () => THREE.Group | null;
     spawners: GeologicalSpawners;
     geologicalCounts: GeologicalCounts;

--- a/src/level_systems_loader.ts
+++ b/src/level_systems_loader.ts
@@ -87,6 +87,13 @@ async function loadSystem(key: SystemKey): Promise<void> {
                 });
                 break;
             }
+            case 'cloudCastles': {
+                const { CloudCastlesSystem } = await import('./cloud_castles_system');
+                installEnvPartial({
+                    cloudCastlesSystem: new CloudCastlesSystem(scene)
+                });
+                break;
+            }
             case 'dayNightCycle': {
                 const { DayNightCycleSystem } = await import('./day_night_cycle');
                 installEnvPartial({
@@ -302,6 +309,7 @@ export function systemsNeededForLevel(cfg: LevelConfig | undefined): SystemKey[]
     if (isEnvironmentEnabled(env.dynamicStarfield)) keys.add('dynamicStarfield');
     if (isEnvironmentEnabled(env.dayNightCycle)) keys.add('dayNightCycle');
     if (isEnvironmentEnabled(env.singingGeodes)) keys.add('singingGeodes');
+    if (isEnvironmentEnabled(env.cloudCastles)) keys.add('cloudCastles');
     if (isEnvironmentEnabled(env.candyPlanetRing)) keys.add('candyPlanetRing');
 
     if ((cfg.chromaShiftDensity ?? 0) > 0) keys.add('chromaShift');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores a green CI typecheck gate and completes the Cloud Castles environment closed loop so the feature actually loads in gameplay.

## Changes

### Typecheck / baseline
- Removed duplicate `CandyFieldSystem` import in `deferred_system_stubs.ts`
- Removed duplicate `candyFieldSystem` entry in `LevelManagerOptions`
- Added missing `THREE` type import in `environment_plugins.ts`
- Aligned `LevelManager.candyFieldSystem` with `LevelEnvironmentPorts['candyFieldSystem']`
- Regenerated `.github/typecheck-baseline.txt` → **0 errors**

### Cloud Castles closed loop
- Added `cloudCastles?: boolean | { density?: number }` to `LevelEnvironments`
- `systemsNeededForLevel` now requests `cloudCastles` when the flag is enabled
- `loadSystem` dynamically imports `CloudCastlesSystem` and replaces the stub via `installEnvPartial`
- `buildEnvironmentPlugins` gains activate/deactivate handlers for `cloudCastles`
- Enabled on **Level 1 (The Neon Garden)** with `{ density: 0.6 }`
- Level manager update path gated on `enabled('cloudCastles')`

## Verification

- `npm run typecheck` — 0 errors
- `npm run typecheck:ci` — baseline OK (0 in baseline)
- `npm run check` — brace balance + typecheck ratchet green
- `npm run build` — production build succeeds; `cloud_castles_system` emitted as lazy chunk

## Acceptance criteria

- [x] `npm run typecheck` exits 0 with no baseline debt
- [x] `npm run typecheck:ci` and `npm run check` green
- [x] Cloud Castles load when level flag is on; stub replaced before first frame
- [x] Full env closed loop: config flag → systemsNeededForLevel → loadSystem → plugin activate
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e03b39e-8bcf-4879-84cb-ac1bf97b8425?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e03b39e-8bcf-4879-84cb-ac1bf97b8425&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cloud castles as an environment feature for supported levels.
  - Enabled cloud castles in Level 1 with adjustable density.
  - Cloud castles now load and activate automatically when configured.
- **Improvements**
  - Environment effects are managed more reliably during level transitions.
  - Cloud-castle updates can be controlled through the relevant debug setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->