### PR TITLE
Add Bounce Pads System

### DIFF
--- a/src/bounce_pads.ts
+++ b/src/bounce_pads.ts
@@ -1,0 +1,137 @@
+import * as THREE from 'three';
+import { time, vec3, color, positionLocal, length, uv, smoothstep, mix, sin } from 'three/tsl';
+import { MeshStandardNodeMaterial } from 'three/webgpu';
+
+export type BouncePadConfig = {
+    x: number;
+    y: number;
+    z?: number;
+    bounceStrength?: number;
+};
+
+export type BouncePadsEnvironmentConfig = {
+    pads: BouncePadConfig[];
+};
+
+export class BouncePadsSystem {
+    scene: THREE.Scene;
+    active: boolean = false;
+    mesh: THREE.InstancedMesh;
+    pads: BouncePadConfig[] = [];
+    private dummy = new THREE.Object3D();
+
+    constructor(scene: THREE.Scene) {
+        this.scene = scene;
+
+        const geo = new THREE.CylinderGeometry(2, 2, 0.5, 16);
+        geo.translate(0, -0.25, 0); // Origin at top center
+
+        const mat = new MeshStandardNodeMaterial({
+            transparent: true,
+            roughness: 0.2,
+            metalness: 0.8
+        });
+
+        const vUv = uv();
+        const dist = length(vUv.sub(0.5));
+        const ringPattern = smoothstep(0.4, 0.45, dist).sub(smoothstep(0.45, 0.5, dist));
+
+        const pulse = sin(time.mul(4.0)).mul(0.5).add(0.5);
+        const baseColor = color(0x334455);
+        const glowColor = color(0x00ffaa);
+
+        mat.colorNode = mix(baseColor, glowColor, ringPattern.mul(0.2));
+        mat.emissiveNode = glowColor.mul(ringPattern).mul(pulse.add(0.5));
+
+        // Start with a small default count, will be expanded in activate if needed
+        this.mesh = new THREE.InstancedMesh(geo, mat, 50);
+        this.mesh.count = 0;
+        this.mesh.frustumCulled = false; // Always render active pads
+
+        this.scene.add(this.mesh);
+        this.deactivate();
+    }
+
+    activate(config?: BouncePadsEnvironmentConfig) {
+        if (this.active) return;
+        this.active = true;
+        this.mesh.visible = true;
+
+        if (config && config.pads) {
+            this.pads = config.pads;
+        } else {
+            this.pads = [];
+        }
+
+        if (this.pads.length > this.mesh.instanceMatrix.count) {
+            // Need a larger mesh pool
+            const oldMesh = this.mesh;
+            this.mesh = new THREE.InstancedMesh(
+                oldMesh.geometry,
+                oldMesh.material as THREE.Material,
+                this.pads.length + 10
+            );
+            this.mesh.frustumCulled = false;
+            this.scene.remove(oldMesh);
+            this.scene.add(this.mesh);
+            oldMesh.dispose();
+        }
+
+        this.mesh.count = this.pads.length;
+
+        for (let i = 0; i < this.pads.length; i++) {
+            const pad = this.pads[i];
+            this.dummy.position.set(pad.x, pad.y, pad.z ?? 0);
+            this.dummy.scale.set(1, 1, 1);
+            this.dummy.rotation.set(0, 0, 0);
+            this.dummy.updateMatrix();
+            this.mesh.setMatrixAt(i, this.dummy.matrix);
+        }
+
+        if (this.pads.length > 0) {
+            this.mesh.instanceMatrix.needsUpdate = true;
+        }
+    }
+
+    deactivate() {
+        if (!this.active) return;
+        this.active = false;
+        this.mesh.visible = false;
+    }
+
+    update(delta: number, cameraX: number, playerPos?: THREE.Vector3) {
+        if (!this.active) return;
+
+        // Minor visual bobbing/scaling could go here if we tracked individual pad states
+    }
+
+    checkCollision(playerPos: THREE.Vector3, playerVelocityY: number): number | null {
+        if (!this.active || playerVelocityY > 0) return null; // Only bounce if falling or stationary
+
+        const radius = 2.0;
+        const padHeight = 0.5;
+
+        for (const pad of this.pads) {
+            const dx = playerPos.x - pad.x;
+            const dy = playerPos.y - pad.y;
+            const dz = playerPos.z - (pad.z ?? 0);
+
+            // Check horizontal bounds (cylinder)
+            if (dx * dx + dz * dz <= radius * radius) {
+                // Check vertical bounds - player should be hitting the top
+                // Assuming playerPos is center, so let's give a generous vertical hit box
+                if (dy >= -padHeight && dy <= 1.0) {
+                    return pad.bounceStrength ?? 40; // Default strength
+                }
+            }
+        }
+
+        return null;
+    }
+
+    cleanup() {
+        this.scene.remove(this.mesh);
+        this.mesh.geometry.dispose();
+        (this.mesh.material as THREE.Material).dispose();
+    }
+}

--- a/src/create_game_systems.ts
+++ b/src/create_game_systems.ts
@@ -1,4 +1,5 @@
 import type { SpaceGardenSystem } from './space_garden';
+import type { BouncePadsSystem } from './bounce_pads';
 import { SkyRailTerminalSystem } from './sky_rail_terminal';
 import type { ChromaShiftSystem } from './chroma_shift';
 import type { StormGeodeSystem } from './storm_geodes';
@@ -38,6 +39,7 @@ import {
     createSingingGeodeSystemStub,
     createWindCurrentsSystemStub,
     createFlowerConstellationsSystemStub,
+    createBouncePadsSystemStub,
     createSpaceGardenSystemStub
 } from './deferred_system_stubs';
 import type { ReEntrySystem } from './reentry';
@@ -154,6 +156,7 @@ export type GameSystems = {
     candyFieldSystem: CandyFieldSystem;
     singingGeodeSystem: SingingGeodeSystem;
     flowerConstellationsSystem: FlowerConstellationsSystem;
+    bouncePadsSystem: BouncePadsSystem;
     spaceGardenSystem: SpaceGardenSystem;
     skyRailTerminalSystem: SkyRailTerminalSystem;
 };
@@ -391,6 +394,7 @@ export function createGameSystems(deps: CreateGameSystemsDeps): GameSystems {
     const candyFieldSystem: CandyFieldSystem = createCandyFieldSystemStub();
     const singingGeodeSystem: SingingGeodeSystem = createSingingGeodeSystemStub();
     const flowerConstellationsSystem: FlowerConstellationsSystem = createFlowerConstellationsSystemStub();
+    const bouncePadsSystem = createBouncePadsSystemStub();
     const spaceGardenSystem = createSpaceGardenSystemStub();
     const skyRailTerminalSystem = new SkyRailTerminalSystem(scene);
     const gravLensManager = new GravLensManager(scene);
@@ -453,6 +457,7 @@ export function createGameSystems(deps: CreateGameSystemsDeps): GameSystems {
         candyFieldSystem,
         singingGeodeSystem,
         flowerConstellationsSystem,
+        bouncePadsSystem,
         spaceGardenSystem,
         gravLensManager,
         derelictBuoyManager,

--- a/src/deferred_system_stubs.ts
+++ b/src/deferred_system_stubs.ts
@@ -353,3 +353,7 @@ export function createFlowerConstellationsSystemStub(): FlowerConstellationsSyst
 export function createSpaceGardenSystemStub(): import('./space_garden').SpaceGardenSystem {
     return { activate: () => {}, deactivate: () => {}, update: () => {}, cleanup: () => {} } as unknown as import('./space_garden').SpaceGardenSystem;
 }
+
+export function createBouncePadsSystemStub(): import('./bounce_pads').BouncePadsSystem {
+    return { activate: () => {}, deactivate: () => {}, update: () => {}, cleanup: () => {}, checkCollision: () => null } as unknown as import('./bounce_pads').BouncePadsSystem;
+}

--- a/src/level_config.ts
+++ b/src/level_config.ts
@@ -142,6 +142,10 @@ export type WindCurrentsEnvironmentConfig = {
     zones: WindZoneConfig[];
 };
 
+export type BouncePadsEnvironmentConfig = {
+    pads: { x: number; y: number; z?: number; bounceStrength?: number }[];
+};
+
 export type LevelEnvironments = {
     pastelNebula?: boolean;
     candyPlanetRing?: boolean;
@@ -181,6 +185,7 @@ export type LevelEnvironments = {
     singingGeodes?: boolean | { density?: number };
     cloudCastles?: boolean | { density?: number };
     windCurrents?: boolean | WindCurrentsEnvironmentConfig;
+    bouncePads?: boolean | BouncePadsEnvironmentConfig;
     flowerConstellations?: boolean | { density?: number };
     skyRailTerminal?: boolean | import('./sky_rail_terminal').SkyRailConfig;
 };
@@ -562,7 +567,13 @@ export const LEVEL_CONFIG: { [key: number]: LevelConfig } = {
             asteroidField: { rate: 2.0 },
             industrial: { intensity: 1.0, tunnelSpeed: 1.2 },
             bubbleCoral: { density: 0.85 },
-            skyRailTerminal: true
+            skyRailTerminal: true,
+            bouncePads: {
+                pads: [
+                    { x: 300, y: 0, z: 0, bounceStrength: 45 },
+                    { x: 400, y: 5, z: 0, bounceStrength: 40 }
+                ]
+            }
         },
         vignettes: {
             treeGroves: 0.6,

--- a/src/level_env_registry.ts
+++ b/src/level_env_registry.ts
@@ -54,6 +54,7 @@ export const DEFERRED_ENV_FLAGS = [
     'cloudCastles',
     'windCurrents',
     'flowerConstellations',
+    'bouncePads',
     'spaceGarden'
 ] as const satisfies readonly (keyof LevelEnvironments)[];
 
@@ -256,6 +257,20 @@ export const DEFERRED_ENV_REGISTRY: {
             flag: 'windCurrents',
             activate: (config) => host.windCurrentsSystem.activate(objectConfig(config)),
             deactivate: () => host.windCurrentsSystem.deactivate()
+        })
+    },
+    bouncePads: {
+        flag: 'bouncePads',
+        systemKey: 'bouncePads',
+        load: () => import('./bounce_pads'),
+        install: (ctx, mod) => {
+            const { BouncePadsSystem } = mod as typeof import('./bounce_pads');
+            ctx.installEnvPartial({ bouncePadsSystem: new BouncePadsSystem(ctx.scene) });
+        },
+        plugin: (host) => ({
+            flag: 'bouncePads',
+            activate: (config) => host.bouncePadsSystem.activate(typeof config === 'object' ? config : undefined),
+            deactivate: () => host.bouncePadsSystem.deactivate()
         })
     },
     flowerConstellations: {
@@ -859,6 +874,7 @@ export const DEFERRED_ENV_PLUGIN_ORDER: DeferredEnvSystemKey[] = [
     'skyRailTerminal',
     'windCurrents',
     'flowerConstellations',
+    'bouncePads',
     'spaceGarden'
 ];
 

--- a/src/level_manager/environment_plugins.ts
+++ b/src/level_manager/environment_plugins.ts
@@ -53,6 +53,7 @@ const PLUGIN_ORDER = [
     'bubbleCoral',
     'flowerConstellations',
     'skyRailTerminal',
+    'bouncePads',
     'spaceGarden'
 ] as const satisfies readonly (keyof LevelEnvironments)[];
 

--- a/src/level_manager/manager.ts
+++ b/src/level_manager/manager.ts
@@ -93,7 +93,8 @@ export class LevelManager {
     dynamicStarfieldSystem: LevelEnvironmentPorts['dynamicStarfieldSystem'];
     dayNightCycleSystem: LevelEnvironmentPorts['dayNightCycleSystem'];
     cloudCastlesSystem: LevelEnvironmentPorts['cloudCastlesSystem'];
-    readonly spaceGardenSystem: LevelEnvironmentPorts['spaceGardenSystem'];
+    readonly bouncePadsSystem: LevelEnvironmentPorts['bouncePadsSystem'];
+    spaceGardenSystem: LevelEnvironmentPorts['spaceGardenSystem'];
     readonly candyFieldSystem: LevelEnvironmentPorts['candyFieldSystem'];
     windCurrentsSystem: LevelEnvironmentPorts['windCurrentsSystem'];
     singingGeodeSystem: LevelEnvironmentPorts['singingGeodeSystem'];
@@ -151,6 +152,7 @@ export class LevelManager {
         this.dynamicStarfieldSystem = options.dynamicStarfieldSystem;
         this.dayNightCycleSystem = options.dayNightCycleSystem;
         this.cloudCastlesSystem = options.cloudCastlesSystem;
+        this.bouncePadsSystem = options.bouncePadsSystem;
         this.spaceGardenSystem = options.spaceGardenSystem;
         this.windCurrentsSystem = options.windCurrentsSystem;
         this.candyFieldSystem = options.candyFieldSystem;

--- a/src/level_manager/plugin_host.ts
+++ b/src/level_manager/plugin_host.ts
@@ -30,6 +30,7 @@ export interface LevelPluginHost extends LevelEnvironmentPorts {
     cloudCastlesSystem: LevelEnvironmentPorts['cloudCastlesSystem'] & { activate: (config?: { density?: number }) => void; deactivate: () => void; cleanup: () => void };
     windCurrentsSystem: LevelEnvironmentPorts['windCurrentsSystem'] & { activate: (config?: any) => void; deactivate: () => void; cleanup: () => void; getWindForce: (pos: THREE.Vector3) => THREE.Vector3; };
     candyFieldSystem: LevelEnvironmentPorts['candyFieldSystem'] & { activate: (config?: unknown) => void; deactivate: () => void; setVisible: (visible: boolean) => void; update: (delta: number, cameraX: number) => void };
+    bouncePadsSystem: LevelEnvironmentPorts['bouncePadsSystem'] & { activate: (config?: any) => void; deactivate: () => void; update: (delta: number, cameraX: number, playerPos?: THREE.Vector3) => void; cleanup: () => void; checkCollision: (pos: THREE.Vector3, velY: number) => number | null; };
     singingGeodeSystem: LevelEnvironmentPorts['singingGeodeSystem'] & { activate: (density?: number) => void; deactivate: () => void; update: (delta: number, cameraX: number, playerPos?: THREE.Vector3) => void; cleanup: () => void };
 }
 

--- a/src/level_manager/types.ts
+++ b/src/level_manager/types.ts
@@ -104,6 +104,7 @@ export type LevelEnvironmentPorts = {
     candyFieldSystem: CandyFieldSystem;
     singingGeodeSystem: { activate: (density?: number) => void; deactivate: () => void; update: (delta: number, cameraX: number, playerPos?: THREE.Vector3) => void; cleanup: () => void; };
     flowerConstellationsSystem: { activate: (config?: any, levelLength?: number) => void; deactivate: () => void; update: (delta: number, cameraX: number, playerPos?: THREE.Vector3) => void; cleanup: () => void; };
+    bouncePadsSystem: { activate: (config?: any) => void; deactivate: () => void; update: (delta: number, cameraX: number, playerPos?: THREE.Vector3) => void; cleanup: () => void; checkCollision: (pos: THREE.Vector3, velY: number) => number | null; };
     skyRailTerminalSystem: SkyRailTerminalSystem;
 };
 
@@ -135,5 +136,6 @@ export type LevelManagerOptions = {
     spaceGardenSystem: LevelEnvironmentPorts['spaceGardenSystem'];
     windCurrentsSystem: LevelEnvironmentPorts['windCurrentsSystem'];
     candyFieldSystem: LevelEnvironmentPorts['candyFieldSystem'];
+    bouncePadsSystem: LevelEnvironmentPorts['bouncePadsSystem'];
     singingGeodeSystem: LevelEnvironmentPorts['singingGeodeSystem'];
 };

--- a/src/main/player_update.ts
+++ b/src/main/player_update.ts
@@ -110,6 +110,16 @@ export function updatePlayer(delta: number) {
         );
     }
 
+    // --- BOUNCE PADS CHECK ---
+    const bounceVelocity = game.bouncePadsSystem?.checkCollision(player.position, playerState.currentSpeedY);
+    if (bounceVelocity !== null) {
+        playerState.currentSpeedY = bounceVelocity;
+        game.audioSystem.playBoing();
+        game.particleSystem.emit(player.position.clone().add(new THREE.Vector3(0, -1, 0)), 0x00ffcc, 15, 5.0, 0.5, 0.5);
+        game.dogController.triggerAnimation(DogAnimationState.VICTORY, 0.5);
+    }
+
+
     player.position.y += playerState.currentSpeedY * delta;
     
     // Soft boundaries - keep player on screen (Y: origin-10 to origin+15).

--- a/src/main/startup.ts
+++ b/src/main/startup.ts
@@ -205,6 +205,7 @@ function createLevelManager(
             skyRailTerminalSystem: systems.skyRailTerminalSystem,
             windCurrentsSystem: systems.windCurrentsSystem,
             flowerConstellationsSystem: systems.flowerConstellationsSystem,
+            bouncePadsSystem: systems.bouncePadsSystem,
             spaceGardenSystem: systems.spaceGardenSystem
         },
         spawners: {
@@ -270,7 +271,8 @@ function createLevelManager(
         candyFieldSystem: systems.candyFieldSystem,
         singingGeodeSystem: systems.singingGeodeSystem,
         windCurrentsSystem: systems.windCurrentsSystem,
-        spaceGardenSystem: systems.spaceGardenSystem
+        bouncePadsSystem: systems.bouncePadsSystem,
+            spaceGardenSystem: systems.spaceGardenSystem
     });
 }
 


### PR DESCRIPTION
Implements the "Bounce-Back City" concept from `docs/plans/ideas.md`.

- Creates `src/bounce_pads.ts` using `InstancedMesh` and a glowing TSL `MeshStandardNodeMaterial`.
- Registers the new feature as a deferred environment flag (`LevelEnvironments.bouncePads`).
- Updates `src/level_config.ts` to place a test pair of bounce pads in Level 4 ("The Rusty Gauntlet").
- Hooks up `checkCollision()` inside `src/main/player_update.ts` causing the player to bounce upwards and triggers `audioSystem.playBoing()` alongside particle bursts.

---
*PR created automatically by Jules for task [6610907646658759970](https://jules.google.com/task/6610907646658759970) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable, animated bounce pads to levels.
  * Players can land on pads to receive a vertical boost.
  * Bounce interactions trigger audio, particle effects, and a victory animation.
  * Enabled bounce pads in level 4 with two configured pads.
  * Added support for activating, updating, and deactivating bounce pads as part of level environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->