### PR TITLE
feat: implement Retro Pixel-Glow Mode post-processing

### DIFF
--- a/src/game_runtime.ts
+++ b/src/game_runtime.ts
@@ -26,6 +26,7 @@ import type {
     WebGLMaterialFallbackRenderer,
     WireframeDebugHelper
 } from './render_debug_helpers';
+import type { PixelGlowSystem } from './pixel_glow';
 
 // ---------------------------------------------------------------------------
 // GameContext field groups (Phase 2 slices — flat on `game`, typed for docs/tests)
@@ -118,6 +119,7 @@ export type GameContextExtensions = {
     wireframeDebugHelper: WireframeDebugHelper;
     collisionDebugOverlay: CollisionDebugOverlay;
     webglMaterialFallbackRenderer: WebGLMaterialFallbackRenderer;
+    pixelGlowSystem: PixelGlowSystem;
     reportComboObjectiveProgress: () => void;
     handleGameOver: () => void;
     /** Re-attach slingable callbacks after deferred manager swap. */

--- a/src/main/game_loop.ts
+++ b/src/main/game_loop.ts
@@ -6,6 +6,7 @@ import { updateLoopCombat } from './loop_combat';
 import { updateLoopWorld } from './loop_world';
 import { updateLoopGeological } from './loop_geological';
 import { updateLoopFinish } from './loop_finish';
+import { renderGameFrame } from './render_helpers';
 
 export function startGameLoop(): void {
     game.clock = new THREE.Clock();
@@ -17,10 +18,10 @@ function animate(): void {
     const delta = game.juiceManager.update(rawDelta);
     const time = game.clock.getElapsedTime();
 
-    if (updateLoopCore(rawDelta, delta, time)) return;
-    if (updateLoopCombat(rawDelta, delta, time)) return;
-
-    updateLoopWorld(delta, time);
-    updateLoopGeological(delta, time);
-    updateLoopFinish(time);
+    if (!updateLoopCore(rawDelta, delta, time) && !updateLoopCombat(rawDelta, delta, time)) {
+        updateLoopWorld(delta, time);
+        updateLoopGeological(delta, time);
+        updateLoopFinish(time);
+    }
+    renderGameFrame();
 }

--- a/src/main/input_bindings.ts
+++ b/src/main/input_bindings.ts
@@ -164,6 +164,11 @@ export function setupInputBindings(): void {
             renderer.setPixelRatio(game.currentPixelRatio);
             console.log(`🔧 Resolution set to ${Math.round(next * 100)}% (pixel ratio ${game.currentPixelRatio.toFixed(2)})`);
         }
+        if (e.code === 'KeyP') {
+            if (game.pixelGlowSystem) {
+                game.pixelGlowSystem.toggle();
+            }
+        }
     });
 
     window.addEventListener('keydown', (e) => {

--- a/src/main/loop_core.ts
+++ b/src/main/loop_core.ts
@@ -106,7 +106,6 @@ export function updateLoopCore(rawDelta: number, delta: number, _time: number): 
         }
         
         if (isGamePaused) {
-            renderGameFrame();
             return true;
         }
     

--- a/src/main/loop_finish.ts
+++ b/src/main/loop_finish.ts
@@ -5,7 +5,6 @@ import { keys, updateDistanceDisplay } from '../ui_controls';
 import { VictoryState } from '../victory_system';
 import { DogAnimationState } from '../dog_cockpit';
 import { updateHeatBar, updateCoresDisplay, updateBoostDisplay, updateRollDisplay, updateBarkDisplay, updateTetherDisplay, updateGrenadeDisplay } from './hud_displays';
-import { renderGameFrame } from './render_helpers';
 
 export function updateLoopFinish(_time: number): void {
         

--- a/src/main/render_helpers.ts
+++ b/src/main/render_helpers.ts
@@ -23,6 +23,15 @@ export function initRenderHelpers(): void {
 }
 
 export function renderGameFrame(): void {
+    const isGlowActive = game.debugSystem.isEnabled('pixelGlow') || (game.pixelGlowSystem && game.pixelGlowSystem.active);
+
+    if (game.pixelGlowSystem && isGlowActive && rendererBackend === 'webgpu') {
+        if (!game.pixelGlowSystem.postProcessing) {
+            game.pixelGlowSystem.activate(renderer as any, scene, camera);
+        }
+        game.pixelGlowSystem.postProcessing!.render();
+        return;
+    }
     game.webglMaterialFallbackRenderer.render(renderer, scene, camera);
 }
 

--- a/src/main/startup.ts
+++ b/src/main/startup.ts
@@ -52,6 +52,7 @@ import {
     WebGLMaterialFallbackRenderer,
     WireframeDebugHelper
 } from '../render_debug_helpers';
+import { PixelGlowSystem } from '../pixel_glow';
 
 async function loadWasm(): Promise<void> {
     const handle = await loadWasmModule();
@@ -403,6 +404,7 @@ export function initializeStartup(): void {
         ['chromaShift', 'Chroma Rocks', true],
         ['godRays', 'God Rays', true],
         ['aurora', 'Aurora Borealis', true],
+        ['pixelGlow', 'Retro Pixel-Glow', hasDebugUrlFlag('pixelGlow')],
         ['wireframe', 'Wireframe', hasDebugUrlFlag('wireframe')],
         ['collisionDebug', 'Collision Debug', hasDebugUrlFlag('collisionDebug') || hasDebugUrlFlag('collision-debug')]
     ];
@@ -462,6 +464,7 @@ export function initializeStartup(): void {
         wireframeDebugHelper: new WireframeDebugHelper(),
         collisionDebugOverlay: new CollisionDebugOverlay(scene),
         webglMaterialFallbackRenderer: new WebGLMaterialFallbackRenderer(rendererBackend),
+        pixelGlowSystem: new PixelGlowSystem(),
         levelManager,
         obstacleSystem,
         handleGameOver

--- a/src/pixel_glow.ts
+++ b/src/pixel_glow.ts
@@ -1,0 +1,56 @@
+import * as THREE from 'three';
+import { WebGPURenderer } from 'three/webgpu';
+import PostProcessing from 'three/src/renderers/common/PostProcessing.js';
+import { pass, float } from 'three/tsl';
+import { bloom } from 'three/examples/jsm/tsl/display/BloomNode.js';
+import { pixelationPass } from 'three/examples/jsm/tsl/display/PixelationPassNode.js';
+
+export class PixelGlowSystem {
+    active: boolean = false;
+    postProcessing: PostProcessing | null = null;
+
+    constructor() {
+        this.deactivate();
+    }
+
+    activate(renderer: any, scene: THREE.Scene, camera: THREE.Camera) {
+        if (!this.postProcessing) {
+            this.postProcessing = new PostProcessing(renderer as any);
+
+            const scenePass = pass(scene, camera);
+
+            // Apply pixelation effect to make it look retro
+            // pixelSize, normalEdgeStrength, depthEdgeStrength
+            const pixelation = pixelationPass(scene, camera, float(4), float(1.5), float(0.2));
+
+            // Apply bloom to the pixelated output for a neon glow
+            // node, strength, radius, threshold
+            const bloomPass = bloom(pixelation, 1.5, 0.4, 0.2);
+
+            this.postProcessing.outputNode = bloomPass as any;
+        }
+    }
+
+    deactivate() {
+        if (!this.active) return;
+        this.active = false;
+    }
+
+    toggle() {
+        this.active = !this.active;
+        console.log(this.active ? '🌌 Retro Pixel-Glow Mode ENABLED' : '🌌 Retro Pixel-Glow Mode DISABLED');
+    }
+
+    update(delta: number, cameraX: number, playerPos?: THREE.Vector3) {
+        if (!this.active) return;
+        // Animation or dynamic adjustments can go here if needed.
+    }
+
+    cleanup() {
+        this.deactivate();
+        if (this.postProcessing) {
+            this.postProcessing.dispose();
+            this.postProcessing = null;
+        }
+    }
+}


### PR DESCRIPTION
- Added `PixelGlowSystem` in `src/pixel_glow.ts` using the Cosmic Architect pattern.
- Implemented TSL post-processing with `pixelationPass` and `bloom` for a neon outline effect, available exclusively on the WebGPU backend.
- Refactored the main render loop to centralize the `renderGameFrame()` call unconditionally at the end of `animate()` in `src/main/game_loop.ts` (removed redundant paused-only render call in `loop_core.ts` and unused import in `loop_finish.ts`).
- Updated `renderGameFrame()` to conditionally trigger the PostProcessing chain if `PixelGlowSystem` is active and the backend is `webgpu`.
- Added a global `KeyP` toggle in `src/main/input_bindings.ts` and a debug toggle in `src/main/startup.ts`.

---
*PR created automatically by Jules for task [14752303180550679051](https://jules.google.com/task/14752303180550679051) started by @ford442*