### PR TITLE
Add level environment registry for closed-loop integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ When a TSL value is reassigned across node subtypes (e.g. `let total = float(0.0
 
 Gameplay systems are constructed in `createGameSystems()` / bootstrap (`src/main/startup.ts`), not at import time. Shared state is the typed `GameContext` on `game` (`src/game_runtime.ts`). Domain modules take ports — see `docs/GAME_CONTEXT.md`.
 
+**Environment features:** register in `src/level_env_registry.ts` (one entry for deferred systems). Do not land features via one-shot `patch_*.py` sed scripts — those caused half-wired systems (e.g. Cloud Castles). `npm run check:env-registry` validates the closed loop.
+
 ## Cursor Cloud specific instructions
 
 Standard commands live in `README.md` / `package.json` / `CLAUDE.md` (`npm run dev` on :5173, `npm run build`, `npm run check` for braces + typecheck ratchet). `predev`/`prebuild` rebuild the AssemblyScript WASM automatically, so no separate WASM step is needed for normal dev. There is no ESLint or unit-test suite; quality gates are brace check, typecheck baseline, production build, and Playwright smoke.

--- a/docs/GAME_CONTEXT.md
+++ b/docs/GAME_CONTEXT.md
@@ -5,8 +5,8 @@ Dog Dash constructs gameplay systems **once at bootstrap**, not at module import
 ## Where to construct a new system
 
 1. Prefer a class (or factory) in its own module under `src/` with an explicit constructor that takes `scene` / ports — **no** `import { scene } from './scene_context'` inside the system if you can avoid it.
-2. Instantiate it in [`src/create_game_systems.ts`](../src/create_game_systems.ts) (`createGameSystems`) when it is needed from Level 1 / always-on, **or** register a dynamic `import()` loader in [`src/level_systems_loader.ts`](../src/level_systems_loader.ts) when it is level-gated and code-split.
-3. Add the field to `GameSystems` / `GameContext` in [`src/game_runtime.ts`](../src/game_runtime.ts) (and `GameSystems` in `create_game_systems.ts` if it is an eager system).
+2. Instantiate it in [`src/create_game_systems.ts`](../src/create_game_systems.ts) when always-on, **or** register one entry in [`src/level_env_registry.ts`](../src/level_env_registry.ts) when level-gated and code-split (see “Adding a level environment flag” below).
+3. Add the field to `GameSystems` / `GameContext` in [`src/game_runtime.ts`](../src/game_runtime.ts) when the system lives on `game`.
 4. Wire cross-system callbacks in [`src/main/startup.ts`](../src/main/startup.ts) or [`src/main/startup_callbacks.ts`](../src/main/startup_callbacks.ts).
 
 Bootstrap flow:
@@ -42,7 +42,7 @@ Call `game.yourSystem.update(...)` (or a thin helper that takes ports from `game
 - **environment.ts**: call `bindEnvironmentSystems({ particleSystem, weaponSystem, liquidMetalSystem })` from bootstrap (and again only if liquid metal were ever swapped — today it is eager).
 - **StormGeodeSystem**: constructor `StormGeodeFxDeps` (`playHit`, `onBoltStrike`) — wired when the storm-geode chunk loads in `level_systems_loader.ts`.
 
-After a deferred module loads, [`level_systems_loader.ts`](../src/level_systems_loader.ts) assigns the real instance onto `game` and calls `game.levelManager.installEnvironmentSystems(...)` for environment ports so stubs are not left stale. Transitions **await** `ensureLevelSystemsForLevel(next)` before `startLevel`.
+After a deferred module loads, [`level_systems_loader.ts`](../src/level_systems_loader.ts) (via `level_env_registry.ts`) assigns the real instance onto `game` and calls `game.levelManager.installEnvironmentSystems(...)` for environment ports so stubs are not left stale. Transitions **await** `ensureLevelSystemsForLevel(next)` before `startLevel`.
 
 ## Heavy / deferred systems
 
@@ -57,7 +57,26 @@ See the chunk map in [`docs/PERFORMANCE_BUDGETS.md`](PERFORMANCE_BUDGETS.md).
 
 ## Adding a level environment flag
 
+Use the **closed-loop registry** in [`src/level_env_registry.ts`](../src/level_env_registry.ts) — do not hand-edit `level_systems_loader.ts` or scatter plugin entries.
+
+### Code-split (deferred) environment
+
 1. Extend `LevelEnvironments` in `level_config.ts`.
-2. Add activate/deactivate in `buildEnvironmentPlugins`.
-3. Ensure the system is on `LevelEnvironmentPorts` (if it is an env plugin) **or** assigned onto `game` from a loader key in `level_systems_loader.ts`, and add the flag → key mapping in `systemsNeededForLevel`.
-4. See also `docs/SIDE_SCROLLER_OBJECTS.md` and decoration / JS budgets in `docs/PERFORMANCE_BUDGETS.md`.
+2. Add **one** entry to `DEFERRED_ENV_REGISTRY` with:
+   - `load` — dynamic `import()` of the feature module
+   - `install` — construct the real system and call `installEnvPartial` (or assign onto `game` for non-port systems)
+   - `plugin` — `activate` / `deactivate` hooks for `buildEnvironmentPlugins`
+3. Add stub + `GameSystems` field in `create_game_systems.ts` if not already present.
+4. Add the flag to `PLUGIN_ORDER` in `level_manager/environment_plugins.ts` (preserves activation order).
+5. Enable the flag on the target level(s) in `LEVEL_CONFIG`.
+
+`DEFERRED_ENV_FLAGS` / `EAGER_ENV_FLAGS` must classify **every** `LevelEnvironments` key (compile-time exhaustiveness). `npm run check:env-registry` walks `LEVEL_CONFIG` and fails if a deferred flag has no loader.
+
+### Eager environment (always constructed at bootstrap)
+
+1. Extend `LevelEnvironments` in `level_config.ts`.
+2. Add activate/deactivate in `buildEagerEnvPlugins` inside `level_env_registry.ts`.
+3. Add the flag to `EAGER_ENV_FLAGS` and `PLUGIN_ORDER`.
+4. Ensure the system is on `LevelEnvironmentPorts` and wired in `create_game_systems.ts`.
+
+See also `docs/SIDE_SCROLLER_OBJECTS.md`, `docs/plans/COSMIC_ARCHITECT_TASK.md`, and decoration / JS budgets in `docs/PERFORMANCE_BUDGETS.md`.

--- a/docs/plans/COSMIC_ARCHITECT_TASK.md
+++ b/docs/plans/COSMIC_ARCHITECT_TASK.md
@@ -101,42 +101,30 @@ export class YourFeatureSystem {
 
 ---
 
-## 🔌 STEP 2: INTEGRATE VIA THE COMPOSITION ROOT
+## 🔌 STEP 2: INTEGRATE VIA THE REGISTRY (required)
 
-There is no monolithic `main.ts`. Systems are wired through the `GameContext` composition root (see `docs/GAME_CONTEXT.md`). You must touch up to 4 areas:
+There is no monolithic `main.ts`. Environment features must use the **closed-loop registry** in `src/level_env_registry.ts` (see `docs/GAME_CONTEXT.md`). Do **not** land features via one-shot Python patch scripts.
 
-### 2A: Instantiate your system
+### 2A: Deferred (code-split) environment
 
-Add construction in `createGameSystems()` (`src/create_game_systems.ts`) or bootstrap (`src/main/startup.ts`) near similar systems, and expose it on the typed `GameContext` (`src/game_runtime.ts`):
+1. Add stub + `GameSystems` field in `create_game_systems.ts` if needed.
+2. Add **one** entry to `DEFERRED_ENV_REGISTRY` with `load`, `install`, and `plugin` hooks.
+3. Append the flag to `PLUGIN_ORDER` in `level_manager/environment_plugins.ts`.
+4. Add `environments: { yourFeature: true }` in `LEVEL_CONFIG` for target level(s).
 
-```typescript
-// YOUR FEATURE SYSTEM
-const yourFeatureSystem = new YourFeatureSystem(scene /*, deps */);
-```
+### 2B: Eager environment (bootstrap stub / full system)
 
-### 2B: Activate/deactivate per level
+1. Construct in `create_game_systems.ts` and expose on `GameContext`.
+2. Add activate/deactivate to `buildEagerEnvPlugins` in `level_env_registry.ts`.
+3. Add the flag to `EAGER_ENV_FLAGS` and `PLUGIN_ORDER`.
 
-Level-conditional environment systems are registered as plugins in `src/level_manager/environment_plugins.ts` (flag in `LevelEnvironments`, `activate`/`deactivate`). Add a plugin entry (or extend an existing one) instead of hand-editing level `if/else` chains:
+### 2C: Per-frame update
 
-```typescript
-{
-    flag: 'yourFeature',
-    activate: () => host.yourFeatureSystem.activate(),
-    deactivate: () => host.yourFeatureSystem.deactivate()
-},
-```
+Hook `update()` from `level_manager/manager.ts` or the matching `src/main/loop_*.ts` module.
 
-### 2C: Add to the per-frame update loop
+### 2D: Cleanup
 
-Hook `update()` from the appropriate loop module under `src/main/` (e.g. `loop_world.ts`, `loop_geological.ts`) alongside similar systems:
-
-```typescript
-yourFeatureSystem.update(delta, cameraX, player ? player.position : undefined);
-```
-
-### 2D: Add to cleanup logic if your system adds scene objects
-
-Search for where `levelObjects` are cleaned up or where other systems call `cleanup()`. If your system spawns objects into `levelObjects`, ensure they get removed on level transition.
+Search for where other systems call `cleanup()` and mirror that pattern on level transition.
 
 ---
 
@@ -163,8 +151,9 @@ Before declaring done, verify:
 - [ ] **File created** under `src/` (e.g., `src/your_feature.ts`)
 - [ ] **Imports use `three/tsl` and `three/webgpu`** (not vanilla Three.js materials for custom shaders)
 - [ ] **`activate()` / `deactivate()` / `update()`** pattern followed
-- [ ] **Instantiation** added to the composition root (`createGameSystems()` / `src/main/startup.ts`) and exposed on `GameContext`
-- [ ] **Level-activation plugin** added in `src/level_manager/environment_plugins.ts` (if level-conditional)
+- [ ] **Registry entry** in `src/level_env_registry.ts` (deferred) or `buildEagerEnvPlugins` (eager)
+- [ ] **`PLUGIN_ORDER`** updated in `level_manager/environment_plugins.ts`
+- [ ] **`npm run check:env-registry`** passes
 - [ ] **Per-frame update hook** added in the matching `src/main/loop_*.ts` module
 - [ ] **Level config updated** (if new fields were added)
 - [ ] **Cleanup handled** — objects don't leak between levels

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "typecheck": "tsc --noEmit",
     "typecheck:ci": "node tools/typecheck_baseline.cjs",
     "typecheck:baseline:update": "node tools/typecheck_baseline.cjs --update",
-    "check": "node tools/check_braces.cjs && npm run typecheck:ci",
+    "check:env-registry": "node tools/check_level_env_registry.cjs",
+    "check": "node tools/check_braces.cjs && node tools/check_level_env_registry.cjs && npm run typecheck:ci",
     "test:smoke": "playwright test"
   },
   "keywords": [],

--- a/src/level_env_registry.ts
+++ b/src/level_env_registry.ts
@@ -1,0 +1,832 @@
+/**
+ * Single source of truth for deferred level-environment systems.
+ *
+ * Adding a new code-split env feature:
+ * 1. Extend `LevelEnvironments` in `level_config.ts`
+ * 2. Add one entry to `DEFERRED_ENV_REGISTRY` (load + install + plugin hooks)
+ * 3. Add stub + `GameSystems` field in `create_game_systems.ts` if not already present
+ *
+ * Eager env flags (bootstrap stubs / full systems) only need an entry in `EAGER_ENV_PLUGINS`.
+ */
+import type * as THREE from 'three';
+import type { LevelConfig, LevelEnvironments, AsteroidFieldEnvironmentConfig } from './level_config';
+import type { LevelEnvironmentPorts } from './level_manager/types';
+import type { LevelPluginHost, EnvPluginBuilder } from './level_manager/plugin_host';
+import { isEnvironmentEnabled } from './level_manager/types';
+import {
+    shouldSpawnStarlightKoi,
+    shouldSpawnBubbleCoral
+} from './level_spawn_rules';
+import type { ParticleSystem, DebrisSystem } from './particles';
+import type { AudioSystem } from './audio_system';
+import type { WeaponLightManager } from './lighting';
+import { createDreamPortalCallbacks } from './main/dream_portal_update';
+
+// ---------------------------------------------------------------------------
+// Env flag classification — every `LevelEnvironments` key must appear here.
+// ---------------------------------------------------------------------------
+
+/** Environment flags whose real implementation is dynamically imported. */
+export const DEFERRED_ENV_FLAGS = [
+    'candyPlanetRing',
+    'blackHole',
+    'industrial',
+    'waterfall',
+    'biological',
+    'cosmicDust',
+    'moonPalace',
+    'planetaryHorizon',
+    'reEntry',
+    'aquaticLife',
+    'ghostDebris',
+    'voidJellyfish',
+    'meteorShower',
+    'wishLanterns',
+    'dancingJellyMoss',
+    'weather',
+    'dynamicStarfield',
+    'dayNightCycle',
+    'galacticCore',
+    'dreamPortals',
+    'singingGeodes',
+    'cloudCastles'
+] as const satisfies readonly (keyof LevelEnvironments)[];
+
+/** Environment flags constructed eagerly at bootstrap (stub or full). */
+export const EAGER_ENV_FLAGS = [
+    'pastelNebula',
+    'butterflySwarm',
+    'nebula',
+    'nebulaRibbons',
+    'godRays',
+    'aurora',
+    'lightning',
+    'asteroidField',
+    'candyField',
+    'bubbleCoral'
+] as const satisfies readonly (keyof LevelEnvironments)[];
+
+type AllClassifiedEnvFlags = (typeof DEFERRED_ENV_FLAGS)[number] | (typeof EAGER_ENV_FLAGS)[number];
+type AssertAllEnvFlagsClassified = Exclude<keyof LevelEnvironments, AllClassifiedEnvFlags> extends never
+    ? true
+    : never;
+const _envFlagCoverage: AssertAllEnvFlagsClassified = true;
+void _envFlagCoverage;
+
+// ---------------------------------------------------------------------------
+// Deferred system keys (env-flag-driven + level-config predicates)
+// ---------------------------------------------------------------------------
+
+export const DEFERRED_LEVEL_SYSTEM_KEYS = [
+    'boss',
+    'chromaShift',
+    'stormGeode',
+    'industrialGeometry',
+    'starlightKoi',
+    'bubbleCoral',
+    'slingables'
+] as const;
+
+export type DeferredEnvSystemKey = (typeof DEFERRED_ENV_FLAGS)[number];
+export type DeferredLevelSystemKey = (typeof DEFERRED_LEVEL_SYSTEM_KEYS)[number];
+export type SystemKey = DeferredEnvSystemKey | DeferredLevelSystemKey;
+
+/** Runtime context passed to registry install hooks (kept narrow to avoid import cycles). */
+export type DeferredLoaderContext = {
+    scene: THREE.Scene;
+    camera: THREE.PerspectiveCamera;
+    game: DeferredGamePorts;
+    installEnvPartial: (partial: Partial<LevelEnvironmentPorts>) => void;
+    assignGameSystem: <K extends keyof DeferredGamePorts>(key: K, value: DeferredGamePorts[K]) => void;
+};
+
+export type DeferredGamePorts = {
+    weaponLightManager: WeaponLightManager;
+    audioSystem: AudioSystem;
+    particleSystem: ParticleSystem;
+    debrisSystem: DebrisSystem;
+    lightningBoltSystem: { onBoltStrike?: (pos: THREE.Vector3, color: THREE.Color) => void };
+    levelManager: {
+        installEnvironmentSystems: (partial: Partial<LevelEnvironmentPorts>) => void;
+        ghostDebrisSystem?: unknown;
+        voidJellyfishSystem?: unknown;
+        industrialGeometryManager?: unknown;
+    } | null;
+    ghostDebrisSystem: unknown;
+    voidJellyfishSystem: unknown;
+    industrialGeometryManager: unknown;
+    aquaticLifeManager: unknown;
+    starlightKoiManager: unknown;
+    bubbleCoralManager: unknown;
+    slingableObjectSystem: unknown;
+    toyRocketSpawnManager: unknown;
+    rewireSlingableCallbacks?: () => void;
+    bossManager: unknown;
+    dreamPortalSystem: unknown;
+};
+
+type DeferredEnvRegistryEntry<F extends DeferredEnvSystemKey> = {
+    flag: F;
+    systemKey: SystemKey;
+    load: () => Promise<Record<string, unknown>>;
+    install: (ctx: DeferredLoaderContext, mod: Record<string, unknown>) => void | Promise<void>;
+    plugin: EnvPluginBuilder;
+};
+
+type DeferredLevelRegistryEntry = {
+    systemKey: DeferredLevelSystemKey;
+    needsLoad: (cfg: LevelConfig) => boolean;
+    load: () => Promise<Record<string, unknown>>;
+    install: (ctx: DeferredLoaderContext, mod: Record<string, unknown>) => void | Promise<void>;
+};
+
+function objectConfig<T>(value: unknown): T | undefined {
+    return typeof value === 'object' && value !== null ? (value as T) : undefined;
+}
+
+function densityFromConfig(value: unknown): number | undefined {
+    const cfg = objectConfig<{ density?: number }>(value);
+    return cfg?.density;
+}
+
+// ---------------------------------------------------------------------------
+// Deferred env registry — one entry per code-split environment flag.
+// ---------------------------------------------------------------------------
+
+export const DEFERRED_ENV_REGISTRY: {
+    [F in DeferredEnvSystemKey]: DeferredEnvRegistryEntry<F>;
+} = {
+    reEntry: {
+        flag: 'reEntry',
+        systemKey: 'reEntry',
+        load: () => import('./reentry'),
+        install: (ctx, mod) => {
+            const { ReEntrySystem } = mod as typeof import('./reentry');
+            ctx.installEnvPartial({ reEntrySystem: new ReEntrySystem(ctx.scene, ctx.camera) });
+        },
+        plugin: (host, _cfg, levelLength) => ({
+            flag: 'reEntry',
+            activate: () => {
+                host.reEntrySystem.levelDistance = levelLength;
+                host.reEntrySystem.activate();
+            },
+            deactivate: () => host.reEntrySystem.deactivate()
+        })
+    },
+    waterfall: {
+        flag: 'waterfall',
+        systemKey: 'waterfall',
+        load: () => import('./waterfall'),
+        install: (ctx, mod) => {
+            const { WaterfallSystem } = mod as typeof import('./waterfall');
+            ctx.installEnvPartial({
+                waterfallSystem: new WaterfallSystem(ctx.scene, ctx.camera, ctx.game.weaponLightManager)
+            });
+        },
+        plugin: (host, _cfg, levelLength) => ({
+            flag: 'waterfall',
+            activate: () => {
+                host.waterfallSystem.levelDistance = levelLength;
+                host.waterfallSystem.activate();
+            },
+            deactivate: () => host.waterfallSystem.deactivate()
+        })
+    },
+    singingGeodes: {
+        flag: 'singingGeodes',
+        systemKey: 'singingGeodes',
+        load: () => import('./singing_geodes'),
+        install: (ctx, mod) => {
+            const { SingingGeodeSystem } = mod as typeof import('./singing_geodes');
+            ctx.installEnvPartial({
+                singingGeodeSystem: new SingingGeodeSystem(ctx.scene, ctx.game.audioSystem, ctx.game.particleSystem)
+            });
+        },
+        plugin: (host) => ({
+            flag: 'singingGeodes',
+            activate: (config) => host.singingGeodeSystem.activate(densityFromConfig(config)),
+            deactivate: () => host.singingGeodeSystem.deactivate()
+        })
+    },
+    cloudCastles: {
+        flag: 'cloudCastles',
+        systemKey: 'cloudCastles',
+        load: () => import('./cloud_castles_system'),
+        install: (ctx, mod) => {
+            const { CloudCastlesSystem } = mod as typeof import('./cloud_castles_system');
+            ctx.installEnvPartial({ cloudCastlesSystem: new CloudCastlesSystem(ctx.scene) });
+        },
+        plugin: (host) => ({
+            flag: 'cloudCastles',
+            activate: (config) => host.cloudCastlesSystem.activate(objectConfig(config)),
+            deactivate: () => host.cloudCastlesSystem.deactivate()
+        })
+    },
+    dayNightCycle: {
+        flag: 'dayNightCycle',
+        systemKey: 'dayNightCycle',
+        load: () => import('./day_night_cycle'),
+        install: (ctx, mod) => {
+            const { DayNightCycleSystem } = mod as typeof import('./day_night_cycle');
+            ctx.installEnvPartial({ dayNightCycleSystem: new DayNightCycleSystem(ctx.scene, ctx.camera) });
+        },
+        plugin: (host) => ({
+            flag: 'dayNightCycle',
+            activate: (config) => host.dayNightCycleSystem.activate(objectConfig(config)),
+            deactivate: () => host.dayNightCycleSystem.deactivate()
+        })
+    },
+    dancingJellyMoss: {
+        flag: 'dancingJellyMoss',
+        systemKey: 'dancingJellyMoss',
+        load: () => import('./dancing_jelly_moss'),
+        install: (ctx, mod) => {
+            const { DancingJellyMossSystem } = mod as typeof import('./dancing_jelly_moss');
+            ctx.installEnvPartial({ dancingJellyMossSystem: new DancingJellyMossSystem(ctx.scene) });
+        },
+        plugin: (host) => ({
+            flag: 'dancingJellyMoss',
+            activate: (config) => host.dancingJellyMossSystem.activate(objectConfig(config)),
+            deactivate: () => host.dancingJellyMossSystem.deactivate()
+        })
+    },
+    dynamicStarfield: {
+        flag: 'dynamicStarfield',
+        systemKey: 'dynamicStarfield',
+        load: () => import('./dynamic_starfield'),
+        install: (ctx, mod) => {
+            const { DynamicStarfieldSystem } = mod as typeof import('./dynamic_starfield');
+            ctx.installEnvPartial({ dynamicStarfieldSystem: new DynamicStarfieldSystem(ctx.scene) });
+        },
+        plugin: (host) => ({
+            flag: 'dynamicStarfield',
+            activate: (config) => host.dynamicStarfieldSystem.activate(objectConfig(config)),
+            deactivate: () => host.dynamicStarfieldSystem.deactivate()
+        })
+    },
+    weather: {
+        flag: 'weather',
+        systemKey: 'weather',
+        load: () => import('./weather_system'),
+        install: (ctx, mod) => {
+            const { WeatherSystem } = mod as typeof import('./weather_system');
+            ctx.installEnvPartial({ weatherSystem: new WeatherSystem(ctx.scene) });
+        },
+        plugin: (host) => ({
+            flag: 'weather',
+            activate: () => host.weatherSystem.activate(),
+            deactivate: () => host.weatherSystem.deactivate()
+        })
+    },
+    wishLanterns: {
+        flag: 'wishLanterns',
+        systemKey: 'wishLanterns',
+        load: () => import('./wish_lanterns'),
+        install: (ctx, mod) => {
+            const { WishLanternSystem } = mod as typeof import('./wish_lanterns');
+            ctx.installEnvPartial({ wishLanternSystem: new WishLanternSystem(ctx.scene) });
+        },
+        plugin: (host) => ({
+            flag: 'wishLanterns',
+            activate: () => host.wishLanternSystem.activate(),
+            deactivate: () => host.wishLanternSystem.deactivate()
+        })
+    },
+    meteorShower: {
+        flag: 'meteorShower',
+        systemKey: 'meteorShower',
+        load: () => import('./meteor_shower'),
+        install: (ctx, mod) => {
+            const { MeteorShowerSystem } = mod as typeof import('./meteor_shower');
+            ctx.installEnvPartial({
+                meteorShowerSystem: new MeteorShowerSystem(ctx.scene, ctx.game.weaponLightManager)
+            });
+        },
+        plugin: (host) => ({
+            flag: 'meteorShower',
+            activate: () => host.meteorShowerSystem.activate(),
+            deactivate: () => host.meteorShowerSystem.deactivate()
+        })
+    },
+    industrial: {
+        flag: 'industrial',
+        systemKey: 'industrial',
+        load: () => import('./industrial_background'),
+        install: (ctx, mod) => {
+            const { IndustrialBackgroundSystem } = mod as typeof import('./industrial_background');
+            ctx.installEnvPartial({
+                industrialSystem: new IndustrialBackgroundSystem(ctx.scene, ctx.game.weaponLightManager)
+            });
+        },
+        plugin: (host) => ({
+            flag: 'industrial',
+            activate: (config) => host.industrialSystem.activate(objectConfig(config)),
+            deactivate: () => host.industrialSystem.deactivate()
+        })
+    },
+    biological: {
+        flag: 'biological',
+        systemKey: 'biological',
+        load: () => import('./biological_background'),
+        install: (ctx, mod) => {
+            const { BiologicalBackgroundSystem } = mod as typeof import('./biological_background');
+            ctx.installEnvPartial({ biologicalSystem: new BiologicalBackgroundSystem(ctx.scene) });
+        },
+        plugin: (host, cfg) => ({
+            flag: 'biological',
+            activate: () => {
+                host.biologicalSystem.activate();
+                host.cloudSystem.layers.forEach((l) => {
+                    l.mesh.visible = false;
+                });
+            },
+            deactivate: () => {
+                host.biologicalSystem.deactivate();
+                const cloudsVisible = (cfg.foliageDensity.cloud ?? 20) > 0;
+                host.cloudSystem.layers.forEach((l) => {
+                    l.mesh.visible = cloudsVisible;
+                });
+            }
+        })
+    },
+    candyPlanetRing: {
+        flag: 'candyPlanetRing',
+        systemKey: 'candyPlanetRing',
+        load: () => import('./candy_obstacles'),
+        install: (ctx, mod) => {
+            const { CandyFieldSystem } = mod as typeof import('./candy_obstacles');
+            ctx.installEnvPartial({ candyFieldSystem: new CandyFieldSystem(ctx.scene) });
+        },
+        plugin: (host) => ({
+            flag: 'candyPlanetRing',
+            activate: () => host.candyFieldSystem.activate(),
+            deactivate: () => host.candyFieldSystem.deactivate()
+        })
+    },
+    cosmicDust: {
+        flag: 'cosmicDust',
+        systemKey: 'cosmicDust',
+        load: () => import('./cosmic_dust'),
+        install: (ctx, mod) => {
+            const { CosmicDustSystem } = mod as typeof import('./cosmic_dust');
+            ctx.installEnvPartial({
+                cosmicDustSystem: new CosmicDustSystem(ctx.scene, ctx.game.weaponLightManager)
+            });
+        },
+        plugin: (host) => ({
+            flag: 'cosmicDust',
+            activate: () => {
+                host.cosmicDustSystem.activate();
+                host.nebulaSystem.activateRibbons();
+            },
+            deactivate: () => {
+                host.cosmicDustSystem.deactivate();
+                host.nebulaSystem.deactivateRibbons();
+            }
+        })
+    },
+    planetaryHorizon: {
+        flag: 'planetaryHorizon',
+        systemKey: 'planetaryHorizon',
+        load: () => import('./planetary_horizon'),
+        install: (ctx, mod) => {
+            const { PlanetaryHorizonSystem } = mod as typeof import('./planetary_horizon');
+            ctx.installEnvPartial({
+                planetaryHorizonSystem: new PlanetaryHorizonSystem(ctx.scene, ctx.camera)
+            });
+        },
+        plugin: (host, _cfg, levelLength) => ({
+            flag: 'planetaryHorizon',
+            activate: () => {
+                host.planetaryHorizonSystem.levelDistance = levelLength;
+                host.planetaryHorizonSystem.activate();
+            },
+            deactivate: () => host.planetaryHorizonSystem.deactivate()
+        })
+    },
+    moonPalace: {
+        flag: 'moonPalace',
+        systemKey: 'moonPalace',
+        load: () => import('./moon_palace'),
+        install: (ctx, mod) => {
+            const { MoonPalaceSystem } = mod as typeof import('./moon_palace');
+            ctx.installEnvPartial({
+                moonPalaceSystem: new MoonPalaceSystem(ctx.scene, ctx.camera, ctx.game.weaponLightManager)
+            });
+        },
+        plugin: (host, _cfg, levelLength) => ({
+            flag: 'moonPalace',
+            activate: () => {
+                host.moonPalaceSystem.levelDistance = levelLength;
+                host.moonPalaceSystem.activate();
+            },
+            deactivate: () => host.moonPalaceSystem.deactivate()
+        })
+    },
+    blackHole: {
+        flag: 'blackHole',
+        systemKey: 'blackHole',
+        load: () => import('./black_hole'),
+        install: (ctx, mod) => {
+            const { BlackHoleSystem } = mod as typeof import('./black_hole');
+            ctx.installEnvPartial({ blackHoleSystem: new BlackHoleSystem(ctx.scene) });
+        },
+        plugin: (host) => ({
+            flag: 'blackHole',
+            activate: (config) => host.blackHoleSystem.activate(config),
+            deactivate: () => host.blackHoleSystem.deactivate()
+        })
+    },
+    galacticCore: {
+        flag: 'galacticCore',
+        systemKey: 'galacticCore',
+        load: () => import('./galactic_core'),
+        install: (ctx, mod) => {
+            const { GalacticCoreSystem } = mod as typeof import('./galactic_core');
+            ctx.installEnvPartial({ galacticCoreSystem: new GalacticCoreSystem(ctx.scene) });
+        },
+        plugin: (host) => ({
+            flag: 'galacticCore',
+            activate: (config) => host.galacticCoreSystem.activate(config),
+            deactivate: () => host.galacticCoreSystem.deactivate()
+        })
+    },
+    dreamPortals: {
+        flag: 'dreamPortals',
+        systemKey: 'dreamPortals',
+        load: () => import('./dream_portal'),
+        install: (ctx, mod) => {
+            const { DreamPortalSystem } = mod as typeof import('./dream_portal');
+            ctx.assignGameSystem(
+                'dreamPortalSystem',
+                new DreamPortalSystem(ctx.scene, createDreamPortalCallbacks())
+            );
+        },
+        plugin: () => ({
+            flag: 'dreamPortals',
+            activate: () => undefined,
+            deactivate: () => undefined
+        })
+    },
+    ghostDebris: {
+        flag: 'ghostDebris',
+        systemKey: 'ghostDebris',
+        load: () => import('./ghost_debris'),
+        install: (ctx, mod) => {
+            const { GhostDebrisSystem } = mod as typeof import('./ghost_debris');
+            const instance = new GhostDebrisSystem(ctx.scene);
+            ctx.game.ghostDebrisSystem = instance;
+            if (ctx.game.levelManager) {
+                ctx.game.levelManager.ghostDebrisSystem = instance;
+            }
+        },
+        plugin: (host) => ({
+            flag: 'ghostDebris',
+            activate: () => host.ghostDebrisSystem.activate(),
+            deactivate: () => host.ghostDebrisSystem.deactivate()
+        })
+    },
+    voidJellyfish: {
+        flag: 'voidJellyfish',
+        systemKey: 'voidJellyfish',
+        load: () => import('./void_jellyfish'),
+        install: (ctx, mod) => {
+            const { VoidJellyfishSystem } = mod as typeof import('./void_jellyfish');
+            const instance = new VoidJellyfishSystem(ctx.scene);
+            ctx.game.voidJellyfishSystem = instance;
+            if (ctx.game.levelManager) {
+                ctx.game.levelManager.voidJellyfishSystem = instance;
+            }
+        },
+        plugin: (host) => ({
+            flag: 'voidJellyfish',
+            activate: (config) => host.voidJellyfishSystem.activate(config),
+            deactivate: () => host.voidJellyfishSystem.deactivate()
+        })
+    },
+    aquaticLife: {
+        flag: 'aquaticLife',
+        systemKey: 'aquaticLife',
+        load: () => import('./aquatic_life'),
+        install: (ctx, mod) => {
+            const { AquaticLifeManager } = mod as typeof import('./aquatic_life');
+            ctx.game.aquaticLifeManager = new AquaticLifeManager(ctx.scene);
+        },
+        plugin: () => ({
+            flag: 'aquaticLife',
+            activate: () => undefined,
+            deactivate: () => undefined
+        })
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Non-env deferred systems (density / objective / spawn-rule driven)
+// ---------------------------------------------------------------------------
+
+export const DEFERRED_LEVEL_REGISTRY: Record<DeferredLevelSystemKey, DeferredLevelRegistryEntry> = {
+    boss: {
+        systemKey: 'boss',
+        needsLoad: (cfg) => cfg.objective?.type === 'boss',
+        load: () => import('./boss_system'),
+        install: (ctx, mod) => {
+            const { BossManager } = mod as typeof import('./boss_system');
+            ctx.assignGameSystem('bossManager', new BossManager(ctx.scene));
+        }
+    },
+    chromaShift: {
+        systemKey: 'chromaShift',
+        needsLoad: (cfg) => (cfg.chromaShiftDensity ?? 0) > 0,
+        load: () => import('./chroma_shift'),
+        install: (ctx, mod) => {
+            const { ChromaShiftSystem } = mod as typeof import('./chroma_shift');
+            ctx.installEnvPartial({ chromaShiftSystem: new ChromaShiftSystem(ctx.scene) });
+        }
+    },
+    stormGeode: {
+        systemKey: 'stormGeode',
+        needsLoad: (cfg) => (cfg.stormGeodeDensity ?? 0) > 0,
+        load: () => import('./storm_geodes'),
+        install: (ctx, mod) => {
+            const { StormGeodeSystem } = mod as typeof import('./storm_geodes');
+            ctx.installEnvPartial({
+                stormGeodeSystem: new StormGeodeSystem(ctx.scene, {
+                    playHit: () => ctx.game.audioSystem.play('hit'),
+                    onBoltStrike: (pos, color) => ctx.game.lightningBoltSystem.onBoltStrike?.(pos, color)
+                })
+            });
+        }
+    },
+    industrialGeometry: {
+        systemKey: 'industrialGeometry',
+        needsLoad: (cfg) => cfg.levelType === 'tunnel' || cfg.levelType === 'organic_tunnel',
+        load: () => import('./industrial_geometry'),
+        install: (ctx, mod) => {
+            const { IndustrialGeometryManager } = mod as typeof import('./industrial_geometry');
+            const instance = new IndustrialGeometryManager(ctx.scene);
+            ctx.game.industrialGeometryManager = instance;
+            if (ctx.game.levelManager) {
+                ctx.game.levelManager.industrialGeometryManager = instance;
+            }
+        }
+    },
+    starlightKoi: {
+        systemKey: 'starlightKoi',
+        needsLoad: (cfg) => shouldSpawnStarlightKoi(cfg.environments, cfg.koiSchoolDensity),
+        load: () => import('./starlight_koi'),
+        install: (ctx, mod) => {
+            const { StarlightKoiManager } = mod as typeof import('./starlight_koi');
+            ctx.game.starlightKoiManager = new StarlightKoiManager(ctx.scene, ctx.game.particleSystem);
+        }
+    },
+    bubbleCoral: {
+        systemKey: 'bubbleCoral',
+        needsLoad: (cfg) => shouldSpawnBubbleCoral(cfg.environments, cfg.bubbleCoralDensity),
+        load: () => import('./bubble_coral'),
+        install: (ctx, mod) => {
+            const { RainbowBubbleCoralManager } = mod as typeof import('./bubble_coral');
+            ctx.game.bubbleCoralManager = new RainbowBubbleCoralManager(ctx.scene, ctx.game.particleSystem);
+        }
+    },
+    slingables: {
+        systemKey: 'slingables',
+        needsLoad: (cfg) => (cfg.toyRocketCount ?? 0) > 0 || cfg.objective?.type === 'sling',
+        load: async () => {
+            const [slingables, rockets] = await Promise.all([
+                import('./slingable_objects'),
+                import('./toy_rockets')
+            ]);
+            return { ...slingables, ...rockets };
+        },
+        install: (ctx, mod) => {
+            const { SlingableObjectSystem, ToyRocketSpawnManager } = mod as typeof import('./slingable_objects') &
+                typeof import('./toy_rockets');
+            const slingableObjectSystem = new SlingableObjectSystem(
+                ctx.scene,
+                ctx.game.particleSystem,
+                ctx.game.debrisSystem
+            );
+            ctx.game.slingableObjectSystem = slingableObjectSystem;
+            ctx.game.toyRocketSpawnManager = new ToyRocketSpawnManager(slingableObjectSystem);
+            if (typeof ctx.game.rewireSlingableCallbacks === 'function') {
+                ctx.game.rewireSlingableCallbacks();
+            }
+        }
+    }
+};
+
+// Compile-time: registry keys must match DEFERRED_ENV_FLAGS
+type RegistryDeferredKeys = keyof typeof DEFERRED_ENV_REGISTRY;
+type AssertRegistryMatchesFlags = Exclude<DeferredEnvSystemKey, RegistryDeferredKeys> extends never
+    ? Exclude<RegistryDeferredKeys, DeferredEnvSystemKey> extends never
+        ? true
+        : never
+    : never;
+const _registryFlagCoverage: AssertRegistryMatchesFlags = true;
+void _registryFlagCoverage;
+
+type RegistryLevelKeys = keyof typeof DEFERRED_LEVEL_REGISTRY;
+type AssertLevelRegistryMatchesKeys = Exclude<DeferredLevelSystemKey, RegistryLevelKeys> extends never
+    ? Exclude<RegistryLevelKeys, DeferredLevelSystemKey> extends never
+        ? true
+        : never
+    : never;
+const _levelRegistryCoverage: AssertLevelRegistryMatchesKeys = true;
+void _levelRegistryCoverage;
+
+// ---------------------------------------------------------------------------
+// Eager environment plugins (no dynamic import — system exists at bootstrap)
+// ---------------------------------------------------------------------------
+
+export const EAGER_ENV_PLUGIN_ORDER = [
+    'pastelNebula',
+    'candyField',
+    'butterflySwarm',
+    'nebula',
+    'nebulaRibbons',
+    'godRays',
+    'aurora',
+    'lightning',
+    'asteroidField',
+    'bubbleCoral'
+] as const satisfies readonly (typeof EAGER_ENV_FLAGS)[number][];
+
+export function buildEagerEnvPlugins(
+    host: LevelPluginHost,
+    cfg: LevelConfig,
+    levelLength: number
+): ReturnType<EnvPluginBuilder>[] {
+    const plugins: ReturnType<EnvPluginBuilder>[] = [];
+
+    for (const flag of EAGER_ENV_PLUGIN_ORDER) {
+        switch (flag) {
+            case 'pastelNebula':
+                plugins.push({
+                    flag,
+                    activate: () => host.pastelNebulaSystem.activate(),
+                    deactivate: () => host.pastelNebulaSystem.deactivate()
+                });
+                break;
+            case 'candyField':
+                plugins.push({
+                    flag,
+                    activate: () => host.candyFieldSystem.activate(),
+                    deactivate: () => host.candyFieldSystem.deactivate()
+                });
+                break;
+            case 'butterflySwarm':
+                plugins.push({
+                    flag,
+                    activate: () => host.butterflySwarmSystem.activate(),
+                    deactivate: () => host.butterflySwarmSystem.deactivate()
+                });
+                break;
+            case 'nebula':
+                plugins.push({
+                    flag,
+                    activate: () => {
+                        host.nebulaSystem.activate();
+                        host.nebulaSystem.activateRibbons();
+                    },
+                    deactivate: () => host.nebulaSystem.deactivate()
+                });
+                break;
+            case 'nebulaRibbons':
+                plugins.push({
+                    flag,
+                    activate: () => host.nebulaSystem.activateRibbons(),
+                    deactivate: () => host.nebulaSystem.deactivateRibbons()
+                });
+                break;
+            case 'godRays':
+                plugins.push({
+                    flag,
+                    activate: (config) => host.godRaySystem.activate(config),
+                    deactivate: () => host.godRaySystem.deactivate()
+                });
+                break;
+            case 'aurora':
+                plugins.push({
+                    flag,
+                    activate: (config) => host.auroraSystem.activate(config),
+                    deactivate: () => host.auroraSystem.deactivate()
+                });
+                break;
+            case 'lightning':
+                plugins.push({
+                    flag,
+                    activate: (config) => host.lightningBoltSystem.activate(config),
+                    deactivate: () => host.lightningBoltSystem.deactivate()
+                });
+                break;
+            case 'asteroidField':
+                plugins.push({
+                    flag,
+                    activate: (config: AsteroidFieldEnvironmentConfig) => {
+                        host.asteroidFieldSystem.activate();
+                        host.baseAsteroidDensity = config.rate * 0.5;
+                        host.asteroidFieldSystem.setDensity(host.baseAsteroidDensity * host.objectDensityMultiplier);
+                        host.asteroidFieldSystem.setCandyChance(cfg.candyAsteroidChance ?? 0);
+                        host.asteroidFieldSystem.resetPositions(host.camera.position.x);
+                    },
+                    deactivate: () => {
+                        host.baseAsteroidDensity = 0;
+                        host.asteroidFieldSystem.deactivate();
+                    }
+                });
+                break;
+            case 'bubbleCoral':
+                plugins.push({
+                    flag,
+                    activate: () => undefined,
+                    deactivate: () => undefined
+                });
+                break;
+        }
+    }
+
+    return plugins;
+}
+
+/** Plugin order for deferred env flags (must match prior behaviour). */
+export const DEFERRED_ENV_PLUGIN_ORDER: DeferredEnvSystemKey[] = [
+    'dynamicStarfield',
+    'dayNightCycle',
+    'candyPlanetRing',
+    'wishLanterns',
+    'blackHole',
+    'galacticCore',
+    'industrial',
+    'waterfall',
+    'planetaryHorizon',
+    'moonPalace',
+    'reEntry',
+    'biological',
+    'cosmicDust',
+    'ghostDebris',
+    'voidJellyfish',
+    'meteorShower',
+    'dancingJellyMoss',
+    'weather',
+    'singingGeodes',
+    'cloudCastles'
+];
+
+export function buildDeferredEnvPlugins(
+    host: LevelPluginHost,
+    cfg: LevelConfig,
+    levelLength: number
+): ReturnType<EnvPluginBuilder>[] {
+    return DEFERRED_ENV_PLUGIN_ORDER.map((flag) =>
+        DEFERRED_ENV_REGISTRY[flag].plugin(host, cfg, levelLength)
+    );
+}
+
+export function systemsNeededForLevel(cfg: LevelConfig | undefined): SystemKey[] {
+    if (!cfg) return [];
+    const keys = new Set<SystemKey>();
+    const env = cfg.environments || {};
+
+    for (const flag of DEFERRED_ENV_FLAGS) {
+        if (isEnvironmentEnabled(env[flag])) {
+            keys.add(DEFERRED_ENV_REGISTRY[flag].systemKey);
+        }
+    }
+
+    for (const entry of Object.values(DEFERRED_LEVEL_REGISTRY)) {
+        if (entry.needsLoad(cfg)) {
+            keys.add(entry.systemKey);
+        }
+    }
+
+    return [...keys];
+}
+
+const SYSTEM_LOADERS: Record<SystemKey, () => Promise<Record<string, unknown>>> = {
+    ...Object.fromEntries(
+        Object.values(DEFERRED_ENV_REGISTRY).map((entry) => [entry.systemKey, entry.load])
+    ) as Record<DeferredEnvSystemKey, () => Promise<Record<string, unknown>>>,
+    ...Object.fromEntries(
+        Object.values(DEFERRED_LEVEL_REGISTRY).map((entry) => [entry.systemKey, entry.load])
+    ) as Record<DeferredLevelSystemKey, () => Promise<Record<string, unknown>>>
+};
+
+const SYSTEM_INSTALLERS: Record<
+    SystemKey,
+    (ctx: DeferredLoaderContext, mod: Record<string, unknown>) => void | Promise<void>
+> = {
+    ...Object.fromEntries(
+        Object.values(DEFERRED_ENV_REGISTRY).map((entry) => [entry.systemKey, entry.install])
+    ) as Record<DeferredEnvSystemKey, (ctx: DeferredLoaderContext, mod: Record<string, unknown>) => void>,
+    ...Object.fromEntries(
+        Object.values(DEFERRED_LEVEL_REGISTRY).map((entry) => [entry.systemKey, entry.install])
+    ) as Record<DeferredLevelSystemKey, (ctx: DeferredLoaderContext, mod: Record<string, unknown>) => void>
+};
+
+export async function installDeferredSystem(key: SystemKey, ctx: DeferredLoaderContext): Promise<void> {
+    const mod = await SYSTEM_LOADERS[key]();
+    await SYSTEM_INSTALLERS[key](ctx, mod);
+}
+
+/** All deferred system keys (for tests and validation scripts). */
+export const ALL_DEFERRED_SYSTEM_KEYS = Object.keys(SYSTEM_LOADERS) as SystemKey[];

--- a/src/level_manager/environment_plugins.ts
+++ b/src/level_manager/environment_plugins.ts
@@ -1,230 +1,74 @@
-import type * as THREE from 'three';
 import type {
     LevelConfig,
-    LevelEnvironments,
-    GodRaysEnvironmentConfig,
-    AuroraEnvironmentConfig,
-    LightningEnvironmentConfig,
-    AsteroidFieldEnvironmentConfig
+    LevelEnvironments
 } from '../level_config';
-import type { EnvironmentPlugin, LevelEnvironmentPorts } from './types';
+import type { EnvironmentPlugin } from './types';
 import { isEnvironmentEnabled } from './types';
+import type { LevelPluginHost } from './plugin_host';
+import {
+    buildDeferredEnvPlugins,
+    buildEagerEnvPlugins
+} from '../level_env_registry';
 
-/** Systems registry host for environment plugin activation. */
-export interface LevelPluginHost extends LevelEnvironmentPorts {
-    butterflySwarmSystem: { activate: () => void; deactivate: () => void };
-    cloudSystem: { layers: { mesh: { visible: boolean } }[] };
-    godRaySystem: { activate: (config: GodRaysEnvironmentConfig) => void; deactivate: () => void };
-    auroraSystem: { activate: (config: AuroraEnvironmentConfig) => void; deactivate: () => void };
-    ghostDebrisSystem: { activate: () => void; deactivate: () => void };
-    voidJellyfishSystem: { activate: (config: NonNullable<LevelEnvironments['voidJellyfish']>) => void; deactivate: () => void };
-    camera: { position: { x: number } };
-    baseAsteroidDensity: number;
-    objectDensityMultiplier: number;
-    moonPalaceSystem: LevelEnvironmentPorts['moonPalaceSystem'] & { levelDistance: number; activate: () => void; deactivate: () => void };
-    wishLanternSystem: LevelEnvironmentPorts['wishLanternSystem'] & { activate: () => void; deactivate: () => void };
-    weatherSystem: LevelEnvironmentPorts['weatherSystem'] & { activate: () => void; deactivate: () => void };
-    dancingJellyMossSystem: LevelEnvironmentPorts['dancingJellyMossSystem'] & { activate: (config?: any) => void; deactivate: () => void };
-    dynamicStarfieldSystem: LevelEnvironmentPorts['dynamicStarfieldSystem'] & { activate: (config?: any) => void; deactivate: () => void };
-    dayNightCycleSystem: LevelEnvironmentPorts['dayNightCycleSystem'] & { activate: (config?: any) => void; deactivate: () => void };
-    cloudCastlesSystem: LevelEnvironmentPorts['cloudCastlesSystem'] & { activate: (config?: any) => void; deactivate: () => void; cleanup: () => void };
-    candyFieldSystem: LevelEnvironmentPorts['candyFieldSystem'] & { activate: (config?: any) => void; deactivate: () => void; setVisible: (visible: boolean) => void; update: (delta: number, cameraX: number) => void };
-    singingGeodeSystem: LevelEnvironmentPorts['singingGeodeSystem'] & { activate: (density?: number) => void; deactivate: () => void; update: (delta: number, cameraX: number, playerPos?: THREE.Vector3) => void; cleanup: () => void; };
-}
+export type { LevelPluginHost } from './plugin_host';
 
 /** Discriminated union of plugins keyed by environment flag, so each
  * `activate` receives its own config type. */
 type AnyEnvironmentPlugin = { [K in keyof LevelEnvironments]-?: EnvironmentPlugin<K> }[keyof LevelEnvironments];
+
+/** Plugin order preserved for level transitions (matches pre-registry behaviour). */
+const PLUGIN_ORDER = [
+    'dynamicStarfield',
+    'dayNightCycle',
+    'candyPlanetRing',
+    'pastelNebula',
+    'candyField',
+    'wishLanterns',
+    'butterflySwarm',
+    'blackHole',
+    'galacticCore',
+    'industrial',
+    'waterfall',
+    'planetaryHorizon',
+    'moonPalace',
+    'reEntry',
+    'biological',
+    'nebula',
+    'nebulaRibbons',
+    'cosmicDust',
+    'godRays',
+    'aurora',
+    'lightning',
+    'asteroidField',
+    'ghostDebris',
+    'voidJellyfish',
+    'meteorShower',
+    'dancingJellyMoss',
+    'weather',
+    'singingGeodes',
+    'cloudCastles',
+    'bubbleCoral'
+] as const satisfies readonly (keyof LevelEnvironments)[];
 
 export function buildEnvironmentPlugins(
     host: LevelPluginHost,
     cfg: LevelConfig,
     levelLength: number
 ): AnyEnvironmentPlugin[] {
-    return [
-        {
-            flag: 'dynamicStarfield',
-            activate: (config: any) => host.dynamicStarfieldSystem.activate(typeof config === 'object' ? config : undefined),
-            deactivate: () => host.dynamicStarfieldSystem.deactivate()
-        },
-        {
-            flag: 'dayNightCycle',
-            activate: (config: any) => host.dayNightCycleSystem.activate(typeof config === 'object' ? config : undefined),
-            deactivate: () => host.dayNightCycleSystem.deactivate()
-        },
-        {
-            flag: 'candyPlanetRing',
-            activate: () => host.candyFieldSystem.activate(),
-            deactivate: () => host.candyFieldSystem.deactivate()
-        },
-        {
-            flag: 'pastelNebula',
-            activate: () => host.pastelNebulaSystem.activate(),
-            deactivate: () => host.pastelNebulaSystem.deactivate()
-        },
-        {
-            flag: 'candyField',
-            activate: () => host.candyFieldSystem.activate(),
-            deactivate: () => host.candyFieldSystem.deactivate()
-        },
-        {
-            flag: 'wishLanterns',
-            activate: () => host.wishLanternSystem.activate(),
-            deactivate: () => host.wishLanternSystem.deactivate()
-        },
-        {
-            flag: 'butterflySwarm',
-            activate: () => host.butterflySwarmSystem.activate(),
-            deactivate: () => host.butterflySwarmSystem.deactivate()
-        },
-        {
-            flag: 'blackHole',
-            activate: (blackHoleConfig) => host.blackHoleSystem.activate(blackHoleConfig),
-            deactivate: () => host.blackHoleSystem.deactivate()
-        },
-        {
-            flag: 'galacticCore',
-            activate: (coreConfig) => host.galacticCoreSystem.activate(coreConfig),
-            deactivate: () => host.galacticCoreSystem.deactivate()
-        },
-        {
-            flag: 'industrial',
-            activate: (config: any) => host.industrialSystem.activate(typeof config === 'object' ? config : undefined),
-            deactivate: () => host.industrialSystem.deactivate()
-        },
-        {
-            flag: 'waterfall',
-            activate: () => {
-                host.waterfallSystem.levelDistance = levelLength;
-                host.waterfallSystem.activate();
-            },
-            deactivate: () => host.waterfallSystem.deactivate()
-        },
-        {
-            flag: 'planetaryHorizon',
-            activate: () => {
-                host.planetaryHorizonSystem.levelDistance = levelLength;
-                host.planetaryHorizonSystem.activate();
-            },
-            deactivate: () => host.planetaryHorizonSystem.deactivate()
-        },
-        {
-            flag: 'moonPalace',
-            activate: () => {
-                host.moonPalaceSystem.levelDistance = levelLength;
-                host.moonPalaceSystem.activate();
-            },
-            deactivate: () => host.moonPalaceSystem.deactivate()
-        },
-        {
-            flag: 'reEntry',
-            activate: () => {
-                host.reEntrySystem.levelDistance = levelLength;
-                host.reEntrySystem.activate();
-            },
-            deactivate: () => host.reEntrySystem.deactivate()
-        },
-        {
-            flag: 'biological',
-            activate: () => {
-                host.biologicalSystem.activate();
-                host.cloudSystem.layers.forEach(l => { l.mesh.visible = false; });
-            },
-            deactivate: () => {
-                host.biologicalSystem.deactivate();
-                const cloudsVisible = (cfg.foliageDensity.cloud ?? 20) > 0;
-                host.cloudSystem.layers.forEach(l => { l.mesh.visible = cloudsVisible; });
-            }
-        },
-        {
-            flag: 'nebula',
-            activate: () => {
-                host.nebulaSystem.activate();
-                host.nebulaSystem.activateRibbons();
-            },
-            deactivate: () => host.nebulaSystem.deactivate()
-        },
-        {
-            flag: 'nebulaRibbons',
-            activate: () => host.nebulaSystem.activateRibbons(),
-            deactivate: () => host.nebulaSystem.deactivateRibbons()
-        },
-        {
-            flag: 'cosmicDust',
-            activate: () => {
-                host.cosmicDustSystem.activate();
-                host.nebulaSystem.activateRibbons();
-            },
-            deactivate: () => {
-                host.cosmicDustSystem.deactivate();
-                host.nebulaSystem.deactivateRibbons();
-            }
-        },
-        {
-            flag: 'godRays',
-            activate: (config: GodRaysEnvironmentConfig) => host.godRaySystem.activate(config),
-            deactivate: () => host.godRaySystem.deactivate()
-        },
-        {
-            flag: 'aurora',
-            activate: (config: AuroraEnvironmentConfig) => host.auroraSystem.activate(config),
-            deactivate: () => host.auroraSystem.deactivate()
-        },
-        {
-            flag: 'lightning',
-            activate: (config: LightningEnvironmentConfig) => host.lightningBoltSystem.activate(config),
-            deactivate: () => host.lightningBoltSystem.deactivate()
-        },
-        {
-            flag: 'asteroidField',
-            activate: (config: AsteroidFieldEnvironmentConfig) => {
-                host.asteroidFieldSystem.activate();
-                host.baseAsteroidDensity = config.rate * 0.5;
-                host.asteroidFieldSystem.setDensity(host.baseAsteroidDensity * host.objectDensityMultiplier);
-                host.asteroidFieldSystem.setCandyChance(cfg.candyAsteroidChance ?? 0);
-                host.asteroidFieldSystem.resetPositions(host.camera.position.x);
-            },
-            deactivate: () => {
-                host.baseAsteroidDensity = 0;
-                host.asteroidFieldSystem.deactivate();
-            }
-        },
-        {
-            flag: 'ghostDebris',
-            activate: () => host.ghostDebrisSystem.activate(),
-            deactivate: () => host.ghostDebrisSystem.deactivate()
-        },
-        {
-            flag: 'voidJellyfish',
-            activate: (config) => host.voidJellyfishSystem.activate(config),
-            deactivate: () => host.voidJellyfishSystem.deactivate()
-        },
-        {
-            flag: 'meteorShower',
-            activate: () => host.meteorShowerSystem.activate(),
-            deactivate: () => host.meteorShowerSystem.deactivate()
-        },
-        {
-            flag: 'dancingJellyMoss',
-            activate: (config: any) => host.dancingJellyMossSystem.activate(typeof config === 'object' ? config : undefined),
-            deactivate: () => host.dancingJellyMossSystem.deactivate()
-        },
-        {
-            flag: 'weather',
-            activate: () => host.weatherSystem.activate(),
-            deactivate: () => host.weatherSystem.deactivate()
-        },
-        {
-            flag: 'singingGeodes',
-            activate: (config: any) => host.singingGeodeSystem.activate(typeof config === 'object' ? config.density : undefined),
-            deactivate: () => host.singingGeodeSystem.deactivate()
-        },
-        {
-            flag: 'cloudCastles',
-            activate: (config: any) => host.cloudCastlesSystem.activate(typeof config === 'object' ? config : undefined),
-            deactivate: () => host.cloudCastlesSystem.deactivate()
+    const eagerByFlag = new Map(
+        buildEagerEnvPlugins(host, cfg, levelLength).map((p) => [p.flag, p])
+    );
+    const deferredByFlag = new Map(
+        buildDeferredEnvPlugins(host, cfg, levelLength).map((p) => [p.flag, p])
+    );
+
+    return PLUGIN_ORDER.map((flag) => {
+        const plugin = deferredByFlag.get(flag) ?? eagerByFlag.get(flag);
+        if (!plugin) {
+            throw new Error(`Missing environment plugin for flag "${String(flag)}"`);
         }
-    ];
+        return plugin as AnyEnvironmentPlugin;
+    });
 }
 
 export function applyEnvironmentPlugins(

--- a/src/level_manager/plugin_host.ts
+++ b/src/level_manager/plugin_host.ts
@@ -1,0 +1,38 @@
+import type * as THREE from 'three';
+import type {
+    LevelConfig,
+    LevelEnvironments,
+    GodRaysEnvironmentConfig,
+    AuroraEnvironmentConfig,
+    LightningEnvironmentConfig,
+    AsteroidFieldEnvironmentConfig
+} from '../level_config';
+import type { LevelEnvironmentPorts } from './types';
+
+/** Systems registry host for environment plugin activation. */
+export interface LevelPluginHost extends LevelEnvironmentPorts {
+    butterflySwarmSystem: { activate: () => void; deactivate: () => void };
+    cloudSystem: { layers: { mesh: { visible: boolean } }[] };
+    godRaySystem: { activate: (config: GodRaysEnvironmentConfig) => void; deactivate: () => void };
+    auroraSystem: { activate: (config: AuroraEnvironmentConfig) => void; deactivate: () => void };
+    ghostDebrisSystem: { activate: () => void; deactivate: () => void };
+    voidJellyfishSystem: { activate: (config: NonNullable<LevelEnvironments['voidJellyfish']>) => void; deactivate: () => void };
+    camera: { position: { x: number } };
+    baseAsteroidDensity: number;
+    objectDensityMultiplier: number;
+    moonPalaceSystem: LevelEnvironmentPorts['moonPalaceSystem'] & { levelDistance: number; activate: () => void; deactivate: () => void };
+    wishLanternSystem: LevelEnvironmentPorts['wishLanternSystem'] & { activate: () => void; deactivate: () => void };
+    weatherSystem: LevelEnvironmentPorts['weatherSystem'] & { activate: () => void; deactivate: () => void };
+    dancingJellyMossSystem: LevelEnvironmentPorts['dancingJellyMossSystem'] & { activate: (config?: { density?: number }) => void; deactivate: () => void };
+    dynamicStarfieldSystem: LevelEnvironmentPorts['dynamicStarfieldSystem'] & { activate: (config?: { speedScaling?: number }) => void; deactivate: () => void };
+    dayNightCycleSystem: LevelEnvironmentPorts['dayNightCycleSystem'] & { activate: (config?: { cycleDuration?: number }) => void; deactivate: () => void };
+    cloudCastlesSystem: LevelEnvironmentPorts['cloudCastlesSystem'] & { activate: (config?: { density?: number }) => void; deactivate: () => void; cleanup: () => void };
+    candyFieldSystem: LevelEnvironmentPorts['candyFieldSystem'] & { activate: (config?: unknown) => void; deactivate: () => void; setVisible: (visible: boolean) => void; update: (delta: number, cameraX: number) => void };
+    singingGeodeSystem: LevelEnvironmentPorts['singingGeodeSystem'] & { activate: (density?: number) => void; deactivate: () => void; update: (delta: number, cameraX: number, playerPos?: THREE.Vector3) => void; cleanup: () => void };
+}
+
+export type EnvPluginBuilder = (
+    host: LevelPluginHost,
+    cfg: LevelConfig,
+    levelLength: number
+) => { flag: keyof LevelEnvironments; activate: (value: never) => void; deactivate: () => void };

--- a/src/level_systems_loader.ts
+++ b/src/level_systems_loader.ts
@@ -2,49 +2,24 @@
  * Per-level / per-flag async system loading.
  * Heavy modules are only downloaded when a level that needs them is about to start
  * (or prefetched near the end of the previous segment).
+ *
+ * Loader keys and install hooks are defined in `level_env_registry.ts`.
  */
 import { game } from './game_runtime';
 import { getLevelSpan } from './depth_layers';
 import { LEVEL_CONFIG, LEVEL_DISTANCE_BOUNDARIES, type LevelConfig } from './level_config';
-import { isEnvironmentEnabled } from './level_manager/types';
 import type { LevelEnvironmentPorts } from './level_manager/types';
 import {
-    shouldSpawnStarlightKoi,
-    shouldSpawnBubbleCoral
-} from './level_spawn_rules';
+    installDeferredSystem,
+    systemsNeededForLevel,
+    type SystemKey,
+    type DeferredLoaderContext,
+    type DeferredGamePorts
+} from './level_env_registry';
 import { scene, camera } from './scene_context';
-import { createDreamPortalCallbacks } from './main/dream_portal_update';
 
-type SystemKey =
-    | 'reEntry'
-    | 'waterfall'
-    | 'meteorShower'
-    | 'industrial'
-    | 'biological'
-    | 'cosmicDust'
-    | 'boss'
-    | 'planetaryHorizon'
-    | 'moonPalace'
-    | 'chromaShift'
-    | 'stormGeode'
-    | 'blackHole'
-    | 'galacticCore'
-    | 'dreamPortals'
-    | 'ghostDebris'
-    | 'voidJellyfish'
-    | 'industrialGeometry'
-    | 'aquaticLife'
-    | 'starlightKoi'
-    | 'bubbleCoral'
-    | 'slingables'
-    | 'wishLanterns'
-    | 'weather'
-    | 'dancingJellyMoss'
-    | 'dynamicStarfield'
-    | 'dayNightCycle'
-    | 'singingGeodes'
-    | 'cloudCastles'
-    | 'candyPlanetRing';
+export type { SystemKey } from './level_env_registry';
+export { systemsNeededForLevel } from './level_env_registry';
 
 const loaded = new Set<SystemKey>();
 const inflight = new Map<SystemKey, Promise<void>>();
@@ -57,8 +32,16 @@ function installEnvPartial(partial: Partial<LevelEnvironmentPorts>): void {
     }
 }
 
-function assignGameSystem<K extends keyof typeof game>(key: K, value: (typeof game)[K]): void {
-    game[key] = value;
+function createLoaderContext(): DeferredLoaderContext {
+    return {
+        scene,
+        camera,
+        game: game as unknown as DeferredGamePorts,
+        installEnvPartial,
+        assignGameSystem(key, value) {
+            (game as unknown as DeferredGamePorts)[key] = value;
+        }
+    };
 }
 
 async function loadSystem(key: SystemKey): Promise<void> {
@@ -67,209 +50,7 @@ async function loadSystem(key: SystemKey): Promise<void> {
     if (existing) return existing;
 
     const promise = (async () => {
-        switch (key) {
-            case 'reEntry': {
-                const { ReEntrySystem } = await import('./reentry');
-                installEnvPartial({ reEntrySystem: new ReEntrySystem(scene, camera) });
-                break;
-            }
-            case 'waterfall': {
-                const { WaterfallSystem } = await import('./waterfall');
-                installEnvPartial({
-                    waterfallSystem: new WaterfallSystem(scene, camera, game.weaponLightManager)
-                });
-                break;
-            }
-            case 'singingGeodes': {
-                const { SingingGeodeSystem } = await import('./singing_geodes');
-                installEnvPartial({
-                    singingGeodeSystem: new SingingGeodeSystem(scene, game.audioSystem, game.particleSystem)
-                });
-                break;
-            }
-            case 'cloudCastles': {
-                const { CloudCastlesSystem } = await import('./cloud_castles_system');
-                installEnvPartial({
-                    cloudCastlesSystem: new CloudCastlesSystem(scene)
-                });
-                break;
-            }
-            case 'dayNightCycle': {
-                const { DayNightCycleSystem } = await import('./day_night_cycle');
-                installEnvPartial({
-                    dayNightCycleSystem: new DayNightCycleSystem(scene, camera)
-                });
-                break;
-            }
-            case 'dancingJellyMoss': {
-                const { DancingJellyMossSystem } = await import('./dancing_jelly_moss');
-                installEnvPartial({
-                    dancingJellyMossSystem: new DancingJellyMossSystem(scene)
-                });
-                break;
-            }
-            case 'dynamicStarfield': {
-                const { DynamicStarfieldSystem } = await import('./dynamic_starfield');
-                installEnvPartial({
-                    dynamicStarfieldSystem: new DynamicStarfieldSystem(scene)
-                });
-                break;
-            }
-            case 'weather': {
-                const { WeatherSystem } = await import('./weather_system');
-                installEnvPartial({
-                    weatherSystem: new WeatherSystem(scene)
-                });
-                break;
-            }
-            case 'wishLanterns': {
-                const { WishLanternSystem } = await import('./wish_lanterns');
-                installEnvPartial({
-                    wishLanternSystem: new WishLanternSystem(scene)
-                });
-                break;
-            }
-            case 'meteorShower': {
-                const { MeteorShowerSystem } = await import('./meteor_shower');
-                installEnvPartial({
-                    meteorShowerSystem: new MeteorShowerSystem(scene, game.weaponLightManager)
-                });
-                break;
-            }
-            case 'industrial': {
-                const { IndustrialBackgroundSystem } = await import('./industrial_background');
-                installEnvPartial({
-                    industrialSystem: new IndustrialBackgroundSystem(scene, game.weaponLightManager)
-                });
-                break;
-            }
-            case 'biological': {
-                const { BiologicalBackgroundSystem } = await import('./biological_background');
-                installEnvPartial({ biologicalSystem: new BiologicalBackgroundSystem(scene) });
-                break;
-            }
-            case 'candyPlanetRing': {
-                const { CandyFieldSystem } = await import('./candy_obstacles');
-                installEnvPartial({ candyFieldSystem: new CandyFieldSystem(scene) });
-                break;
-            }
-
-            case 'cosmicDust': {
-                const { CosmicDustSystem } = await import('./cosmic_dust');
-                installEnvPartial({
-                    cosmicDustSystem: new CosmicDustSystem(scene, game.weaponLightManager)
-                });
-                break;
-            }
-            case 'boss': {
-                const { BossManager } = await import('./boss_system');
-                assignGameSystem('bossManager', new BossManager(scene));
-                break;
-            }
-            case 'planetaryHorizon': {
-                const { PlanetaryHorizonSystem } = await import('./planetary_horizon');
-                installEnvPartial({
-                    planetaryHorizonSystem: new PlanetaryHorizonSystem(scene, camera)
-                });
-                break;
-            }
-            case 'moonPalace': {
-                const { MoonPalaceSystem } = await import('./moon_palace');
-                installEnvPartial({
-                    moonPalaceSystem: new MoonPalaceSystem(scene, camera, game.weaponLightManager)
-                });
-                break;
-            }
-            case 'chromaShift': {
-                const { ChromaShiftSystem } = await import('./chroma_shift');
-                installEnvPartial({ chromaShiftSystem: new ChromaShiftSystem(scene) });
-                break;
-            }
-            case 'stormGeode': {
-                const { StormGeodeSystem } = await import('./storm_geodes');
-                installEnvPartial({
-                    stormGeodeSystem: new StormGeodeSystem(scene, {
-                        playHit: () => game.audioSystem.play('hit'),
-                        onBoltStrike: (pos, color) => game.lightningBoltSystem.onBoltStrike?.(pos, color)
-                    })
-                });
-                break;
-            }
-            case 'blackHole': {
-                const { BlackHoleSystem } = await import('./black_hole');
-                installEnvPartial({ blackHoleSystem: new BlackHoleSystem(scene) });
-                break;
-            }
-            case 'galacticCore': {
-                const { GalacticCoreSystem } = await import('./galactic_core');
-                installEnvPartial({ galacticCoreSystem: new GalacticCoreSystem(scene) });
-                break;
-            }
-            case 'dreamPortals': {
-                const { DreamPortalSystem } = await import('./dream_portal');
-                assignGameSystem(
-                    'dreamPortalSystem',
-                    new DreamPortalSystem(scene, createDreamPortalCallbacks())
-                );
-                break;
-            }
-            case 'ghostDebris': {
-                const { GhostDebrisSystem } = await import('./ghost_debris');
-                game.ghostDebrisSystem = new GhostDebrisSystem(scene);
-                if (game.levelManager) {
-                    game.levelManager.ghostDebrisSystem = game.ghostDebrisSystem;
-                }
-                break;
-            }
-            case 'voidJellyfish': {
-                const { VoidJellyfishSystem } = await import('./void_jellyfish');
-                game.voidJellyfishSystem = new VoidJellyfishSystem(scene);
-                if (game.levelManager) {
-                    game.levelManager.voidJellyfishSystem = game.voidJellyfishSystem;
-                }
-                break;
-            }
-            case 'industrialGeometry': {
-                const { IndustrialGeometryManager } = await import('./industrial_geometry');
-                game.industrialGeometryManager = new IndustrialGeometryManager(scene);
-                if (game.levelManager) {
-                    game.levelManager.industrialGeometryManager = game.industrialGeometryManager;
-                }
-                break;
-            }
-            case 'aquaticLife': {
-                const { AquaticLifeManager } = await import('./aquatic_life');
-                game.aquaticLifeManager = new AquaticLifeManager(scene);
-                break;
-            }
-            case 'starlightKoi': {
-                const { StarlightKoiManager } = await import('./starlight_koi');
-                game.starlightKoiManager = new StarlightKoiManager(scene, game.particleSystem);
-                break;
-            }
-            case 'bubbleCoral': {
-                const { RainbowBubbleCoralManager } = await import('./bubble_coral');
-                game.bubbleCoralManager = new RainbowBubbleCoralManager(scene, game.particleSystem);
-                break;
-            }
-            case 'slingables': {
-                const [{ SlingableObjectSystem }, { ToyRocketSpawnManager }] = await Promise.all([
-                    import('./slingable_objects'),
-                    import('./toy_rockets')
-                ]);
-                const slingableObjectSystem = new SlingableObjectSystem(
-                    scene,
-                    game.particleSystem,
-                    game.debrisSystem
-                );
-                game.slingableObjectSystem = slingableObjectSystem;
-                game.toyRocketSpawnManager = new ToyRocketSpawnManager(slingableObjectSystem);
-                if (typeof game.rewireSlingableCallbacks === 'function') {
-                    game.rewireSlingableCallbacks();
-                }
-                break;
-            }
-        }
+        await installDeferredSystem(key, createLoaderContext());
         loaded.add(key);
         inflight.delete(key);
     })();
@@ -281,54 +62,6 @@ async function loadSystem(key: SystemKey): Promise<void> {
         inflight.delete(key);
         throw err;
     }
-}
-
-/** Resolve which deferred systems a level config needs. */
-export function systemsNeededForLevel(cfg: LevelConfig | undefined): SystemKey[] {
-    if (!cfg) return [];
-    const keys = new Set<SystemKey>();
-    const env = cfg.environments || {};
-
-    if (isEnvironmentEnabled(env.reEntry)) keys.add('reEntry');
-    if (isEnvironmentEnabled(env.waterfall)) keys.add('waterfall');
-    if (isEnvironmentEnabled(env.meteorShower)) keys.add('meteorShower');
-    if (isEnvironmentEnabled(env.industrial)) keys.add('industrial');
-    if (isEnvironmentEnabled(env.biological)) keys.add('biological');
-    if (isEnvironmentEnabled(env.cosmicDust)) keys.add('cosmicDust');
-    if (isEnvironmentEnabled(env.planetaryHorizon)) keys.add('planetaryHorizon');
-    if (isEnvironmentEnabled(env.moonPalace)) keys.add('moonPalace');
-    if (isEnvironmentEnabled(env.blackHole)) keys.add('blackHole');
-    if (isEnvironmentEnabled(env.galacticCore)) keys.add('galacticCore');
-    if (isEnvironmentEnabled(env.dreamPortals)) keys.add('dreamPortals');
-    if (isEnvironmentEnabled(env.ghostDebris)) keys.add('ghostDebris');
-    if (isEnvironmentEnabled(env.voidJellyfish)) keys.add('voidJellyfish');
-    if (isEnvironmentEnabled(env.aquaticLife)) keys.add('aquaticLife');
-    if (isEnvironmentEnabled(env.wishLanterns)) keys.add('wishLanterns');
-    if (isEnvironmentEnabled(env.weather)) keys.add('weather');
-    if (isEnvironmentEnabled(env.dancingJellyMoss)) keys.add('dancingJellyMoss');
-    if (isEnvironmentEnabled(env.dynamicStarfield)) keys.add('dynamicStarfield');
-    if (isEnvironmentEnabled(env.dayNightCycle)) keys.add('dayNightCycle');
-    if (isEnvironmentEnabled(env.singingGeodes)) keys.add('singingGeodes');
-    if (isEnvironmentEnabled(env.cloudCastles)) keys.add('cloudCastles');
-    if (isEnvironmentEnabled(env.candyPlanetRing)) keys.add('candyPlanetRing');
-
-    if ((cfg.chromaShiftDensity ?? 0) > 0) keys.add('chromaShift');
-    if ((cfg.stormGeodeDensity ?? 0) > 0) keys.add('stormGeode');
-
-    if (cfg.levelType === 'tunnel' || cfg.levelType === 'organic_tunnel') {
-        keys.add('industrialGeometry');
-    }
-
-    if (cfg.objective?.type === 'boss') keys.add('boss');
-
-    if (shouldSpawnStarlightKoi(env, cfg.koiSchoolDensity)) keys.add('starlightKoi');
-    if (shouldSpawnBubbleCoral(env, cfg.bubbleCoralDensity)) keys.add('bubbleCoral');
-
-    if ((cfg.toyRocketCount ?? 0) > 0 || cfg.objective?.type === 'sling') {
-        keys.add('slingables');
-    }
-
-    return [...keys];
 }
 
 async function loadKeys(keys: SystemKey[]): Promise<void> {

--- a/tools/check_level_env_registry.cjs
+++ b/tools/check_level_env_registry.cjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Validates the level environment registry closed loop:
+ * - Every LevelEnvironments key is classified deferred or eager
+ * - DEFERRED_ENV_REGISTRY keys match DEFERRED_ENV_FLAGS
+ * - PLUGIN_ORDER covers every flag that needs activate/deactivate (except load-only flags)
+ * - LEVEL_CONFIG enabled deferred flags resolve to registry entries
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+
+function read(rel) {
+    return fs.readFileSync(path.join(ROOT, rel), 'utf8');
+}
+
+function parseStringArray(source, constName) {
+    const re = new RegExp(`export const ${constName} = \\[([\\s\\S]*?)\\] as const`);
+    const match = source.match(re);
+    if (!match) throw new Error(`Could not parse ${constName}`);
+    return [...match[1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+}
+
+function parseRegistryKeys(source) {
+    const match = source.match(/export const DEFERRED_ENV_REGISTRY[^=]*=\s*\{([\s\S]*?)\n\};/);
+    if (!match) throw new Error('Could not parse DEFERRED_ENV_REGISTRY');
+    return [...match[1].matchAll(/^\s+([a-zA-Z0-9_]+):\s*\{/gm)].map((m) => m[1]);
+}
+
+function parseLevelEnvTypeKeys(source) {
+    const match = source.match(/export type LevelEnvironments = \{([\s\S]*?)\n\};/);
+    if (!match) throw new Error('Could not parse LevelEnvironments type');
+    return [...match[1].matchAll(/^\s+([a-zA-Z0-9_]+)\??:/gm)].map((m) => m[1]);
+}
+
+function parsePluginOrder(source) {
+    const match = source.match(/const PLUGIN_ORDER = \[([\s\S]*?)\] as const/);
+    if (!match) throw new Error('Could not parse PLUGIN_ORDER');
+    return [...match[1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+}
+
+function parseEnabledDeferredFlagsInLevels(levelConfigSource, deferredFlags) {
+    const enabled = new Set();
+    for (const flag of deferredFlags) {
+        const re = new RegExp(`\\b${flag}\\s*:`);
+        if (re.test(levelConfigSource)) enabled.add(flag);
+    }
+    return enabled;
+}
+
+function fail(msg) {
+    console.error(`level_env_registry check FAILED: ${msg}`);
+    process.exit(1);
+}
+
+function main() {
+    const registrySrc = read('src/level_env_registry.ts');
+    const pluginsSrc = read('src/level_manager/environment_plugins.ts');
+    const levelConfigSrc = read('src/level_config.ts');
+
+    const deferredFlags = parseStringArray(registrySrc, 'DEFERRED_ENV_FLAGS');
+    const eagerFlags = parseStringArray(registrySrc, 'EAGER_ENV_FLAGS');
+    const registryKeys = parseRegistryKeys(registrySrc);
+    const envTypeKeys = parseLevelEnvTypeKeys(levelConfigSrc);
+    const pluginOrder = parsePluginOrder(pluginsSrc);
+
+    const classified = new Set([...deferredFlags, ...eagerFlags]);
+    const missingClassification = envTypeKeys.filter((k) => !classified.has(k));
+    if (missingClassification.length) {
+        fail(`LevelEnvironments keys missing from DEFERRED_ENV_FLAGS / EAGER_ENV_FLAGS: ${missingClassification.join(', ')}`);
+    }
+
+    const extraClassification = [...classified].filter((k) => !envTypeKeys.includes(k));
+    if (extraClassification.length) {
+        fail(`Registry classifies unknown env flags: ${extraClassification.join(', ')}`);
+    }
+
+    const missingRegistry = deferredFlags.filter((f) => !registryKeys.includes(f));
+    if (missingRegistry.length) {
+        fail(`DEFERRED_ENV_FLAGS without DEFERRED_ENV_REGISTRY entry: ${missingRegistry.join(', ')}`);
+    }
+
+    const extraRegistry = registryKeys.filter((f) => !deferredFlags.includes(f));
+    if (extraRegistry.length) {
+        fail(`DEFERRED_ENV_REGISTRY keys not in DEFERRED_ENV_FLAGS: ${extraRegistry.join(', ')}`);
+    }
+
+    // dreamPortals / aquaticLife load via registry but have no level plugin wiring.
+    const loadOnlyFlags = new Set(['dreamPortals', 'aquaticLife']);
+    const flagsNeedingPlugins = envTypeKeys.filter((f) => !loadOnlyFlags.has(f));
+    const missingPlugins = flagsNeedingPlugins.filter((f) => !pluginOrder.includes(f));
+    if (missingPlugins.length) {
+        fail(`PLUGIN_ORDER missing flags: ${missingPlugins.join(', ')}`);
+    }
+
+    const enabledInLevels = parseEnabledDeferredFlagsInLevels(levelConfigSrc, deferredFlags);
+    for (const flag of enabledInLevels) {
+        if (!registryKeys.includes(flag)) {
+            fail(`Level config enables deferred flag "${flag}" with no registry loader`);
+        }
+    }
+
+    console.log(
+        `level_env_registry check OK — ${deferredFlags.length} deferred, ${eagerFlags.length} eager, ${pluginOrder.length} plugins, ${enabledInLevels.size} deferred flags used in levels`
+    );
+}
+
+main();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Introduces a **closed-loop level environment registry** so new code-split features are integrated in one place instead of ~6 hand-edited files. Follows the P0 Cloud Castles / typecheck fix (included on this branch).

## Architecture

### `src/level_env_registry.ts` (new)
Single declarative map for deferred environment systems:
- `DEFERRED_ENV_REGISTRY` — `load`, `install`, and `plugin` hooks per deferred flag
- `DEFERRED_LEVEL_REGISTRY` — non-env loaders (boss, chromaShift, slingables, …)
- `EAGER_ENV_FLAGS` / `buildEagerEnvPlugins` — bootstrap env systems
- Compile-time exhaustiveness: every `LevelEnvironments` key is `DEFERRED_ENV_FLAGS` or `EAGER_ENV_FLAGS`
- `systemsNeededForLevel` + `installDeferredSystem` derived from registry

### Refactors
- `level_systems_loader.ts` — thin wrapper; no manual switch/case
- `environment_plugins.ts` — merges registry plugins + `PLUGIN_ORDER`
- `plugin_host.ts` — `LevelPluginHost` extracted to break import cycles

### Validation
- `tools/check_level_env_registry.cjs` — verifies flag classification, registry coverage, plugin order, and level-config usage
- Wired into `npm run check` (+ standalone `npm run check:env-registry`)

### Docs
- `docs/GAME_CONTEXT.md`, `docs/plans/COSMIC_ARCHITECT_TASK.md`, `AGENTS.md` — registry workflow; explicit ban on `patch_*.py` sed scripts

> **Note:** Root `patch_*.py` scripts are already absent from the repo; docs now forbid reintroducing them.

## Adding a new deferred env feature

1. `LevelEnvironments` flag in `level_config.ts`
2. One `DEFERRED_ENV_REGISTRY` entry (`load` + `install` + `plugin`)
3. Stub in `create_game_systems.ts` if needed
4. Append flag to `PLUGIN_ORDER` in `environment_plugins.ts`
5. Enable on target level(s)

## Verification

- `npm run typecheck` — 0 errors
- `npm run check` — braces + env registry + typecheck ratchet green
- `npm run build` — production build succeeds

## Acceptance criteria

- [x] New env system = one registry entry (+ class + level flag), not 6 manual edits
- [x] Type + test fail if deferred flag has no loader
- [x] `patch_*.py` documented as forbidden (already removed from tree)
- [x] Cosmic Architect template updated with registry steps
- [x] Existing plugin order / loaders preserved after refactor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e03b39e-8bcf-4879-84cb-ac1bf97b8425?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e03b39e-8bcf-4879-84cb-ac1bf97b8425&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

