### PR TITLE
Implement Aerial Guard Patrol detection hook

### DIFF
--- a/src/main/player_update.ts
+++ b/src/main/player_update.ts
@@ -12,6 +12,7 @@ import { BARK_RADIUS } from '../bark_blast_system';
 import { maybePrefetchNextLevel } from '../level_systems_loader';
 import { PowerUpType } from '../powerup_manager';
 import { DogAnimationState } from '../dog_cockpit';
+import { ShakeType } from '../juice_effects/shared';
 
 export function updatePlayer(delta: number) {
     // Don't update if player hasn't loaded yet
@@ -117,6 +118,15 @@ export function updatePlayer(delta: number) {
         game.audioSystem.playBoing();
         game.particleSystem.emit(player.position.clone().add(new THREE.Vector3(0, -1, 0)), 0x00ffcc, 15, 5.0, 0.5, 0.5);
         game.dogController.triggerAnimation(DogAnimationState.VICTORY, 0.5);
+    }
+
+    // --- AERIAL GUARD PATROL CHECK ---
+    const detectionLevel = game.aerialGuardPatrolSystem?.checkDetection(player.position) ?? 0;
+    if (detectionLevel > 0) {
+        playerState.autoScrollSpeed = Math.max(5, playerState.autoScrollSpeed - detectionLevel * 20 * delta);
+        if (detectionLevel > 0.5) {
+            game.juiceManager.shakeScreen(ShakeType.LIGHT, 0.1);
+        }
     }
 
 


### PR DESCRIPTION
Implemented the previously missing gameplay hook for the Aerial Guard Patrol system. The system tracks detection levels properly but player movement wasn't penalised. Now it correctly penalises scroll speed and provides visual feedback via screen shake when detected.

---
*PR created automatically by Jules for task [13649676591963007083](https://jules.google.com/task/13649676591963007083) started by @ford442*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added aerial guard patrol detection during gameplay.
  * Detection now slows automatic scrolling, with a minimum speed limit.
  * Higher detection levels trigger a subtle screen shake for visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->