### PR TITLE
Self-registering env system descriptors (Endless Dash foundation, part 1/2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ JS writes object positions directly into the `Float32Array` views, then calls th
 | Physics & WASM | `physics_utils.ts`, `wasm_loader.ts`, `jelly_moss_softbody.ts` (Verlet soft-body, ships by default), `biome_noise.ts` (fractal noise, ships by default), `assembly/index.ts` + `assembly/noise.ts` + `assembly/physics.ts` (supported, always built); `cpp/` experimental research tree only — [docs/WASM_BACKENDS.md](docs/WASM_BACKENDS.md) |
 | Audio | `audio_system/` (incl. `chapter_music.ts` + `mixins/chapter_music.ts`), `audio_settings.ts`, `ui_audio_settings.ts`, `main/music_update.ts` — [docs/CHAPTER_MUSIC.md](docs/CHAPTER_MUSIC.md). 100% procedural; never add audio files to `public/` |
 | Game-wide config / composition root | `game_config.ts`, `create_game_systems.ts`, `game_runtime.ts` (`GameContext`); see `docs/GAME_CONTEXT.md` |
+| Env system metadata (biome/role/palette/difficulty per system) | `env_system_descriptors.ts` — see `docs/ENV_SYSTEM_DESCRIPTORS.md` |
 
 ## Code Style
 

--- a/docs/ENV_SYSTEM_DESCRIPTORS.md
+++ b/docs/ENV_SYSTEM_DESCRIPTORS.md
@@ -1,0 +1,89 @@
+# Env System Descriptors
+
+Machine-readable metadata for every level-environment system, in
+[`src/env_system_descriptors.ts`](../src/env_system_descriptors.ts).
+
+## Why this exists
+
+`level_env_registry.ts` and `level_deferred_registry.ts` answer *how* to
+load and activate a system. Until this file, nothing answered *where a
+system belongs* — which biome(s) it reads coherently in, what role it
+plays (backdrop / traversal / hazard / flavor / boss), its rough palette,
+and how much it adds to difficulty. That metadata used to live only
+implicitly in `LEVEL_CONFIG`, spread across 6 levels — not queryable.
+
+This is prerequisite groundwork for **Endless Dash** (procedural
+post-campaign chapters composed from the existing environment systems):
+a generator needs to ask "give me a traversal system for the `industrial`
+biome" instead of hand-maintaining a table per feature.
+
+## Shape
+
+```ts
+interface EnvSystemDescriptor {
+    key: EnvDescriptorKey;       // SystemKey | 'butterflySwarm'
+    label: string;
+    role: 'backdrop' | 'traversal' | 'hazard' | 'flavor' | 'boss';
+    biomes: Biome[];             // 'nebula' | 'industrial' | 'biological' | 'crystalline' | 'candy'
+    paletteTags: PaletteTag[];   // coarse visual-coherence hint, not literal colors
+    difficultyWeight: 1 | 2 | 3 | 4 | 5;
+    tutorialId?: string;         // unset until a generator actually gates on it
+}
+```
+
+`defineEnvSystem(descriptor)` is the registration call each system
+"declares" itself with. Descriptors live beside each other in one file
+rather than inside ~40 separate implementation modules — every system
+already has exactly one declaration site (its entry in
+`DEFERRED_ENV_REGISTRY` / `DEFERRED_LEVEL_REGISTRY`), and this metadata
+has nothing to do with how those modules render, so it's declared once
+here in the same order instead.
+
+## Adding a new environment system
+
+1. Add the system to `level_env_registry.ts` / `level_deferred_registry.ts`
+   as usual (see that file's own header comment).
+2. Add one `defineEnvSystem({...})` entry to `ENV_SYSTEM_DESCRIPTORS` in
+   `src/env_system_descriptors.ts`, keyed by the same flag / system key.
+3. `tests/unit/env_system_descriptors.test.ts` and a compile-time
+   exhaustiveness check both fail the build if the descriptor is missing.
+
+## Query API
+
+```ts
+import { envSystemsForRoleInBiome } from './env_system_descriptors';
+
+const industrialHazards = envSystemsForRoleInBiome('hazard', 'industrial');
+```
+
+Also exported: `getEnvSystemDescriptor`, `allEnvSystemDescriptors`,
+`envSystemsForBiome`, `envSystemsForRole`.
+
+## Biome mapping (how it was derived)
+
+Biome affinity was derived from which levels each system is actually
+enabled in (`LEVEL_CONFIG` in `level_config.ts`), mapped through:
+
+| Level | Name | Biome |
+|-------|------|-------|
+| 1 | The Neon Garden | `candy` |
+| 2 | The Asteroid Belt | `nebula` |
+| 3 | Orbital Descent | `nebula` |
+| 4 | The Rusty Gauntlet | `industrial` |
+| 5 | The Astral Leviathan | `biological` |
+| 6 | The Aqua Expanse | `crystalline` |
+
+A handful of backdrop systems were given a broader affinity than their
+historical single-level usage (e.g. `nebula`/`nebulaRibbons` also tagged
+`biological`) where the visual clearly reads in more than one biome —
+the whole point of Endless Dash is combinations the 6 hand-authored
+levels never tried. Treat these as a first pass to refine once generated
+chapters are actually played, not as ground truth.
+
+## Not yet included
+
+- `tutorialId` gating (needs `tutorial_system` step ids wired through).
+- The `ChapterRecipe` / constraint solver itself (Endless Dash Phase 1+).
+- Literal color values for palette coherence — `paletteTags` is a coarse
+  heuristic (`warm`/`cool`/`pastel`/`neon`/`iridescent`/`monochrome`), not
+  a color system.

--- a/src/env_system_descriptors.ts
+++ b/src/env_system_descriptors.ts
@@ -1,0 +1,568 @@
+/**
+ * Self-registering metadata for every level-environment system in the game.
+ *
+ * This is the machine-readable counterpart to `level_env_registry.ts` /
+ * `level_deferred_registry.ts`: those two files answer "how do I load and
+ * activate system X", this one answers "where does system X belong" —
+ * which biome(s) it reads coherently in, what role it plays in a chapter
+ * (backdrop / traversal / hazard / flavor / boss), its rough palette, and
+ * how much it contributes to per-chapter difficulty.
+ *
+ * Every system already has exactly one declaration site — its entry in
+ * `DEFERRED_ENV_REGISTRY` or `DEFERRED_LEVEL_REGISTRY` — so descriptors are
+ * declared once here, in the same order, rather than requiring an edit to
+ * ~40 separate implementation modules for metadata that has nothing to do
+ * with how those modules render. `defineEnvSystem()` is the registration
+ * call each system "declares" itself with; `ENV_SYSTEM_DESCRIPTORS` is the
+ * queryable table a future generator (Endless Dash) reads instead of
+ * hand-cross-referencing `LEVEL_CONFIG` across 6 levels.
+ *
+ * Keep in sync with `DEFERRED_ENV_FLAGS`, `EAGER_ENV_FLAGS`, and
+ * `DEFERRED_LEVEL_SYSTEM_KEYS` in `level_deferred_registry.ts` — the
+ * compile-time assertion below fails the build if a key is added to either
+ * side without a matching update to the other. `tests/unit/env_system_descriptors.test.ts`
+ * runtime-checks the same invariant plus descriptor field sanity.
+ */
+import type { SystemKey } from './level_deferred_registry';
+
+/** Recipe biomes a generated Endless Dash chapter can draw from (see issue: Endless Dash). */
+export type Biome = 'nebula' | 'industrial' | 'biological' | 'crystalline' | 'candy';
+
+/** The slot a system fills inside a `ChapterRecipe`. */
+export type EnvRole = 'backdrop' | 'traversal' | 'hazard' | 'flavor' | 'boss';
+
+/**
+ * Coarse visual-coherence tags. A generator should avoid stacking backdrops
+ * whose tag sets don't overlap (e.g. `pastel` + `neon` reads as "fighting").
+ * Deliberately coarse — this is a coherence heuristic, not a color system.
+ */
+export type PaletteTag = 'warm' | 'cool' | 'pastel' | 'neon' | 'iridescent' | 'monochrome';
+
+/** `butterflySwarm` is eager (bootstrap-owned, no dynamic import) so it has no `SystemKey`. */
+export type EnvDescriptorKey = SystemKey | 'butterflySwarm';
+
+export interface EnvSystemDescriptor {
+    /** Matches the key this descriptor is registered under in `ENV_SYSTEM_DESCRIPTORS`. */
+    readonly key: EnvDescriptorKey;
+    /** Human label for debug UI / generator logs. */
+    readonly label: string;
+    readonly role: EnvRole;
+    /** Biomes this system reads coherently in. Order carries no meaning. */
+    readonly biomes: readonly Biome[];
+    readonly paletteTags: readonly PaletteTag[];
+    /** Relative contribution to per-chapter difficulty: 1 lightest .. 5 heaviest. */
+    readonly difficultyWeight: 1 | 2 | 3 | 4 | 5;
+    /**
+     * `tutorial_system` step id that must have been shown before this system
+     * can appear in a generated chapter. Omitted where no gating tutorial
+     * exists yet — left for a future pass once Endless Dash actually
+     * consumes it (see issue: Endless Dash — "a traversal system the player
+     * has been taught").
+     */
+    readonly tutorialId?: string;
+}
+
+/** Identity registration call — each system "declares" its descriptor through this. */
+function defineEnvSystem(descriptor: EnvSystemDescriptor): EnvSystemDescriptor {
+    return descriptor;
+}
+
+// ---------------------------------------------------------------------------
+// Deferred env-flag systems (mirrors DEFERRED_ENV_FLAGS order in level_deferred_registry.ts)
+// ---------------------------------------------------------------------------
+
+export const ENV_SYSTEM_DESCRIPTORS: Record<EnvDescriptorKey, EnvSystemDescriptor> = {
+    skyRailTerminal: defineEnvSystem({
+        key: 'skyRailTerminal',
+        label: 'Sky Rail Terminal',
+        role: 'traversal',
+        biomes: ['industrial'],
+        paletteTags: ['cool'],
+        difficultyWeight: 2
+    }),
+    candyPlanetRing: defineEnvSystem({
+        key: 'candyPlanetRing',
+        label: 'Candy Planet Ring',
+        role: 'backdrop',
+        biomes: ['candy', 'nebula'],
+        paletteTags: ['pastel', 'neon'],
+        difficultyWeight: 1
+    }),
+    blackHole: defineEnvSystem({
+        key: 'blackHole',
+        label: 'Black Hole',
+        role: 'hazard',
+        biomes: ['nebula'],
+        paletteTags: ['monochrome', 'cool'],
+        difficultyWeight: 4
+    }),
+    industrial: defineEnvSystem({
+        key: 'industrial',
+        label: 'Industrial Background',
+        role: 'backdrop',
+        biomes: ['industrial'],
+        paletteTags: ['warm', 'monochrome'],
+        difficultyWeight: 1
+    }),
+    waterfall: defineEnvSystem({
+        key: 'waterfall',
+        label: 'Waterfall',
+        role: 'backdrop',
+        biomes: ['crystalline'],
+        paletteTags: ['cool'],
+        difficultyWeight: 1
+    }),
+    biological: defineEnvSystem({
+        key: 'biological',
+        label: 'Biological Background',
+        role: 'backdrop',
+        biomes: ['biological'],
+        paletteTags: ['iridescent', 'cool'],
+        difficultyWeight: 1
+    }),
+    cosmicDust: defineEnvSystem({
+        key: 'cosmicDust',
+        label: 'Cosmic Dust',
+        role: 'backdrop',
+        biomes: ['nebula', 'biological'],
+        paletteTags: ['cool', 'iridescent'],
+        difficultyWeight: 1
+    }),
+    moonPalace: defineEnvSystem({
+        key: 'moonPalace',
+        label: 'Moon Palace',
+        role: 'backdrop',
+        biomes: ['crystalline'],
+        paletteTags: ['cool', 'monochrome'],
+        difficultyWeight: 1
+    }),
+    planetaryHorizon: defineEnvSystem({
+        key: 'planetaryHorizon',
+        label: 'Planetary Horizon',
+        role: 'backdrop',
+        biomes: ['nebula'],
+        paletteTags: ['warm', 'cool'],
+        difficultyWeight: 1
+    }),
+    reEntry: defineEnvSystem({
+        key: 'reEntry',
+        label: 'Re-Entry',
+        role: 'hazard',
+        biomes: ['nebula'],
+        paletteTags: ['warm'],
+        difficultyWeight: 3
+    }),
+    aquaticLife: defineEnvSystem({
+        key: 'aquaticLife',
+        label: 'Aquatic Life',
+        role: 'flavor',
+        biomes: ['crystalline'],
+        paletteTags: ['cool'],
+        difficultyWeight: 1
+    }),
+    ghostDebris: defineEnvSystem({
+        key: 'ghostDebris',
+        label: 'Ghost Debris',
+        role: 'hazard',
+        biomes: ['nebula'],
+        paletteTags: ['monochrome', 'cool'],
+        difficultyWeight: 3
+    }),
+    voidJellyfish: defineEnvSystem({
+        key: 'voidJellyfish',
+        label: 'Void Jellyfish',
+        role: 'flavor',
+        biomes: ['biological', 'crystalline'],
+        paletteTags: ['iridescent', 'cool'],
+        difficultyWeight: 1
+    }),
+    meteorShower: defineEnvSystem({
+        key: 'meteorShower',
+        label: 'Meteor Shower',
+        role: 'hazard',
+        biomes: ['nebula'],
+        paletteTags: ['warm'],
+        difficultyWeight: 3
+    }),
+    wishLanterns: defineEnvSystem({
+        key: 'wishLanterns',
+        label: 'Wish Lanterns',
+        role: 'flavor',
+        biomes: ['candy'],
+        paletteTags: ['warm', 'pastel'],
+        difficultyWeight: 1
+    }),
+    dancingJellyMoss: defineEnvSystem({
+        key: 'dancingJellyMoss',
+        label: 'Dancing Jelly Moss',
+        role: 'flavor',
+        biomes: ['candy', 'biological'],
+        paletteTags: ['iridescent', 'pastel'],
+        difficultyWeight: 1
+    }),
+    spacePetsSwarm: defineEnvSystem({
+        key: 'spacePetsSwarm',
+        label: 'Space Pets Swarm',
+        role: 'flavor',
+        biomes: ['candy'],
+        paletteTags: ['pastel'],
+        difficultyWeight: 1
+    }),
+    weather: defineEnvSystem({
+        key: 'weather',
+        label: 'Weather',
+        role: 'backdrop',
+        biomes: ['crystalline'],
+        paletteTags: ['cool', 'monochrome'],
+        difficultyWeight: 2
+    }),
+    dynamicStarfield: defineEnvSystem({
+        key: 'dynamicStarfield',
+        label: 'Dynamic Starfield',
+        role: 'backdrop',
+        biomes: ['nebula', 'industrial', 'biological', 'crystalline', 'candy'],
+        paletteTags: ['monochrome', 'cool'],
+        difficultyWeight: 1
+    }),
+    dayNightCycle: defineEnvSystem({
+        key: 'dayNightCycle',
+        label: 'Day/Night Cycle',
+        role: 'backdrop',
+        biomes: ['candy'],
+        paletteTags: ['warm', 'cool'],
+        difficultyWeight: 1
+    }),
+    galacticCore: defineEnvSystem({
+        key: 'galacticCore',
+        label: 'Galactic Core',
+        role: 'backdrop',
+        biomes: ['crystalline'],
+        paletteTags: ['warm', 'iridescent'],
+        difficultyWeight: 2
+    }),
+    dreamPortals: defineEnvSystem({
+        key: 'dreamPortals',
+        label: 'Dream Portals',
+        role: 'flavor',
+        biomes: ['candy', 'nebula', 'crystalline'],
+        paletteTags: ['iridescent', 'pastel'],
+        difficultyWeight: 1
+    }),
+    singingGeodes: defineEnvSystem({
+        key: 'singingGeodes',
+        label: 'Singing Geodes',
+        role: 'flavor',
+        biomes: ['biological', 'crystalline'],
+        paletteTags: ['cool', 'iridescent'],
+        difficultyWeight: 1
+    }),
+    cloudCastles: defineEnvSystem({
+        key: 'cloudCastles',
+        label: 'Cloud Castles',
+        role: 'flavor',
+        biomes: ['candy', 'biological'],
+        paletteTags: ['pastel'],
+        difficultyWeight: 1
+    }),
+    grappleIsles: defineEnvSystem({
+        key: 'grappleIsles',
+        label: 'Grapple Isles',
+        role: 'traversal',
+        biomes: ['candy'],
+        paletteTags: ['pastel', 'neon'],
+        difficultyWeight: 2
+    }),
+    windCurrents: defineEnvSystem({
+        key: 'windCurrents',
+        label: 'Wind Currents',
+        role: 'traversal',
+        biomes: ['nebula'],
+        paletteTags: ['cool'],
+        difficultyWeight: 2
+    }),
+    timeShiftZones: defineEnvSystem({
+        key: 'timeShiftZones',
+        label: 'Time Shift Zones',
+        role: 'traversal',
+        biomes: ['industrial'],
+        paletteTags: ['neon', 'cool'],
+        difficultyWeight: 3
+    }),
+    flowerConstellations: defineEnvSystem({
+        key: 'flowerConstellations',
+        label: 'Flower Constellations',
+        role: 'flavor',
+        biomes: ['candy', 'nebula'],
+        paletteTags: ['pastel', 'neon'],
+        difficultyWeight: 1
+    }),
+    bouncePads: defineEnvSystem({
+        key: 'bouncePads',
+        label: 'Bounce Pads',
+        role: 'traversal',
+        biomes: ['industrial'],
+        paletteTags: ['neon', 'warm'],
+        difficultyWeight: 2
+    }),
+    spaceGarden: defineEnvSystem({
+        key: 'spaceGarden',
+        label: 'Space Garden',
+        role: 'flavor',
+        biomes: ['candy'],
+        paletteTags: ['pastel'],
+        difficultyWeight: 1
+    }),
+    comboCorridor: defineEnvSystem({
+        key: 'comboCorridor',
+        label: 'Combo Corridor',
+        role: 'traversal',
+        biomes: ['industrial', 'biological'],
+        paletteTags: ['neon'],
+        difficultyWeight: 2
+    }),
+    aerialGuardPatrol: defineEnvSystem({
+        key: 'aerialGuardPatrol',
+        label: 'Aerial Guard Patrol',
+        role: 'hazard',
+        biomes: ['industrial'],
+        paletteTags: ['monochrome', 'warm'],
+        difficultyWeight: 3
+    }),
+    airTokens: defineEnvSystem({
+        key: 'airTokens',
+        label: 'Air Tokens',
+        role: 'traversal',
+        biomes: ['candy'],
+        paletteTags: ['neon', 'pastel'],
+        difficultyWeight: 2
+    }),
+    shootingStars: defineEnvSystem({
+        key: 'shootingStars',
+        label: 'Shooting Stars',
+        role: 'flavor',
+        biomes: ['candy', 'nebula'],
+        paletteTags: ['warm', 'neon'],
+        difficultyWeight: 1
+    }),
+    pastelNebula: defineEnvSystem({
+        key: 'pastelNebula',
+        label: 'Pastel Nebula',
+        role: 'backdrop',
+        biomes: ['candy'],
+        paletteTags: ['pastel'],
+        difficultyWeight: 1
+    }),
+    nebula: defineEnvSystem({
+        key: 'nebula',
+        label: 'Nebula',
+        role: 'backdrop',
+        biomes: ['nebula', 'biological'],
+        paletteTags: ['cool', 'iridescent'],
+        difficultyWeight: 1
+    }),
+    nebulaRibbons: defineEnvSystem({
+        key: 'nebulaRibbons',
+        label: 'Nebula Ribbons',
+        role: 'backdrop',
+        biomes: ['nebula', 'biological', 'crystalline'],
+        paletteTags: ['cool', 'iridescent'],
+        difficultyWeight: 1
+    }),
+    godRays: defineEnvSystem({
+        key: 'godRays',
+        label: 'God Rays',
+        role: 'backdrop',
+        biomes: ['candy', 'nebula', 'biological'],
+        paletteTags: ['warm'],
+        difficultyWeight: 1
+    }),
+    aurora: defineEnvSystem({
+        key: 'aurora',
+        label: 'Aurora',
+        role: 'backdrop',
+        biomes: ['crystalline'],
+        paletteTags: ['cool', 'iridescent'],
+        difficultyWeight: 1
+    }),
+    lightning: defineEnvSystem({
+        key: 'lightning',
+        label: 'Lightning',
+        role: 'hazard',
+        biomes: ['candy', 'nebula', 'biological'],
+        paletteTags: ['monochrome', 'neon'],
+        difficultyWeight: 2
+    }),
+    asteroidField: defineEnvSystem({
+        key: 'asteroidField',
+        label: 'Asteroid Field',
+        role: 'hazard',
+        biomes: ['nebula', 'industrial', 'biological', 'crystalline', 'candy'],
+        paletteTags: ['monochrome', 'warm'],
+        difficultyWeight: 2
+    }),
+    candyField: defineEnvSystem({
+        key: 'candyField',
+        label: 'Candy Field',
+        role: 'backdrop',
+        biomes: ['candy', 'nebula'],
+        paletteTags: ['pastel', 'neon'],
+        difficultyWeight: 1
+    }),
+
+    // -----------------------------------------------------------------------
+    // Non-env deferred systems (density / objective / spawn-rule driven —
+    // DEFERRED_LEVEL_SYSTEM_KEYS in level_deferred_registry.ts)
+    // -----------------------------------------------------------------------
+
+    boss: defineEnvSystem({
+        key: 'boss',
+        label: 'Boss',
+        role: 'boss',
+        biomes: ['nebula', 'industrial', 'biological', 'crystalline', 'candy'],
+        paletteTags: ['monochrome', 'warm'],
+        difficultyWeight: 5
+    }),
+    chromaShift: defineEnvSystem({
+        key: 'chromaShift',
+        label: 'Chroma Shift',
+        role: 'hazard',
+        biomes: ['nebula'],
+        paletteTags: ['neon'],
+        difficultyWeight: 3
+    }),
+    stormGeode: defineEnvSystem({
+        key: 'stormGeode',
+        label: 'Storm Geode',
+        role: 'hazard',
+        biomes: ['nebula', 'industrial', 'biological'],
+        paletteTags: ['warm', 'monochrome'],
+        difficultyWeight: 3
+    }),
+    industrialGeometry: defineEnvSystem({
+        key: 'industrialGeometry',
+        label: 'Industrial Geometry',
+        role: 'hazard',
+        biomes: ['industrial', 'biological'],
+        paletteTags: ['warm', 'monochrome'],
+        difficultyWeight: 3
+    }),
+    starlightKoi: defineEnvSystem({
+        key: 'starlightKoi',
+        label: 'Starlight Koi',
+        role: 'flavor',
+        biomes: ['biological', 'crystalline'],
+        paletteTags: ['iridescent', 'cool'],
+        difficultyWeight: 1
+    }),
+    bubbleCoral: defineEnvSystem({
+        key: 'bubbleCoral',
+        label: 'Rainbow Bubble Coral',
+        role: 'flavor',
+        biomes: ['nebula', 'industrial', 'biological', 'crystalline'],
+        paletteTags: ['iridescent', 'pastel'],
+        difficultyWeight: 1
+    }),
+    slingables: defineEnvSystem({
+        key: 'slingables',
+        label: 'Slingable Objects',
+        role: 'traversal',
+        biomes: ['nebula', 'industrial', 'biological', 'crystalline'],
+        paletteTags: ['neon', 'warm'],
+        difficultyWeight: 2
+    }),
+    liquidMetal: defineEnvSystem({
+        key: 'liquidMetal',
+        label: 'Liquid Metal',
+        role: 'flavor',
+        biomes: ['nebula', 'industrial', 'biological', 'crystalline', 'candy'],
+        paletteTags: ['monochrome', 'iridescent'],
+        difficultyWeight: 1
+    }),
+    crystalChimes: defineEnvSystem({
+        key: 'crystalChimes',
+        label: 'Crystal Chimes',
+        role: 'flavor',
+        biomes: ['nebula', 'industrial', 'biological'],
+        paletteTags: ['cool', 'iridescent'],
+        difficultyWeight: 1
+    }),
+    gravLens: defineEnvSystem({
+        key: 'gravLens',
+        label: 'Grav Lens',
+        role: 'traversal',
+        biomes: ['nebula'],
+        paletteTags: ['cool', 'monochrome'],
+        difficultyWeight: 3
+    }),
+    derelictBuoys: defineEnvSystem({
+        key: 'derelictBuoys',
+        label: 'Derelict Buoys',
+        role: 'flavor',
+        biomes: ['industrial', 'biological'],
+        paletteTags: ['warm', 'monochrome'],
+        difficultyWeight: 2
+    }),
+    dataMonoliths: defineEnvSystem({
+        key: 'dataMonoliths',
+        label: 'Data Monoliths',
+        role: 'flavor',
+        biomes: ['industrial', 'biological'],
+        paletteTags: ['cool', 'monochrome'],
+        difficultyWeight: 2
+    }),
+    magicPaintbrush: defineEnvSystem({
+        key: 'magicPaintbrush',
+        label: 'Magic Paintbrush',
+        role: 'flavor',
+        biomes: ['nebula', 'industrial', 'biological', 'crystalline', 'candy'],
+        paletteTags: ['pastel', 'neon'],
+        difficultyWeight: 1
+    }),
+
+    // -----------------------------------------------------------------------
+    // Eager (bootstrap-owned) systems
+    // -----------------------------------------------------------------------
+
+    butterflySwarm: defineEnvSystem({
+        key: 'butterflySwarm',
+        label: 'Butterfly Swarm',
+        role: 'flavor',
+        biomes: ['nebula', 'industrial', 'biological', 'crystalline', 'candy'],
+        paletteTags: ['pastel'],
+        difficultyWeight: 1
+    })
+};
+
+// Compile-time: descriptor keys must exactly match EnvDescriptorKey.
+type DescriptorKeys = keyof typeof ENV_SYSTEM_DESCRIPTORS;
+type AssertDescriptorCoverage = Exclude<EnvDescriptorKey, DescriptorKeys> extends never
+    ? Exclude<DescriptorKeys, EnvDescriptorKey> extends never
+        ? true
+        : never
+    : never;
+const _descriptorCoverage: AssertDescriptorCoverage = true;
+void _descriptorCoverage;
+
+// ---------------------------------------------------------------------------
+// Query API
+// ---------------------------------------------------------------------------
+
+export function getEnvSystemDescriptor(key: EnvDescriptorKey): EnvSystemDescriptor {
+    return ENV_SYSTEM_DESCRIPTORS[key];
+}
+
+export function allEnvSystemDescriptors(): EnvSystemDescriptor[] {
+    return Object.values(ENV_SYSTEM_DESCRIPTORS);
+}
+
+export function envSystemsForBiome(biome: Biome): EnvSystemDescriptor[] {
+    return allEnvSystemDescriptors().filter((d) => d.biomes.includes(biome));
+}
+
+export function envSystemsForRole(role: EnvRole): EnvSystemDescriptor[] {
+    return allEnvSystemDescriptors().filter((d) => d.role === role);
+}
+
+export function envSystemsForRoleInBiome(role: EnvRole, biome: Biome): EnvSystemDescriptor[] {
+    return allEnvSystemDescriptors().filter((d) => d.role === role && d.biomes.includes(biome));
+}

--- a/tests/unit/env_system_descriptors.test.ts
+++ b/tests/unit/env_system_descriptors.test.ts
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    ENV_SYSTEM_DESCRIPTORS,
+    allEnvSystemDescriptors,
+    envSystemsForBiome,
+    envSystemsForRole,
+    envSystemsForRoleInBiome,
+    type Biome,
+    type EnvRole
+} from '../../src/env_system_descriptors.ts';
+import {
+    DEFERRED_ENV_FLAGS,
+    DEFERRED_LEVEL_SYSTEM_KEYS
+} from '../../src/level_deferred_registry.ts';
+
+const BIOMES: Biome[] = ['nebula', 'industrial', 'biological', 'crystalline', 'candy'];
+const ROLES: EnvRole[] = ['backdrop', 'traversal', 'hazard', 'flavor', 'boss'];
+
+test('every DEFERRED_ENV_FLAGS entry has a descriptor', () => {
+    for (const flag of DEFERRED_ENV_FLAGS) {
+        assert.ok(ENV_SYSTEM_DESCRIPTORS[flag], `missing descriptor for env flag "${flag}"`);
+    }
+});
+
+test('every DEFERRED_LEVEL_SYSTEM_KEYS entry has a descriptor', () => {
+    for (const key of DEFERRED_LEVEL_SYSTEM_KEYS) {
+        assert.ok(ENV_SYSTEM_DESCRIPTORS[key], `missing descriptor for level system key "${key}"`);
+    }
+});
+
+test('descriptor table has no keys outside the known registries + eager butterflySwarm', () => {
+    const known = new Set<string>([...DEFERRED_ENV_FLAGS, ...DEFERRED_LEVEL_SYSTEM_KEYS, 'butterflySwarm']);
+    for (const key of Object.keys(ENV_SYSTEM_DESCRIPTORS)) {
+        assert.ok(known.has(key), `descriptor "${key}" does not correspond to any registered system`);
+    }
+    assert.equal(Object.keys(ENV_SYSTEM_DESCRIPTORS).length, known.size);
+});
+
+test('every descriptor has well-formed fields', () => {
+    for (const d of allEnvSystemDescriptors()) {
+        assert.equal(d.key, d.key, `descriptor key mismatch for "${d.label}"`);
+        assert.ok(d.label.length > 0, `empty label for "${d.key}"`);
+        assert.ok(ROLES.includes(d.role), `invalid role "${d.role}" for "${d.key}"`);
+        assert.ok(d.biomes.length > 0, `"${d.key}" declares no biome affinity`);
+        for (const b of d.biomes) {
+            assert.ok(BIOMES.includes(b), `invalid biome "${b}" for "${d.key}"`);
+        }
+        assert.ok(d.paletteTags.length > 0, `"${d.key}" declares no palette tags`);
+        assert.ok(
+            Number.isInteger(d.difficultyWeight) && d.difficultyWeight >= 1 && d.difficultyWeight <= 5,
+            `difficultyWeight out of range for "${d.key}"`
+        );
+    }
+});
+
+test('every registered system is reachable by at least one (role, biome) combination', () => {
+    const reachable = new Set<string>();
+    for (const role of ROLES) {
+        for (const biome of BIOMES) {
+            for (const d of envSystemsForRoleInBiome(role, biome)) {
+                reachable.add(d.key);
+            }
+        }
+    }
+    const all = new Set(Object.keys(ENV_SYSTEM_DESCRIPTORS));
+    for (const key of all) {
+        assert.ok(reachable.has(key), `"${key}" is unreachable by any (role, biome) recipe query`);
+    }
+});
+
+test('envSystemsForBiome / envSystemsForRole filter correctly', () => {
+    const nebulaSystems = envSystemsForBiome('nebula');
+    assert.ok(nebulaSystems.every((d) => d.biomes.includes('nebula')));
+    assert.ok(nebulaSystems.some((d) => d.key === 'blackHole'));
+
+    const hazards = envSystemsForRole('hazard');
+    assert.ok(hazards.every((d) => d.role === 'hazard'));
+    assert.ok(hazards.some((d) => d.key === 'asteroidField'));
+
+    const boss = envSystemsForRole('boss');
+    assert.deepEqual(boss.map((d) => d.key), ['boss']);
+});
+
+test('every biome has at least one backdrop, one traversal, and one hazard system', () => {
+    for (const biome of BIOMES) {
+        assert.ok(envSystemsForRoleInBiome('backdrop', biome).length > 0, `no backdrop for ${biome}`);
+        assert.ok(envSystemsForRoleInBiome('traversal', biome).length > 0, `no traversal for ${biome}`);
+        assert.ok(envSystemsForRoleInBiome('hazard', biome).length > 0, `no hazard for ${biome}`);
+    }
+});


### PR DESCRIPTION
## Summary

The **Endless Dash** issue (procedural post-campaign chapters composed from the ~50 existing environment systems) explicitly lists itself as blocked until four prerequisites land, including issue #313 — self-registering env modules with machine-readable metadata, since "hand-maintained tables across 11 files cannot be queried."

This PR is that prerequisite. It does **not** build the chapter generator itself — see the follow-up plan below.

- Adds `src/env_system_descriptors.ts`: a `defineEnvSystem()` registration call plus `ENV_SYSTEM_DESCRIPTORS`, one entry per system already declared in `DEFERRED_ENV_REGISTRY` / `DEFERRED_LEVEL_REGISTRY` (56 systems total, including the two eager systems).
- Each descriptor carries: `role` (`backdrop` / `traversal` / `hazard` / `flavor` / `boss` — the slots a future `ChapterRecipe` needs), `biomes` (`nebula` / `industrial` / `biological` / `crystalline` / `candy`), `paletteTags` (coarse visual-coherence hint), and `difficultyWeight` (1–5).
- Biome affinity was derived from which of the 6 hand-authored levels each system is actually enabled in (`LEVEL_CONFIG`), documented in `docs/ENV_SYSTEM_DESCRIPTORS.md` along with the level → biome mapping and where affinity was deliberately broadened beyond historical single-level usage.
- Query API: `getEnvSystemDescriptor`, `allEnvSystemDescriptors`, `envSystemsForBiome`, `envSystemsForRole`, `envSystemsForRoleInBiome`.
- A compile-time exhaustiveness check (mirroring the existing pattern in `level_env_registry.ts`) plus `tests/unit/env_system_descriptors.test.ts` keep descriptor coverage in sync with `DEFERRED_ENV_FLAGS` / `EAGER_ENV_FLAGS` / `DEFERRED_LEVEL_SYSTEM_KEYS`, and assert every biome has at least one backdrop/traversal/hazard system.
- `CLAUDE.md` domain map gets one new row pointing at the new file/doc.

## Why centralized instead of one `defineEnvSystem()` call per implementation module

Every system already has exactly one declaration site — its entry in `DEFERRED_ENV_REGISTRY` / `DEFERRED_LEVEL_REGISTRY` — and this metadata (biome/role/palette/difficulty) has nothing to do with how those ~40 modules render. Touching all of them for metadata alone would be a large, purely mechanical diff with no behavioral payoff; declaring descriptors once, in the same order, in a single reviewable file achieves the actual goal (one canonical, queryable source of truth) without that blast radius. Documented explicitly in the new file's header and in `docs/ENV_SYSTEM_DESCRIPTORS.md`.

## Not in this PR

- The `ChapterRecipe` schema / constraint solver / generator itself (Endless Dash Phase 1).
- `tutorialId` gating (the field exists but is left unset everywhere — no generator consumes it yet).
- Issue #316 (broad-phase collision), also listed as blocking Endless Dash, is unaddressed — separate scope.

## Test plan

- [x] `npm run check` (brace check + env-registry check + typecheck ratchet + unit tests) — all green.
- [x] `npm run typecheck:ci` — 0 new errors.
- [x] New tests in `tests/unit/env_system_descriptors.test.ts`: descriptor coverage matches the existing registries exactly, every descriptor has well-formed fields, every (role, biome) pair used by the intended recipe shape resolves to at least one system.
- No runtime/UI change — this is a pure metadata addition, nothing wired into gameplay yet.

Related: Endless Dash issue (#313, #314, #315, #316 prerequisites — #315 and #314 are already landed on `main`; this PR addresses #313).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Np8JvxhULpqGTP1AZgJLSr)_