### PR TITLE
Wire C++ fractalNoise2D into streaming density (Option B)

### DIFF
--- a/docs/WASM_BACKENDS.md
+++ b/docs/WASM_BACKENDS.md
@@ -12,7 +12,7 @@ The C++/Emscripten tree under [`cpp/`](../cpp/) is **experimental / opt-in**. It
 | **Default build** | Yes — `predev` / `prebuild` | No |
 | **Toolchain** | `asc` via npm (`--initialMemory 2 --optimize`) — AS-only; not coupled to C++ | Emscripten emsdk or Docker |
 | **Collision API** | Asteroids, spores, boss hitboxes | Same symbols (parity) |
-| **Verlet / noise** | — | Verlet consumed by Jelly-Moss soft-body (Option A); noise still unused |
+| **Verlet / noise** | — | Verlet consumed by Jelly-Moss soft-body (Option A); noise consumed by streaming density (Option B) |
 | **Onboarding** | Required | Not required |
 
 ## Default path (what you need day-to-day)
@@ -68,6 +68,26 @@ Runtime breadcrumbs (for smoke / debugging):
 `asc` flags (`--initialMemory 2 --optimize`) stay on the AssemblyScript `build:wasm` script only. C++ memory growth is handled by `refreshMemoryView()` after `allocPhysicsBodies` (and other `alloc*` calls).
 
 Native host tests: `BUILD_NATIVE_TESTS` stays off — see comment in [`cpp/CMakeLists.txt`](../cpp/CMakeLists.txt).
+
+## Option B — biome noise for streaming density
+
+**Chosen deliverable: chunk-level `fractalNoise2D` density modulation for streaming spawn systems**, via [`src/biome_noise.ts`](../src/biome_noise.ts) implementing `BiomeNoisePort` ([`src/ports/biome_noise_port.ts`](../src/ports/biome_noise_port.ts)).
+
+`BiomeNoiseSystem` samples noise **once per streaming chunk** (`CHUNK_SIZE = 64` world units), not per vertex/object, and caches the result in a small per-channel ring buffer (`foliage` / `spore` / `candy` channels, offset in noise-space so they don't move in lockstep). Wired exactly like Option A: a module-level singleton (`biomeNoise`), bound in [`src/main/startup.ts`](../src/main/startup.ts) alongside `jellyMossSoftBody.bindWasm(handle)` — no `GameContext` growth.
+
+| Backend | Source |
+|---|---|
+| C++ (`wasmBackend === 'cpp'` and `fractalNoise2D` present) | `exports.fractalNoise2D(worldX * scale, channelSeed * scale, octaves, lacunarity, gain)` |
+| AssemblyScript / no C++ binary | Tiny JS multi-octave value-noise fallback (same fBm shape, no crash, no emsdk needed) |
+
+Consumers (direct import of the singleton, same pattern as `jellyMossSoftBody`):
+
+- [`src/level_manager/foliage_streaming.ts`](../src/level_manager/foliage_streaming.ts) — `spawnOpenFoliage` multiplies `scaledCount()` by `biomeNoise.densityMultiplier(x, 'foliage')`, varying foliage scatter **and** void-root-ball density (both route through `scaledCount`) per chunk. Spore-cloud spawn count uses its own `'spore'` channel sample so it varies independently of general foliage.
+- [`src/candy_obstacles/candy_belt_manager.ts`](../src/candy_obstacles/candy_belt_manager.ts) — `generateCandyBelt` samples `biomeNoise.sample(x, 'candy')` per candidate spawn and skips below `CANDY_GAP_THRESHOLD`, carving organic gaps into the belt instead of a flat Poisson scatter.
+
+Both consumers run under **every** backend — the JS fallback keeps density variation active (and stable) on the default AssemblyScript path; only the noise *source* changes with `VITE_CPP_WASM=true`. No new build steps or emsdk requirement are added to `npm run dev` / `npm run build` / CI.
+
+Breadcrumb: `window.biomeNoiseBackend` — `'cpp' | 'js'`.
 
 ## CI
 

--- a/scripts/verify-cpp-wasm.mjs
+++ b/scripts/verify-cpp-wasm.mjs
@@ -69,4 +69,11 @@ if (!Number.isFinite(x)) {
     process.exit(1);
 }
 
+// Light call smoke for noise (Option B biome-noise consumer — src/biome_noise.ts)
+const n = exports.fractalNoise2D(1.23, 4.56, 4, 2.0, 0.5);
+if (!Number.isFinite(n)) {
+    console.error('❌ fractalNoise2D produced non-finite value');
+    process.exit(1);
+}
+
 console.log(`✅ C++ WASM verified (${wasmPath})`);

--- a/src/biome_noise.ts
+++ b/src/biome_noise.ts
@@ -1,0 +1,167 @@
+/**
+ * biome_noise.ts
+ *
+ * Option B consumer of the experimental C++ WASM noise exports
+ * (`fractalNoise2D` in cpp/src/noise.cpp — see docs/WASM_BACKENDS.md).
+ * Streaming hosts (foliage/void-root scatter, spore-cloud spawn rate,
+ * candy-belt gaps) sample a chunk-cached density value here instead of
+ * pure `Math.random()`, so density varies organically and deterministically
+ * per world X.
+ *
+ * C++ backend (`VITE_CPP_WASM=true` + game_cpp.wasm present): calls
+ * `fractalNoise2D` once per streaming chunk, cached in a small ring buffer.
+ * Default AssemblyScript backend: a tiny JS value-noise fallback keeps
+ * `npm run dev` / CI green with no emsdk required.
+ *
+ * Mirrors the direct-singleton-import wiring used by `jelly_moss_softbody.ts`
+ * (Option A) rather than growing `GameContext` with a noise field.
+ */
+
+import { WasmBackend, type WasmExports, type WasmHandle } from './wasm_loader';
+import type { BiomeNoiseChannel, BiomeNoisePort } from './ports/biome_noise_port';
+
+/** World-X size of one cached noise sample. Matches streaming-zone granularity, not per-vertex. */
+const CHUNK_SIZE = 64;
+const NOISE_SCALE = 0.015;
+const OCTAVES = 4;
+const LACUNARITY = 2.0;
+const GAIN = 0.5;
+const RING_BUFFER_SIZE = 64;
+
+// Per-channel Y offset into the 2-D noise field so foliage/spore/candy don't move in lockstep.
+const CHANNEL_OFFSET: Record<BiomeNoiseChannel, number> = {
+    foliage: 0,
+    spore: 311,
+    candy: 977,
+};
+
+function hasFractalNoise(exports: WasmExports | null | undefined): boolean {
+    return !!exports && typeof exports.fractalNoise2D === 'function';
+}
+
+/** Deterministic hash to [0, 1) — stand-in permutation for the JS fallback. */
+function hash01(n: number): number {
+    const s = Math.sin(n * 12.9898) * 43758.5453123;
+    return s - Math.floor(s);
+}
+
+/** Smoothstep value noise (1-D): cheap, stable, never crashes. */
+function jsValueNoise(x: number): number {
+    const xi = Math.floor(x);
+    const xf = x - xi;
+    const a = hash01(xi);
+    const b = hash01(xi + 1);
+    const t = xf * xf * (3 - 2 * xf);
+    return a + (b - a) * t;
+}
+
+/** JS fractal fallback shaped like cpp's octave-sum fBm, normalized to [0, 1]. */
+function jsFractalNoise(x: number, seed: number): number {
+    let value = 0;
+    let amplitude = 1;
+    let frequency = 1;
+    let maxValue = 0;
+    for (let i = 0; i < OCTAVES; i++) {
+        value += jsValueNoise(x * frequency + seed) * amplitude;
+        maxValue += amplitude;
+        amplitude *= GAIN;
+        frequency *= LACUNARITY;
+    }
+    return value / maxValue;
+}
+
+type RingEntry = { chunkIndex: number; value: number };
+
+function makeRing(): (RingEntry | undefined)[] {
+    return new Array(RING_BUFFER_SIZE);
+}
+
+/**
+ * Chunk-cached biome density noise. Safe to call before `bindWasm()` runs —
+ * defaults to the JS fallback until a C++ handle is bound.
+ */
+export class BiomeNoiseSystem implements BiomeNoisePort {
+    private handle: WasmHandle | null = null;
+    private useCpp = false;
+    private rings: Record<BiomeNoiseChannel, (RingEntry | undefined)[]> = {
+        foliage: makeRing(),
+        spore: makeRing(),
+        candy: makeRing(),
+    };
+
+    get backend(): 'cpp' | 'js' {
+        return this.useCpp ? 'cpp' : 'js';
+    }
+
+    /** Bind (or clear) the active WASM handle. Falls back to JS when not C++ or noise exports are missing. */
+    bindWasm(handle: WasmHandle | null): void {
+        this.handle = handle;
+        this.useCpp = handle?.backend === WasmBackend.Cpp && hasFractalNoise(handle.exports);
+        this.rings = { foliage: makeRing(), spore: makeRing(), candy: makeRing() };
+        this.publishBreadcrumb();
+        if (this.useCpp) {
+            console.log('[biome-noise] C++ fractalNoise2D active for streaming density');
+        }
+    }
+
+    /** Chunk-cached noise sample in [0, 1] for worldX on the given channel. */
+    sample(worldX: number, channel: BiomeNoiseChannel): number {
+        const chunkIndex = Math.floor(worldX / CHUNK_SIZE);
+        const ring = this.rings[channel];
+        const slot = ((chunkIndex % RING_BUFFER_SIZE) + RING_BUFFER_SIZE) % RING_BUFFER_SIZE;
+        const cached = ring[slot];
+        if (cached && cached.chunkIndex === chunkIndex) {
+            return cached.value;
+        }
+
+        const chunkX = chunkIndex * CHUNK_SIZE;
+        const value = this.computeSample(chunkX, channel);
+        ring[slot] = { chunkIndex, value };
+        return value;
+    }
+
+    /** Density multiplier centered on 1.0 (e.g. spread=0.6 -> range [0.4, 1.6]). */
+    densityMultiplier(worldX: number, channel: BiomeNoiseChannel, spread = 0.6): number {
+        const s = this.sample(worldX, channel);
+        return 1 + (s * 2 - 1) * spread;
+    }
+
+    private computeSample(chunkX: number, channel: BiomeNoiseChannel): number {
+        const seed = CHANNEL_OFFSET[channel];
+        let raw: number;
+        if (this.useCpp && this.handle) {
+            try {
+                raw = this.handle.exports.fractalNoise2D!(
+                    chunkX * NOISE_SCALE,
+                    seed * NOISE_SCALE,
+                    OCTAVES,
+                    LACUNARITY,
+                    GAIN
+                );
+                raw = raw * 0.5 + 0.5; // [-1, 1] -> [0, 1]
+            } catch (err) {
+                console.warn('[biome-noise] fractalNoise2D failed, falling back to JS:', err);
+                this.useCpp = false;
+                this.publishBreadcrumb();
+                raw = jsFractalNoise(chunkX * NOISE_SCALE, seed * NOISE_SCALE);
+            }
+        } else {
+            raw = jsFractalNoise(chunkX * NOISE_SCALE, seed * NOISE_SCALE);
+        }
+        return Math.min(1, Math.max(0, raw));
+    }
+
+    private publishBreadcrumb(): void {
+        if (typeof window === 'undefined') return;
+        window.biomeNoiseBackend = this.backend;
+    }
+}
+
+/** Shared instance used by streaming hosts (foliage, spore clouds, candy belt) and startup. */
+export const biomeNoise = new BiomeNoiseSystem();
+
+declare global {
+    interface Window {
+        biomeNoiseBackend?: 'cpp' | 'js';
+    }
+}

--- a/src/candy_obstacles/candy_belt_manager.ts
+++ b/src/candy_obstacles/candy_belt_manager.ts
@@ -12,6 +12,12 @@ import {
 } from './shared';
 import { CandyAsteroid } from './candy_asteroid';
 import { GummyRing } from './gummy_ring';
+import { biomeNoise } from '../biome_noise';
+
+// Below this chunk-noise sample, a candidate spawn is skipped — carves organic
+// gaps into the belt instead of a flat Poisson scatter (C++ fractalNoise2D
+// under VITE_CPP_WASM=true, JS value-noise fallback otherwise).
+const CANDY_GAP_THRESHOLD = 0.32;
 
 export class CandyBeltManager {
     private scene: THREE.Scene;
@@ -94,9 +100,12 @@ export class CandyBeltManager {
         this.beltStartX = startX;
 
         const count = Math.floor(length * density);
+        let spawned = 0;
 
         for (let i = 0; i < count; i++) {
             const x = startX + Math.random() * length;
+            if (biomeNoise.sample(x, 'candy') < CANDY_GAP_THRESHOLD) continue; // organic belt gap
+
             const y = (Math.random() - 0.5) * 28;
             const z = zBand.min + Math.random() * (zBand.max - zBand.min);
 
@@ -104,9 +113,10 @@ export class CandyBeltManager {
             const flavor = this.getRandomFlavor();
 
             this.spawnCandyAsteroid(x, y, z, type, flavor);
+            spawned++;
         }
 
-        console.log(`🍭 Generated candy belt with ${count} sweet treats along x=${startX.toFixed(0)}..${(startX + length).toFixed(0)}`);
+        console.log(`🍭 Generated candy belt with ${spawned}/${count} sweet treats (biome-noise gaps, ${biomeNoise.backend}) along x=${startX.toFixed(0)}..${(startX + length).toFixed(0)}`);
     }
 
     /**

--- a/src/level_manager/foliage_streaming.ts
+++ b/src/level_manager/foliage_streaming.ts
@@ -14,6 +14,7 @@ import {
 import { DEPTH_LAYERS, randomZInLayer, randomZInRange } from '../depth_layers';
 import { moonPlants } from '../visuals';
 import { decorationBudget } from '../decoration_budget';
+import { biomeNoise } from '../biome_noise';
 import { STREAM_AHEAD_END, STREAM_AHEAD_START } from './constants';
 import type { LevelFoliageHost } from './foliage_host';
 
@@ -105,7 +106,11 @@ export function spawnOpenFoliage(lm: LevelFoliageHost,
         levelConfig: LevelConfig,
         yRange: [number, number] = [-20, 20]
     ) {
-        const scaledCount = (count: number) => Math.max(0, Math.floor(count * lm.objectDensityMultiplier));
+        // Chunk-cached biome noise (C++ fractalNoise2D under VITE_CPP_WASM=true, JS fallback otherwise)
+        // varies foliage/void-root scatter density per world X instead of a flat multiplier.
+        const foliageDensityMul = biomeNoise.densityMultiplier(startX + width / 2, 'foliage');
+        const scaledCount = (count: number) =>
+            Math.max(0, Math.floor(count * lm.objectDensityMultiplier * foliageDensityMul));
         const foliageZ: [number, number] = [DEPTH_LAYERS.MIDGROUND.min, DEPTH_LAYERS.MIDGROUND.max];
         const geoZ: [number, number] = [DEPTH_LAYERS.BACKGROUND.min + 5, DEPTH_LAYERS.MIDGROUND.max];
         const vignettes = levelConfig.vignettes || {};
@@ -197,8 +202,10 @@ export function spawnOpenFoliage(lm: LevelFoliageHost,
         }
         spawnFoliageVignettes(lm, startX, width, density, yRange, treeYRange, foliageZ, geoZ, vignettes, vignetteCount, geodeClearings);
         if (density.cloud) {
+            // Independent noise sample (own channel) so spore-cloud rate doesn't move in lockstep with foliage.
+            const sporeDensityMul = biomeNoise.densityMultiplier(startX + width / 2, 'spore');
             const targetCount = Math.min(
-                scaledCount(density.cloud),
+                Math.max(0, Math.floor(density.cloud * lm.objectDensityMultiplier * sporeDensityMul)),
                 Math.max(0, lm.GEOLOGICAL_SPAWN_CAPS.cloud - lm.geologicalCounts.sporeClouds())
             );
             for (let i = 0; i < targetCount; i++) {

--- a/src/main/startup.ts
+++ b/src/main/startup.ts
@@ -29,6 +29,7 @@ import { ShakeType } from '../juice_effects';
 import { hasDebugUrlFlag } from '../renderer_mode';
 import { loadWasm as loadWasmModule } from '../wasm_loader';
 import { jellyMossSoftBody } from '../jelly_moss_softbody';
+import { biomeNoise } from '../biome_noise';
 import {
     createGameContextFrameState,
     installGameContext,
@@ -62,6 +63,7 @@ async function loadWasm(): Promise<void> {
         game.wasmBackend = null;
     }
     jellyMossSoftBody.bindWasm(handle);
+    biomeNoise.bindWasm(handle);
 }
 
 import {

--- a/src/ports/biome_noise_port.ts
+++ b/src/ports/biome_noise_port.ts
@@ -1,0 +1,18 @@
+/** Streaming systems that sample chunk-cached biome density noise. */
+export type BiomeNoiseChannel = 'foliage' | 'spore' | 'candy';
+
+/**
+ * Deterministic per-chunk density noise for streaming world generation.
+ * Backed by the experimental C++ WASM `fractalNoise2D` export when
+ * `VITE_CPP_WASM=true` and `game_cpp.wasm` is loaded; otherwise a JS
+ * value-noise fallback. Never throws — always returns a stable value in
+ * [0, 1] for a given world X + channel so callers can multiply spawn
+ * counts or gate spawn probability without extra null checks.
+ */
+export interface BiomeNoisePort {
+    readonly backend: 'cpp' | 'js';
+    /** Chunk-cached fractal noise sample in [0, 1] for worldX on the given channel. */
+    sample(worldX: number, channel: BiomeNoiseChannel): number;
+    /** Density multiplier centered on 1.0 (e.g. spread=0.6 -> range [0.4, 1.6]). */
+    densityMultiplier(worldX: number, channel: BiomeNoiseChannel, spread?: number): number;
+}

--- a/src/ports/index.ts
+++ b/src/ports/index.ts
@@ -4,3 +4,4 @@ export type { HudPort } from './hud_port';
 export type { InventoryPort } from './inventory_port';
 export type { PlayerMotionPort } from './player_motion_port';
 export type { CollisionPort, CollisionWasmHandle } from './collision_port';
+export type { BiomeNoisePort, BiomeNoiseChannel } from './biome_noise_port';


### PR DESCRIPTION
## Summary

Implements Option B from the task: at least one gameplay/streaming system now varies spawn density from the experimental C++ WASM `fractalNoise2D` export (`cpp/src/noise.cpp`), which was exported and typed but previously unused on the TS side.

- **`src/ports/biome_noise_port.ts`** — new `BiomeNoisePort` interface: `sample(worldX, channel)` → `[0,1]`, `densityMultiplier(worldX, channel, spread?)` → multiplier centered on 1.0.
- **`src/biome_noise.ts`** — `BiomeNoiseSystem` implementation, wired as a module-level singleton (`biomeNoise`), same pattern as `jellyMossSoftBody` (Option A):
  - Samples noise **once per streaming chunk** (`CHUNK_SIZE = 64` world units), not per vertex, cached in a small per-channel ring buffer (`foliage` / `spore` / `candy` channels, offset in noise-space so they vary independently).
  - C++ backend (`wasmBackend === 'cpp'` and `fractalNoise2D` present): calls `exports.fractalNoise2D(...)`.
  - Otherwise: a tiny JS multi-octave value-noise fallback (same fBm shape) — stable, non-crashing, no emsdk required.
  - Bound in `main/startup.ts` right alongside `jellyMossSoftBody.bindWasm(handle)` — no `GameContext` growth.
  - Publishes `window.biomeNoiseBackend` (`'cpp' | 'js'`) breadcrumb.

### Consumers (gameplay-visible density variation)

- `level_manager/foliage_streaming.ts` — `spawnOpenFoliage` scales `scaledCount()` by a `'foliage'`-channel sample, varying **foliage scatter and void-root-ball density** together per chunk. Spore-cloud spawn count uses its own `'spore'`-channel sample so it varies independently.
- `candy_obstacles/candy_belt_manager.ts` — `generateCandyBelt` samples the `'candy'` channel per candidate spawn and skips below a threshold, carving organic **gaps into the candy belt** instead of a flat Poisson scatter.

### Other changes

- `scripts/verify-cpp-wasm.mjs` — added a light `fractalNoise2D` call smoke (mirrors the existing physics smoke check) so the new consumer path is exercised when the optional `cpp-wasm` CI job runs.
- `docs/WASM_BACKENDS.md` — new "Option B — biome noise for streaming density" section documenting the wiring; updated the backend comparison table.

## Verification

- `npm run check` (brace check + env-registry check + `typecheck:ci`) — passes, 0 new errors.
- `npm run build` (default AssemblyScript path) — succeeds, no emsdk involved.
- `npm run test:smoke` (Playwright, SwiftShader) — both smoke tests pass on the default build.
- Built with `VITE_CPP_WASM=true` and no `game_cpp.wasm` present, loaded in a real browser: confirmed `window.wasmBackend === 'assemblyscript'` and `window.biomeNoiseBackend === 'js'` with zero page errors — the documented no-crash fallback holds.
- `jelly_moss_softbody.ts` (Option A) is untouched.

## Test plan

- [x] `npm run check`
- [x] `npm run build`
- [x] `npm run test:smoke`
- [x] Manual browser check of `VITE_CPP_WASM=true` fallback (binary absent → JS noise, no crash)
- [ ] Optional: build `game_cpp.wasm` via emsdk/Docker and run `npm run verify:cpp-wasm` + `smoke:cpp-softbody` to confirm the real C++ noise path end-to-end (not run here — no emsdk in this environment; not required for the default onboarding path)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_015D9Bsn3L3X3UHYET4HjJmV

---
_Generated by [Claude Code](https://claude.ai/code/session_015D9Bsn3L3X3UHYET4HjJmV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added biome-based density variation for foliage, spore clouds, and candy obstacles.
  * Added deterministic chunk-level noise with C++ and JavaScript fallback support.
  * Added runtime visibility into the active noise backend.

* **Bug Fixes**
  * Added validation to detect invalid noise results during backend verification.

* **Documentation**
  * Expanded backend documentation with biome-noise behavior and supported consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->