### PR TITLE
Fixed-timestep gameplay simulation with render interpolation

### DIFF
--- a/src/combo_corridor.ts
+++ b/src/combo_corridor.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { time, color, positionWorld, mix, smoothstep, uniform } from 'three/tsl';
 import { MeshBasicNodeMaterial } from 'three/webgpu';
 import type { TSLNode, TSLUniform } from './tsl_types';
+import { comboCorridorRandom } from './combo_corridor_rng';
 
 export interface ComboCorridorEnvironmentConfig {
     density?: number;
@@ -55,10 +56,10 @@ export class ComboCorridorSystem {
         for (let i = 0; i < this.ringCount; i++) {
             this._dummy.position.set(
                 i * spacing,
-                (Math.random() - 0.5) * 20,
-                (Math.random() - 0.5) * 20
+                (comboCorridorRandom() - 0.5) * 20,
+                (comboCorridorRandom() - 0.5) * 20
             );
-            this._dummy.scale.setScalar(0.5 + Math.random() * 1.5);
+            this._dummy.scale.setScalar(0.5 + comboCorridorRandom() * 1.5);
             this._dummy.updateMatrix();
             this.mesh.setMatrixAt(i, this._dummy.matrix);
         }
@@ -100,8 +101,8 @@ export class ComboCorridorSystem {
 
             if (this._position.x < limitBack) {
                 this._position.x += wrapRange + this._speed * 50;
-                this._position.y = (Math.random() - 0.5) * 20;
-                this._position.z = (Math.random() - 0.5) * 20;
+                this._position.y = (comboCorridorRandom() - 0.5) * 20;
+                this._position.z = (comboCorridorRandom() - 0.5) * 20;
             } else if (this._position.x > limitFront) {
                 this._position.x -= wrapRange;
             } else {

--- a/src/combo_corridor_rng.ts
+++ b/src/combo_corridor_rng.ts
@@ -1,0 +1,14 @@
+import { tryGetRunSeed, getRunRngFork } from './run_seed';
+
+/**
+ * Uniform float in [0, 1) for Combo Corridor ring placement.
+ *
+ * Routed through the seeded run RNG (named substream `comboCorridor`) so a
+ * run replayed from the same seed places rings identically. Falls back to
+ * Math.random() only if a ring is placed before beginRun() has run (e.g.
+ * during isolated construction outside a real game session) — this is
+ * decorative placement, not something a fallback here would desync.
+ */
+export function comboCorridorRandom(): number {
+    return tryGetRunSeed() ? getRunRngFork('comboCorridor').random() : Math.random();
+}

--- a/src/main/fixed_timestep.ts
+++ b/src/main/fixed_timestep.ts
@@ -1,0 +1,65 @@
+/**
+ * Fixed-timestep accumulator for the gameplay simulation.
+ *
+ * Gameplay systems (player motion, obstacles, combat, etc.) must integrate
+ * against a constant step size so runs are reproducible independent of
+ * display refresh rate. Purely visual systems (particles, screen shake,
+ * shader `time` uniforms) should keep using wall-clock delta and are not
+ * routed through this accumulator.
+ */
+
+/** Simulation rate in Hz. Gameplay always advances in increments of SIM_STEP seconds. */
+export const SIM_HZ = 60;
+export const SIM_STEP = 1 / SIM_HZ;
+
+/** Clamp on a single rendered frame's wall-clock delta (matches the previous per-frame clamp). */
+export const MAX_FRAME_DELTA = 0.1;
+
+/**
+ * Spiral-of-death guard: the most sim steps `advanceAccumulator` will report
+ * for a single frame. Any remaining accumulated time beyond that is dropped
+ * rather than queued, so a slow frame produces visible slow-motion instead
+ * of an ever-growing backlog of catch-up steps.
+ */
+export const MAX_STEPS_PER_FRAME = 8;
+
+export interface AccumulatorResult {
+    /** Number of fixed steps to run this frame (0..MAX_STEPS_PER_FRAME). */
+    steps: number;
+    /** Accumulator value after consuming `steps` worth of simulation time. */
+    remainder: number;
+}
+
+/**
+ * Pure step-count computation: given the current accumulator and the delta
+ * to add this frame, returns how many SIM_STEP-sized steps to run and the
+ * leftover accumulator (used as the render-interpolation alpha numerator).
+ */
+// Floating-point tolerance so repeated frame deltas that sum to *almost*
+// exactly SIM_STEP (e.g. 144 frames of 1/144s at a 60Hz sim) still fire the
+// step instead of drifting a whole step behind.
+const EPSILON = 1e-9;
+
+export function advanceAccumulator(accumulator: number, frameDelta: number): AccumulatorResult {
+    let acc = accumulator + Math.max(0, frameDelta);
+    let steps = 0;
+
+    while (acc >= SIM_STEP - EPSILON && steps < MAX_STEPS_PER_FRAME) {
+        acc -= SIM_STEP;
+        steps++;
+    }
+    acc = Math.max(0, acc);
+
+    // Spiral-of-death: drop any backlog beyond MAX_STEPS_PER_FRAME instead of
+    // letting it carry forward and compound on the next frame.
+    if (steps === MAX_STEPS_PER_FRAME && acc >= SIM_STEP) {
+        acc = acc % SIM_STEP;
+    }
+
+    return { steps, remainder: acc };
+}
+
+/** Render-interpolation alpha in [0, 1] for the given leftover accumulator. */
+export function interpolationAlpha(remainder: number): number {
+    return Math.min(1, Math.max(0, remainder / SIM_STEP));
+}

--- a/src/main/frame_housekeeping.ts
+++ b/src/main/frame_housekeeping.ts
@@ -1,0 +1,105 @@
+import { scene, camera, mainLight, renderer, touchControls } from '../scene_context';
+import { player } from '../player_loader';
+import { isGamePaused } from '../game_config';
+import { game } from '../game_runtime';
+import { getCollisionDebugTargets, RESOLUTION_RATIOS } from './render_helpers';
+import { updateGpuLeakDetector } from '../gpu_leak_detector';
+import * as THREE from 'three';
+
+/**
+ * Runs once per rendered frame on wall-clock `rawDelta`, independent of how
+ * many (if any) fixed simulation steps run this frame. Everything here is
+ * debug/perf instrumentation or input plumbing that must be measured against
+ * real time — folding it into the sim accumulator would make the FPS-based
+ * dynamic resolution logic read a constant ~60fps instead of the actual
+ * render rate.
+ *
+ * Returns whether gameplay is currently paused (the caller should skip the
+ * fixed-step accumulator entirely when true).
+ */
+export function updateFrameHousekeeping(rawDelta: number): boolean {
+    // --- Debug System ---
+    game.debugSystem.update(rawDelta);
+    updateGpuLeakDetector(rawDelta);
+    try {
+        game.wireframeDebugHelper.update(scene, game.debugSystem.isEnabled('wireframe'));
+        game.collisionDebugOverlay.update(
+            game.debugSystem.isEnabled('collisionDebug'),
+            getCollisionDebugTargets()
+        );
+    } catch (error) {
+        if (!game.renderDebugWarningIssued) {
+            game.renderDebugWarningIssued = true;
+            console.warn('Renderer debug helpers skipped because a tracked object was malformed.', error);
+        }
+    }
+
+    // --- FPS Tracking & Dynamic Pixel Ratio ---
+    game.fpsFrameCount++;
+    game.fpsElapsedTime += rawDelta;
+    if (game.fpsElapsedTime >= 1.0) {
+        const fps = game.fpsFrameCount / game.fpsElapsedTime;
+        game.fpsFrameCount = 0;
+        game.fpsElapsedTime = 0;
+
+        if (fps < 45) {
+            game.fpsLowDuration += 1.0;
+            game.fpsHighDuration = 0;
+            if (game.fpsLowDuration >= 3.0 && game.currentRatioIndex > 0) {
+                game.currentRatioIndex--;
+                game.currentPixelRatio = Math.min(2, window.devicePixelRatio * RESOLUTION_RATIOS[game.currentRatioIndex]);
+                renderer.setPixelRatio(game.currentPixelRatio);
+                console.log(`Performance low — dropping resolution to ${Math.round(RESOLUTION_RATIOS[game.currentRatioIndex] * 100)}%`);
+            }
+        } else if (fps > 55) {
+            game.fpsHighDuration += 1.0;
+            game.fpsLowDuration = 0;
+            if (game.fpsHighDuration >= 5.0 && game.currentRatioIndex < RESOLUTION_RATIOS.length - 1) {
+                game.currentRatioIndex++;
+                game.currentPixelRatio = Math.min(2, window.devicePixelRatio * RESOLUTION_RATIOS[game.currentRatioIndex]);
+                renderer.setPixelRatio(game.currentPixelRatio);
+                console.log(`Performance recovered — restoring resolution to ${Math.round(RESOLUTION_RATIOS[game.currentRatioIndex] * 100)}%`);
+            }
+        } else {
+            game.fpsLowDuration = 0;
+            game.fpsHighDuration = 0;
+        }
+
+        if (fps < 45 && game.objectDensityMultiplier > 0.25) {
+            game.objectDensityMultiplier = Math.max(0.25, game.objectDensityMultiplier - 0.25);
+            game.levelManager.setObjectDensityMultiplier(game.objectDensityMultiplier);
+            console.log(`Performance low — reducing object density to ${Math.round(game.objectDensityMultiplier * 100)}%`);
+        } else if (fps > 55 && game.objectDensityMultiplier < 1.0) {
+            game.objectDensityMultiplier = Math.min(1.0, game.objectDensityMultiplier + 0.25);
+            game.levelManager.setObjectDensityMultiplier(game.objectDensityMultiplier);
+            console.log(`Performance recovered — restoring object density to ${Math.round(game.objectDensityMultiplier * 100)}%`);
+        }
+    }
+
+    // --- Debug Shadow Toggle ---
+    const shadowsOn = game.debugSystem.isEnabled('shadows');
+    if (mainLight.castShadow !== shadowsOn) {
+        mainLight.castShadow = shadowsOn;
+        renderer.shadowMap.enabled = shadowsOn;
+    }
+
+    if (isGamePaused) {
+        return true;
+    }
+
+    // Update rocket position for touch controls (follow finger mode)
+    if (touchControls && player) {
+        // Convert player position to screen space for follow finger mode
+        const vector = player.position.clone();
+        vector.project(camera);
+        const screenX = (vector.x * 0.5 + 0.5) * window.innerWidth;
+        const screenY = (-vector.y * 0.5 + 0.5) * window.innerHeight;
+
+        touchControls.setRocketPosition(
+            player.position,
+            new THREE.Vector2(screenX, screenY)
+        );
+    }
+
+    return false;
+}

--- a/src/main/game_loop.ts
+++ b/src/main/game_loop.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { renderer } from '../scene_context';
+import { player } from '../player_loader';
 import { game } from '../game_runtime';
 import { updateLoopCore } from './loop_core';
 import { updateLoopCombat } from './loop_combat';
@@ -7,21 +8,68 @@ import { updateLoopWorld } from './loop_world';
 import { updateLoopGeological } from './loop_geological';
 import { updateLoopFinish } from './loop_finish';
 import { renderGameFrame } from './render_helpers';
+import { updateFrameHousekeeping } from './frame_housekeeping';
+import { advanceAccumulator, interpolationAlpha, MAX_FRAME_DELTA, SIM_STEP } from './fixed_timestep';
+import { PositionInterpolator } from './render_interpolation';
+
+let accumulator = 0;
+const playerInterpolator = new PositionInterpolator();
 
 export function startGameLoop(): void {
     game.clock = new THREE.Clock();
+    accumulator = 0;
+    playerInterpolator.reset();
     renderer.setAnimationLoop(animate);
 }
 
 function animate(): void {
-    const rawDelta = Math.min(game.clock.getDelta(), 0.1);
-    const delta = game.juiceManager.update(rawDelta);
+    const rawDelta = Math.min(game.clock.getDelta(), MAX_FRAME_DELTA);
+    // Visual-only systems (screen shake, flashes, floating text) stay on
+    // wall-clock delta; hit-pause freezes gameplay by shrinking it below.
+    const hitPauseDelta = game.juiceManager.update(rawDelta);
     const time = game.clock.getElapsedTime();
 
-    if (!updateLoopCore(rawDelta, delta, time) && !updateLoopCombat(rawDelta, delta, time)) {
-        updateLoopWorld(delta, time);
-        updateLoopGeological(delta, time);
-        updateLoopFinish(time);
+    const paused = updateFrameHousekeeping(rawDelta);
+
+    if (paused) {
+        accumulator = 0;
+    } else {
+        const { steps, remainder } = advanceAccumulator(accumulator, hitPauseDelta);
+        accumulator = remainder;
+        for (let i = 0; i < steps; i++) {
+            stepSimulation(time);
+            if (player) playerInterpolator.recordStep(player.position);
+        }
     }
+
+    renderInterpolated(time);
+}
+
+function stepSimulation(time: number): void {
+    updateLoopCore(SIM_STEP, time);
+    if (updateLoopCombat(SIM_STEP, time)) return;
+    updateLoopWorld(SIM_STEP, time);
+    updateLoopGeological(SIM_STEP, time);
+    updateLoopFinish(time);
+}
+
+/**
+ * Draws the frame with the player's rendered mesh blended between its last
+ * two simulation positions, so a fixed 60Hz sim doesn't look worse than
+ * wall-clock movement on a high-refresh display. All other gameplay state
+ * (collision, camera targeting, HUD) already ran against the true
+ * end-of-step position inside stepSimulation — only this draw call sees the
+ * interpolated blend, so no other consumer of player.position is affected.
+ */
+function renderInterpolated(_time: number): void {
+    const interpolated = player ? playerInterpolator.getInterpolated(interpolationAlpha(accumulator)) : null;
+    if (!player || !interpolated) {
+        renderGameFrame();
+        return;
+    }
+
+    const truePosition = player.position.clone();
+    player.position.copy(interpolated);
     renderGameFrame();
+    player.position.copy(truePosition);
 }

--- a/src/main/loop_combat/index.ts
+++ b/src/main/loop_combat/index.ts
@@ -11,7 +11,7 @@ import { updateCombatWeapons } from './weapons';
  * Combat-phase loop: boss, pickups, power-ups, friends, weapons.
  * Returns true on mouth-snap game-over (early exit from animate).
  */
-export function updateLoopCombat(_rawDelta: number, delta: number, time: number): boolean {
+export function updateLoopCombat(delta: number, time: number): boolean {
     if (updateCombatBoss(delta)) return true;
 
     let timeScale = game.powerUpManager.getCombinedModifiers().timeScale;

--- a/src/main/loop_core.ts
+++ b/src/main/loop_core.ts
@@ -1,7 +1,6 @@
-import * as THREE from 'three';
-import { scene, camera, mainLight, renderer, touchControls } from '../scene_context';
+import { camera, touchControls } from '../scene_context';
 import { player } from '../player_loader';
-import { playerState, isGamePaused } from '../game_config';
+import { playerState } from '../game_config';
 import { game } from '../game_runtime';
 import { DogAnimationState } from '../dog_cockpit';
 import { ShakeType } from '../juice_effects';
@@ -30,99 +29,19 @@ import {
 } from '../geological';
 
 import { updatePlayer } from './player_update';
-import { renderGameFrame, getCollisionDebugTargets, RESOLUTION_RATIOS } from './render_helpers';
-import { updateGpuLeakDetector } from '../gpu_leak_detector';
 import { ghostRunRecorder, buildActionFlags } from '../ghost_run';
 import { updateChapterMusicDynamics } from './music_update';
 
-
-export function updateLoopCore(rawDelta: number, delta: number, _time: number): boolean {
+/**
+ * Gameplay-affecting portion of the "core" loop phase, run once per fixed
+ * simulation step (see fixed_timestep.ts). Per-frame-only bookkeeping (FPS
+ * tracking, dynamic resolution, debug toggles, the pause gate) lives in
+ * frame_housekeeping.ts and runs once per rendered frame instead.
+ */
+export function updateLoopCore(delta: number, _time: number): void {
         // --- Sling Combo Manager ---
         game.slingComboManager.update(delta);
-    
-        // --- Debug System ---
-        game.debugSystem.update(rawDelta);
-        updateGpuLeakDetector(rawDelta);
-        try {
-            game.wireframeDebugHelper.update(scene, game.debugSystem.isEnabled('wireframe'));
-            game.collisionDebugOverlay.update(
-                game.debugSystem.isEnabled('collisionDebug'),
-                getCollisionDebugTargets()
-            );
-        } catch (error) {
-            if (!game.renderDebugWarningIssued) {
-                game.renderDebugWarningIssued = true;
-                console.warn('Renderer debug helpers skipped because a tracked object was malformed.', error);
-            }
-        }
-    
-        // --- FPS Tracking & Dynamic Pixel Ratio ---
-        game.fpsFrameCount++;
-        game.fpsElapsedTime += rawDelta;
-        if (game.fpsElapsedTime >= 1.0) {
-            const fps = game.fpsFrameCount / game.fpsElapsedTime;
-            game.fpsFrameCount = 0;
-            game.fpsElapsedTime = 0;
-    
-            if (fps < 45) {
-                game.fpsLowDuration += 1.0;
-                game.fpsHighDuration = 0;
-                if (game.fpsLowDuration >= 3.0 && game.currentRatioIndex > 0) {
-                    game.currentRatioIndex--;
-                    game.currentPixelRatio = Math.min(2, window.devicePixelRatio * RESOLUTION_RATIOS[game.currentRatioIndex]);
-                    renderer.setPixelRatio(game.currentPixelRatio);
-                    console.log(`Performance low — dropping resolution to ${Math.round(RESOLUTION_RATIOS[game.currentRatioIndex] * 100)}%`);
-                }
-            } else if (fps > 55) {
-                game.fpsHighDuration += 1.0;
-                game.fpsLowDuration = 0;
-                if (game.fpsHighDuration >= 5.0 && game.currentRatioIndex < RESOLUTION_RATIOS.length - 1) {
-                    game.currentRatioIndex++;
-                    game.currentPixelRatio = Math.min(2, window.devicePixelRatio * RESOLUTION_RATIOS[game.currentRatioIndex]);
-                    renderer.setPixelRatio(game.currentPixelRatio);
-                    console.log(`Performance recovered — restoring resolution to ${Math.round(RESOLUTION_RATIOS[game.currentRatioIndex] * 100)}%`);
-                }
-            } else {
-                game.fpsLowDuration = 0;
-                game.fpsHighDuration = 0;
-            }
-    
-            if (fps < 45 && game.objectDensityMultiplier > 0.25) {
-                game.objectDensityMultiplier = Math.max(0.25, game.objectDensityMultiplier - 0.25);
-                game.levelManager.setObjectDensityMultiplier(game.objectDensityMultiplier);
-                console.log(`Performance low — reducing object density to ${Math.round(game.objectDensityMultiplier * 100)}%`);
-            } else if (fps > 55 && game.objectDensityMultiplier < 1.0) {
-                game.objectDensityMultiplier = Math.min(1.0, game.objectDensityMultiplier + 0.25);
-                game.levelManager.setObjectDensityMultiplier(game.objectDensityMultiplier);
-                console.log(`Performance recovered — restoring object density to ${Math.round(game.objectDensityMultiplier * 100)}%`);
-            }
-        }
-    
-        // --- Debug Shadow Toggle ---
-        const shadowsOn = game.debugSystem.isEnabled('shadows');
-        if (mainLight.castShadow !== shadowsOn) {
-            mainLight.castShadow = shadowsOn;
-            renderer.shadowMap.enabled = shadowsOn;
-        }
-        
-        if (isGamePaused) {
-            return true;
-        }
-    
-        // Update rocket position for touch controls (follow finger mode)
-        if (touchControls && player) {
-            // Convert player position to screen space for follow finger mode
-            const vector = player.position.clone();
-            vector.project(camera);
-            const screenX = (vector.x * 0.5 + 0.5) * window.innerWidth;
-            const screenY = (-vector.y * 0.5 + 0.5) * window.innerHeight;
-            
-            touchControls.setRocketPosition(
-                player.position,
-                new THREE.Vector2(screenX, screenY)
-            );
-        }
-    
+
         updatePlayer(delta);
 
         if (player) {
@@ -241,6 +160,4 @@ export function updateLoopCore(rawDelta: number, delta: number, _time: number): 
 
         // Feed speed / boost / danger / quiet into the chapter music mix.
         updateChapterMusicDynamics();
-
-        return false;
 }

--- a/src/main/render_interpolation.ts
+++ b/src/main/render_interpolation.ts
@@ -1,0 +1,49 @@
+import * as THREE from 'three';
+
+/**
+ * Tracks the last two authoritative simulation positions of a fast-moving
+ * entity (the player) so the renderer can draw a blend between them instead
+ * of snapping to the latest fixed-step position. This keeps a 60Hz sim from
+ * looking worse than wall-clock movement on a high-refresh display.
+ *
+ * The sim keeps writing to the entity's real Object3D.position each fixed
+ * step; callers should sample() before/after each step and only use
+ * getInterpolated() to compute a transient render-only position.
+ */
+export class PositionInterpolator {
+    private readonly previous = new THREE.Vector3();
+    private readonly current = new THREE.Vector3();
+    private readonly blended = new THREE.Vector3();
+    private primed = false;
+
+    /**
+     * Call once after every fixed simulation step. Shifts `current` into
+     * `previous` first, so after N steps in a frame `previous`/`current`
+     * hold exactly the last two simulation states — never the state from
+     * before the frame's whole catch-up run.
+     */
+    recordStep(position: THREE.Vector3): void {
+        if (this.primed) {
+            this.previous.copy(this.current);
+        } else {
+            this.previous.copy(position);
+            this.primed = true;
+        }
+        this.current.copy(position);
+    }
+
+    reset(): void {
+        this.primed = false;
+    }
+
+    hasSample(): boolean {
+        return this.primed;
+    }
+
+    /** Blend of the last two recorded positions; alpha is clamped to [0, 1]. */
+    getInterpolated(alpha: number): THREE.Vector3 | null {
+        if (!this.primed) return null;
+        const a = Math.min(1, Math.max(0, alpha));
+        return this.blended.lerpVectors(this.previous, this.current, a);
+    }
+}

--- a/tests/unit/combo_corridor_rng.test.ts
+++ b/tests/unit/combo_corridor_rng.test.ts
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { comboCorridorRandom } from '../../src/combo_corridor_rng.ts';
+import { beginRun } from '../../src/run_seed/run_context.ts';
+import { RUN_SEED_SCHEMA_VERSION } from '../../src/run_seed/types.ts';
+
+function draws(n: number): number[] {
+    const values: number[] = [];
+    for (let i = 0; i < n; i++) values.push(comboCorridorRandom());
+    return values;
+}
+
+test('comboCorridorRandom is deterministic for the same run seed', () => {
+    beginRun({ version: RUN_SEED_SCHEMA_VERSION, campaignId: 'campaign', rngSeed: 777, modifiers: [] });
+    const a = draws(10);
+
+    beginRun({ version: RUN_SEED_SCHEMA_VERSION, campaignId: 'campaign', rngSeed: 777, modifiers: [] });
+    const b = draws(10);
+
+    assert.deepEqual(a, b);
+});
+
+test('comboCorridorRandom differs for different run seeds', () => {
+    beginRun({ version: RUN_SEED_SCHEMA_VERSION, campaignId: 'campaign', rngSeed: 1, modifiers: [] });
+    const a = draws(5);
+
+    beginRun({ version: RUN_SEED_SCHEMA_VERSION, campaignId: 'campaign', rngSeed: 2, modifiers: [] });
+    const b = draws(5);
+
+    assert.notDeepEqual(a, b);
+});
+
+test('comboCorridorRandom stays in [0, 1)', () => {
+    beginRun({ version: RUN_SEED_SCHEMA_VERSION, campaignId: 'campaign', rngSeed: 42, modifiers: [] });
+    for (const v of draws(200)) {
+        assert.ok(v >= 0 && v < 1);
+    }
+});

--- a/tests/unit/fixed_timestep.test.ts
+++ b/tests/unit/fixed_timestep.test.ts
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    advanceAccumulator,
+    interpolationAlpha,
+    SIM_STEP,
+    SIM_HZ,
+    MAX_STEPS_PER_FRAME
+} from '../../src/main/fixed_timestep.ts';
+
+test('SIM_STEP matches SIM_HZ', () => {
+    assert.equal(SIM_STEP, 1 / SIM_HZ);
+});
+
+test('advanceAccumulator runs zero steps when under one SIM_STEP', () => {
+    const result = advanceAccumulator(0, SIM_STEP * 0.5);
+    assert.equal(result.steps, 0);
+    assert.equal(result.remainder, SIM_STEP * 0.5);
+});
+
+test('advanceAccumulator runs exactly one step at the sim rate', () => {
+    const result = advanceAccumulator(0, SIM_STEP);
+    assert.equal(result.steps, 1);
+    assert.ok(Math.abs(result.remainder) < 1e-12);
+});
+
+test('advanceAccumulator produces the same total simulated time at different frame rates', () => {
+    // Simulate ~1 second of wall-clock time at three different frame rates
+    // and confirm the same number of fixed steps run in each case.
+    const rates = [30, 60, 144];
+    const stepCounts = rates.map((hz) => {
+        const frameDelta = 1 / hz;
+        let acc = 0;
+        let totalSteps = 0;
+        for (let frame = 0; frame < hz; frame++) {
+            const { steps, remainder } = advanceAccumulator(acc, frameDelta);
+            totalSteps += steps;
+            acc = remainder;
+        }
+        return totalSteps;
+    });
+
+    assert.deepEqual(stepCounts, [SIM_HZ, SIM_HZ, SIM_HZ]);
+});
+
+test('advanceAccumulator clamps a huge stall instead of spiraling', () => {
+    const result = advanceAccumulator(0, 5.0); // a 5 second stall (e.g. tab backgrounded)
+    assert.equal(result.steps, MAX_STEPS_PER_FRAME);
+    assert.ok(result.remainder < SIM_STEP, 'backlog beyond the cap must be dropped, not queued');
+});
+
+test('advanceAccumulator never returns a negative remainder for a negative delta', () => {
+    const result = advanceAccumulator(SIM_STEP * 0.5, -1);
+    assert.equal(result.steps, 0);
+    assert.equal(result.remainder, SIM_STEP * 0.5);
+});
+
+test('interpolationAlpha is 0 at the start of a step window and approaches 1 before the next step', () => {
+    assert.equal(interpolationAlpha(0), 0);
+    assert.ok(interpolationAlpha(SIM_STEP * 0.999) > 0.99);
+    assert.equal(interpolationAlpha(SIM_STEP), 1);
+});
+
+test('interpolationAlpha clamps out-of-range remainders', () => {
+    assert.equal(interpolationAlpha(-1), 0);
+    assert.equal(interpolationAlpha(SIM_STEP * 5), 1);
+});

--- a/tests/unit/render_interpolation.test.ts
+++ b/tests/unit/render_interpolation.test.ts
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import * as THREE from 'three';
+import { PositionInterpolator } from '../../src/main/render_interpolation.ts';
+
+test('getInterpolated returns null before any step is recorded', () => {
+    const interpolator = new PositionInterpolator();
+    assert.equal(interpolator.hasSample(), false);
+    assert.equal(interpolator.getInterpolated(0.5), null);
+});
+
+test('the first recorded step has no previous state to blend from', () => {
+    const interpolator = new PositionInterpolator();
+    interpolator.recordStep(new THREE.Vector3(10, 0, 0));
+    const blended = interpolator.getInterpolated(0.5)!;
+    assert.equal(blended.x, 10);
+});
+
+test('blends between the last two recorded steps', () => {
+    const interpolator = new PositionInterpolator();
+    interpolator.recordStep(new THREE.Vector3(0, 0, 0));
+    interpolator.recordStep(new THREE.Vector3(10, 0, 0));
+
+    assert.equal(interpolator.getInterpolated(0)!.x, 0);
+    assert.equal(interpolator.getInterpolated(1)!.x, 10);
+    assert.equal(interpolator.getInterpolated(0.5)!.x, 5);
+});
+
+test('after multiple steps in one frame, only the last two states are blended', () => {
+    const interpolator = new PositionInterpolator();
+    interpolator.recordStep(new THREE.Vector3(0, 0, 0));
+    interpolator.recordStep(new THREE.Vector3(10, 0, 0));
+    interpolator.recordStep(new THREE.Vector3(20, 0, 0));
+    interpolator.recordStep(new THREE.Vector3(30, 0, 0));
+
+    // Must blend between 20 and 30, not between the very first (0) and last (30).
+    assert.equal(interpolator.getInterpolated(0)!.x, 20);
+    assert.equal(interpolator.getInterpolated(1)!.x, 30);
+});
+
+test('getInterpolated clamps alpha outside [0, 1]', () => {
+    const interpolator = new PositionInterpolator();
+    interpolator.recordStep(new THREE.Vector3(0, 0, 0));
+    interpolator.recordStep(new THREE.Vector3(10, 0, 0));
+
+    assert.equal(interpolator.getInterpolated(-5)!.x, 0);
+    assert.equal(interpolator.getInterpolated(5)!.x, 10);
+});
+
+test('reset clears the sample', () => {
+    const interpolator = new PositionInterpolator();
+    interpolator.recordStep(new THREE.Vector3(1, 2, 3));
+    interpolator.reset();
+    assert.equal(interpolator.hasSample(), false);
+    assert.equal(interpolator.getInterpolated(0.5), null);
+});


### PR DESCRIPTION
## Summary

This is the first slice of the fixed-timestep proposal: it decouples gameplay from raw frame delta and gets render interpolation working, without attempting the full multi-week epic (see "Not in this PR" below).

- **Fixed-timestep accumulator** (`src/main/fixed_timestep.ts`, wired in `src/main/game_loop.ts`): gameplay (`updateLoopCore`/`updateLoopCombat`/`updateLoopWorld`/`updateLoopGeological`/`updateLoopFinish`) now always advances in `1/60`s increments via an accumulator, instead of whatever `rawDelta` the display produced. A slow frame runs multiple catch-up steps; a fast (144Hz) frame sometimes skips a step — both converge to the same simulated time. A spiral-of-death guard caps catch-up at 8 steps/frame and drops any further backlog instead of queuing it (visible slow-motion on a stall, not a lockup).
- **Hit-pause stays gameplay-affecting**: `juiceManager.update()` still runs on wall-clock delta (so shake/flash/floating-text keep animating), but its hit-pause-shrunk delta is what feeds the accumulator, so a hit-pause still freezes the sim the way it did before.
- **Per-frame bookkeeping split out**: FPS tracking, dynamic pixel-ratio/object-density scaling, debug toggles, and the pause gate used to live inside `updateLoopCore` and therefore ran at whatever cadence gameplay ran at. If left as-is, that would have made the FPS-based dynamic-resolution feature (the thing meant to help low-end GPUs, motivating #311) read a constant ~60fps instead of the real render rate. Extracted to `src/main/frame_housekeeping.ts`, which now always runs once per real rendered frame.
- **Render interpolation for the player** (`src/main/render_interpolation.ts`): tracks the last two fixed-step positions and blends them for the draw call only — `player.position` is temporarily swapped to the interpolated value around `renderGameFrame()` and restored immediately after, so every other consumer of `player.position` (collision, camera, HUD, ~32 files) keeps seeing the true simulation state. This is what keeps a 60Hz sim from looking worse than today on a 144Hz display.
- **One Math.random() gameplay path routed to the seeded RNG**: Combo Corridor's ring placement (`src/combo_corridor.ts`, called out explicitly in the proposal) now goes through `getRunRngFork('comboCorridor')` via a small `src/combo_corridor_rng.ts` helper, following the same pattern already used by `obstacle_system`, `candy_obstacles`, and `foliage_streaming`. Same seed now places identical rings; falls back to `Math.random()` only if a ring is placed before `beginRun()` (defensive, shouldn't happen in a real session).

## Not in this PR

The full acceptance list in the proposal is a much larger effort; this PR is scoped to the load-bearing primitive plus one worked example, not a full sweep:

- Most `Math.random()` call sites are still unrouted (grep counts ~1300 across ~150 files — mostly VFX jitter/flicker, but some are gameplay-affecting spawns that should move to the seeded RNG).
- No replay-based CI regression harness yet (`ghost_run/` already has the recorder/replayer/codec; wiring it into a headless `?skip_gpu_boot` CI test per chapter is follow-up work).
- No end-to-end verification that player motion produces identical end positions at 30/60/144Hz for an identical input trace — the accumulator makes this structurally possible now, but confirming it needs a real browser with WebGPU, which isn't available in this sandbox (documented in CLAUDE.md).
- `loop_world`/`loop_geological`/combat sub-systems (camera easing, particle spawn timers, etc.) now run at fixed-step cadence as part of "gameplay," which is a net win for determinism, but their internal smoothing constants weren't individually re-tuned for it.

## Test plan

- [x] `npm run check` (brace balance, env-registry, typecheck ratchet, unit tests) — all green
- [x] `npm run build` — production build succeeds
- [x] `npm run test:smoke` — WebGPU boot-probe passes (headless Chromium has no real GPU, so this only confirms the bundle boots, not in-game physics)
- [x] New unit tests: `tests/unit/fixed_timestep.test.ts` (accumulator determinism across 30/60/144Hz, spiral-of-death clamp, floating-point edge case), `tests/unit/render_interpolation.test.ts` (blend correctness across multi-step frames), `tests/unit/combo_corridor_rng.test.ts` (same-seed determinism)
- [ ] Manual playtest in a WebGPU browser — not done in this sandboxed session; recommend a quick sanity pass before merge given this touches the main loop

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WuR7CtdEE4dG6L5uFUNR7q

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuR7CtdEE4dG6L5uFUNR7q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more consistent gameplay simulation across different frame rates.
  * Improved rendering smoothness for fast-moving objects.
  * Added safeguards for unusually long or stalled frames.
  * Combo Corridor ring placement is now repeatable during seeded runs, improving replay consistency.

* **Bug Fixes**
  * Improved pause handling, frame-rate adaptation, and touch-control responsiveness.
  * Separated visual updates from gameplay timing for more reliable performance.

* **Tests**
  * Added coverage for deterministic ring placement, timing behavior, and render interpolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->